### PR TITLE
feat: add sd and lb for grpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,9 +49,9 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cda8f4bcc10624c4e85bc66b3f452cca98cfa5ca002dc83a16aad2367641bea"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -70,9 +70,9 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -81,9 +81,9 @@ version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -114,18 +114,6 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
 
 [[package]]
 name = "bumpalo"
@@ -189,9 +177,9 @@ checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -251,20 +239,9 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
-]
-
-[[package]]
-name = "derive-newtype"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f8f71c67643f334ff15fb57bb099ee8df05c3cc5111d4dcb30c69e4ed6741c9"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -379,12 +356,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
 name = "futures"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,9 +409,9 @@ version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -633,12 +604,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "index_list"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9d968042a4902e08810946fc7cd5851eb75e80301342305af755ca06cb82ce"
-
-[[package]]
 name = "indexmap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,18 +760,9 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06f9e10fcf7b679da499ba91dbbf52fed22761580a0d18b950f264a9c3907095"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
-]
-
-[[package]]
-name = "newtype"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631afaabdccc7e07dfbe047e331c8de1f95d153953a805a9b3aa0065399524c3"
-dependencies = [
- "derive-newtype",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -829,16 +785,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "num_enum"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,9 +800,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -981,9 +927,9 @@ checksum = "92aacdc5f16768709a569e913f7451034034178b05bdc8acda226659a3dccc66"
 dependencies = [
  "phf_generator",
  "phf_shared",
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1027,13 +973,13 @@ dependencies = [
  "petgraph",
  "phf",
  "pilota-thrift-parser",
- "proc-macro2 1.0.43",
+ "proc-macro2",
  "protobuf-parse2",
  "protobuf2",
- "quote 1.0.21",
+ "quote",
  "salsa",
  "scoped-tls",
- "syn 1.0.99",
+ "syn",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1062,9 +1008,9 @@ version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1113,9 +1059,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2",
+ "quote",
+ "syn",
  "version_check",
 ]
 
@@ -1125,18 +1071,9 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
+ "proc-macro2",
+ "quote",
  "version_check",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid",
 ]
 
 [[package]]
@@ -1166,9 +1103,9 @@ checksum = "7345d5f0e08c0536d7ac7229952590239e77abf0a0100a1b1d890add6ea96364"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1215,27 +1152,12 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
- "proc-macro2 1.0.43",
+ "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1394,9 +1316,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c2e352df550bf019da7b16164ed2f7fa107c39653d1311d1bba42d1582ff7"
 dependencies = [
  "heck 0.3.3",
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1451,9 +1373,9 @@ version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1552,31 +1474,14 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -1635,9 +1540,9 @@ version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c251e90f708e16c49a16f4917dc2131e75222b72edfa9cb7f7c58ae56aae0c09"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1675,7 +1580,6 @@ dependencies = [
  "libc",
  "memchr",
  "mio",
- "num_cpus",
  "once_cell",
  "parking_lot 0.12.1",
  "pin-project-lite",
@@ -1701,9 +1605,9 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1792,9 +1696,9 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1868,12 +1772,6 @@ name = "unicode-segmentation"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -1988,11 +1886,11 @@ dependencies = [
  "paste",
  "pathdiff",
  "pilota-build",
- "proc-macro2 1.0.43",
- "quote 1.0.21",
+ "proc-macro2",
+ "quote",
  "serde",
  "serde_yaml",
- "syn 1.0.99",
+ "syn",
  "tempfile",
  "url_path",
  "walkdir",
@@ -2029,28 +1927,20 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64",
- "bitvec",
- "byteorder",
  "bytes",
  "futures",
- "futures-core",
  "futures-util",
  "h2",
  "http",
  "http-body",
  "hyper",
  "hyper-timeout",
- "index_list",
  "metainfo",
  "motore",
- "newtype",
  "percent-encoding",
  "pin-project",
  "prost",
- "regex",
  "smol_str",
- "socket2",
- "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -2132,9 +2022,9 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2",
+ "quote",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -2144,7 +2034,7 @@ version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
 dependencies = [
- "quote 1.0.21",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -2154,9 +2044,9 @@ version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2",
+ "quote",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2280,12 +2170,3 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
-
-[[package]]
-name = "wyz"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
-dependencies = [
- "tap",
-]

--- a/volo-build/src/grpc_backend.rs
+++ b/volo-build/src/grpc_backend.rs
@@ -379,8 +379,10 @@ impl CodegenBackend for VoloGrpcBackend {
                 pub fn new(
                     service_name: impl AsRef<str>,
                 ) -> ::volo_grpc::client::ClientBuilder<
-                    #client_name,
                     ::volo::layer::Identity,
+                    ::volo::layer::Identity,
+                    #client_name,
+                    ::volo_grpc::layer::loadbalance::LbConfig<::volo::loadbalance::random::WeightedRandomBalance<()>, ::volo::discovery::DummyDiscover>,
                     #req_enum_name_send,
                     #resp_enum_name_recv,
                 > {

--- a/volo-grpc/Cargo.toml
+++ b/volo-grpc/Cargo.toml
@@ -34,7 +34,6 @@ tower = { version = "0.4", features = [
 anyhow = "1"
 hyper = { version = "0.14", features = ["full"] }
 hyper-timeout = { version = "0.4" }
-thiserror = "1"
 prost = "0.11"
 futures = "0.3"
 futures-util = "0.3"
@@ -45,12 +44,6 @@ metainfo = "0.6"
 pin-project = "1"
 http = "0.2"
 h2 = "0.3"
-byteorder = "1"
-newtype = "0.2"
-index_list = "0.2"
-bitvec = "1"
-# convert_case = "0.5"
-socket2 = "0.4"
 smol_str = "0.1"
 async-trait = "0.1"
 http-body = "0.4"
@@ -58,10 +51,6 @@ percent-encoding = "2"
 base64 = "0.13"
 tokio-stream = "0.1"
 async-stream = "0.3"
-regex = "1"
-futures-core = "0.3"
 
 [dev-dependencies]
-tokio = { version = "1", features = ["full"] }
-async-trait = "0.1"
 tracing-subscriber = "0.3"

--- a/volo-grpc/README.md
+++ b/volo-grpc/README.md
@@ -1,1 +1,9 @@
 # Volo-gRPC
+
+`volo-grpc` implements a Protobuf-based RPC framework.
+
+Users rarely need to use volo-thrift directly. Instead, they should use the `Client` and `Server` in the generated code.
+
+For extension developers, they may need to use some of the components in `volo-grpc`.
+
+For detailed guides, please refer to the [guides](https://www.cloudwego.io/docs/volo/).

--- a/volo-grpc/src/client/callopt.rs
+++ b/volo-grpc/src/client/callopt.rs
@@ -45,6 +45,8 @@ pub struct CallOpt {
     /// Sets the callee tags for the call.
     pub callee_tags: TypeMap,
     /// Sets the address for the call.
+    ///
+    /// The client will skip the discovery and loadbalance Service if this is set.
     pub address: Option<Address>,
     pub config: Config,
     /// Sets the caller tags for the call.

--- a/volo-grpc/src/layer/loadbalance/mod.rs
+++ b/volo-grpc/src/layer/loadbalance/mod.rs
@@ -3,15 +3,46 @@ use std::{fmt::Debug, future::Future, sync::Arc};
 use anyhow::{anyhow, Context as _};
 use motore::{BoxError, Service};
 use tracing::warn;
+use volo::{
+    context::Context,
+    discovery::Discover,
+    loadbalance::{LoadBalance, MkLbLayer},
+    Layer,
+};
 
-use crate::{context::Context, discovery::Discover, loadbalance::LoadBalance, Layer};
+use crate::Request;
 
+#[derive(Clone, Default, Copy)]
+pub struct LoadBalanceLayer<D, LB> {
+    discover: D,
+    load_balance: LB,
+}
+
+impl<D, LB> LoadBalanceLayer<D, LB> {
+    pub fn new(discover: D, load_balance: LB) -> Self {
+        LoadBalanceLayer {
+            discover,
+            load_balance,
+        }
+    }
+}
+
+impl<D, LB, S> Layer<S> for LoadBalanceLayer<D, LB>
+where
+    D: Discover,
+    LB: LoadBalance<D>,
+{
+    type Service = LoadBalanceService<D, LB, S>;
+
+    fn layer(self, inner: S) -> Self::Service {
+        LoadBalanceService::new(self.discover, self.load_balance, inner)
+    }
+}
 #[derive(Clone)]
 pub struct LoadBalanceService<D, LB, S> {
     discover: D,
     load_balance: Arc<LB>,
     service: S,
-    retry: usize,
 }
 
 impl<D, LB, S> LoadBalanceService<D, LB, S>
@@ -19,14 +50,13 @@ where
     D: Discover,
     LB: LoadBalance<D>,
 {
-    pub fn new(discover: D, load_balance: LB, service: S, retry: usize) -> Self {
+    pub fn new(discover: D, load_balance: LB, service: S) -> Self {
         let lb = Arc::new(load_balance);
 
         let service = Self {
             discover,
             load_balance: lb.clone(),
             service,
-            retry,
         };
 
         if let Some(mut channel) = service.discover.watch() {
@@ -43,15 +73,15 @@ where
     }
 }
 
-impl<Cx, Req, D, LB, S> Service<Cx, Req> for LoadBalanceService<D, LB, S>
+impl<Cx, T, D, LB, S> Service<Cx, Request<T>> for LoadBalanceService<D, LB, S>
 where
     <Cx as Context>::Config: std::marker::Sync,
     Cx: 'static + Context + Send + Sync,
     D: Discover,
     LB: LoadBalance<D>,
-    S: Service<Cx, Req> + 'static + Send,
+    S: Service<Cx, Request<T>> + 'static + Send,
     S::Error: Into<BoxError> + Debug,
-    Req: Clone + Send + Sync + 'static,
+    T: Send + 'static,
 {
     type Response = S::Response;
 
@@ -61,7 +91,7 @@ where
     where
         Self: 'cx;
 
-    fn call<'cx, 's>(&'s mut self, cx: &'cx mut Cx, req: Req) -> Self::Future<'cx>
+    fn call<'cx, 's>(&'s mut self, cx: &'cx mut Cx, req: Request<T>) -> Self::Future<'cx>
     where
         's: 'cx,
     {
@@ -71,7 +101,7 @@ where
         );
         async move {
             if let Some(info) = &cx.rpc_info().callee {
-                let picker = match &info.address {
+                let mut picker = match &info.address {
                     None => self
                         .load_balance
                         .get_picker(info, &self.discover)
@@ -81,14 +111,13 @@ where
                         return self.service.call(cx, req).await.map_err(Into::into);
                     }
                 };
-                let mut call_count = 0;
-                for (addr, _) in picker.zip(0..self.retry + 1) {
-                    call_count += 1;
+
+                if let Some(addr) = picker.next() {
                     if let Some(callee) = cx.rpc_info_mut().callee_mut() {
                         callee.address = Some(addr.clone())
                     }
 
-                    match self.service.call(cx, req.clone()).await {
+                    match self.service.call(cx, req).await {
                         Ok(resp) => {
                             return Ok(resp);
                         }
@@ -96,11 +125,10 @@ where
                             tracing::warn!("[VOLO] call endpoint: {:?} error: {:?}", addr, err);
                         }
                     }
-                }
-                if call_count == 0 {
+                } else {
                     tracing::warn!("[VOLO] zero call count, call info: {:?}", cx.rpc_info());
                 }
-                Err(anyhow!("load balance retry reaches end").into())
+                Err(anyhow!("load balance call reaches end").into())
             } else {
                 Err(anyhow!("load balance get empty endpoint").into())
             }
@@ -122,58 +150,38 @@ where
     }
 }
 
-#[derive(Clone, Default, Copy)]
-pub struct LoadBalanceLayer<D, LB> {
-    discover: D,
-    load_balance: LB,
-    retry_count: usize,
+pub struct LbConfig<L, DISC> {
+    load_balance: L,
+    discover: DISC,
 }
 
-impl<D, LB> LoadBalanceLayer<D, LB> {
-    pub fn new(discover: D, load_balance: LB, retry_count: usize) -> Self {
-        LoadBalanceLayer {
-            discover,
+impl<L, DISC> LbConfig<L, DISC> {
+    pub fn new(load_balance: L, discover: DISC) -> Self {
+        LbConfig {
             load_balance,
-            retry_count,
+            discover,
+        }
+    }
+
+    pub fn load_balance<NL>(self, load_balance: NL) -> LbConfig<NL, DISC> {
+        LbConfig {
+            load_balance,
+            discover: self.discover,
+        }
+    }
+
+    pub fn discover<NDISC>(self, discover: NDISC) -> LbConfig<L, NDISC> {
+        LbConfig {
+            load_balance: self.load_balance,
+            discover,
         }
     }
 }
 
-impl<D, LB, S> Layer<S> for LoadBalanceLayer<D, LB>
-where
-    D: Discover,
-    LB: LoadBalance<D>,
-{
-    type Service = LoadBalanceService<D, LB, S>;
+impl<LB, DISC, S> MkLbLayer<S> for LbConfig<LB, DISC> {
+    type Layer = LoadBalanceLayer<DISC, LB>;
 
-    fn layer(self, inner: S) -> Self::Service {
-        LoadBalanceService::new(self.discover, self.load_balance, inner, self.retry_count)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::convert::Infallible;
-
-    use motore::service::service_fn;
-
-    use super::LoadBalanceService;
-    use crate::{discovery::StaticDiscover, loadbalance::random::WeightedRandomBalance};
-
-    #[derive(Debug)]
-    struct MotoreContext;
-
-    async fn handle(cx: &mut MotoreContext, request: String) -> Result<String, Infallible> {
-        println!("{:?}, {:?}", cx, request);
-        Ok::<_, Infallible>(request.to_uppercase())
-    }
-
-    #[test]
-    fn test_service() {
-        let discover = StaticDiscover::from(vec!["127.0.0.1:8000".parse().unwrap()]);
-        let lb = WeightedRandomBalance::with_discover(&discover);
-        let service = service_fn(handle);
-
-        LoadBalanceService::new(discover, lb, service, 1);
+    fn make(self) -> Self::Layer {
+        LoadBalanceLayer::new(self.discover, self.load_balance)
     }
 }

--- a/volo-grpc/src/layer/mod.rs
+++ b/volo-grpc/src/layer/mod.rs
@@ -1,3 +1,4 @@
 pub mod cross_origin;
 pub mod grpc_timeout;
+pub mod loadbalance;
 pub mod user_agent;

--- a/volo-grpc/src/lib.rs
+++ b/volo-grpc/src/lib.rs
@@ -21,7 +21,7 @@ pub mod status;
 pub mod transport;
 
 pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
-pub type BoxStream<'l, T> = std::pin::Pin<Box<dyn futures_core::Stream<Item = T> + Send + 'l>>;
+pub type BoxStream<'l, T> = std::pin::Pin<Box<dyn futures::Stream<Item = T> + Send + 'l>>;
 
 pub use codec::decode::RecvStream;
 pub use message::{RecvEntryMessage, SendEntryMessage};


### PR DESCRIPTION
Add ServiceDiscovery and LoadBalance interface for Volo-gRPC. For now, Volo-gRPC doesn't support retry due to 
lack of ability to clone streaming requests or allow for passing a reference request.

**Mention:** In order to maintain a consistent user experience with Volo-Thrift, this commit is a **breaking change**.