### PR TITLE
retry IO error only

### DIFF
--- a/volo-thrift/src/error.rs
+++ b/volo-thrift/src/error.rs
@@ -6,7 +6,7 @@ use pilota::thrift::{
     TransportError,
 };
 use tokio::io::AsyncRead;
-use volo::loadbalance::error::LoadBalanceError;
+use volo::loadbalance::error::{LoadBalanceError, Retryable};
 
 use crate::AnyhowError;
 
@@ -64,6 +64,15 @@ impl From<std::io::Error> for Error {
 impl From<LoadBalanceError> for Error {
     fn from(err: LoadBalanceError) -> Self {
         new_application_error(ApplicationErrorKind::LoadBalanceError, err.to_string())
+    }
+}
+
+impl Retryable for Error {
+    fn retryable(&self) -> bool {
+        if let Error::Pilota(PilotaError::Transport(_)) = self {
+            return true;
+        }
+        false
     }
 }
 

--- a/volo/src/loadbalance/error.rs
+++ b/volo/src/loadbalance/error.rs
@@ -8,3 +8,9 @@ pub enum LoadBalanceError {
     #[error("load balance discovery error: {0:?}")]
     Discover(#[from] BoxError),
 }
+
+pub trait Retryable {
+    fn retryable(&self) -> bool {
+        false
+    }
+}


### PR DESCRIPTION
## Motivation

In current, we retry all errors in LB service. However, it does not need to retry in all cases, LB service provides a marker trait which makes user promise the behavior of error should be fine.

## Solution
Provides a trait in LB mod:
```rust
pub trait Retryable {
    fn retryable(&self) -> bool {
        false
    }
}
```

Then mark `volo_grpc::Status` and `volo_thrift::Error` implement it, and only retry transport error as default.

