### PR TITLE
fix: cx is not used in parameter list of the `impl Trait` type alias

### DIFF
--- a/volo-build/src/grpc_backend.rs
+++ b/volo-build/src/grpc_backend.rs
@@ -457,7 +457,7 @@ impl CodegenBackend for VoloGrpcBackend {
             {
                 type Response = ::volo_grpc::Response<#resp_enum_name_send>;
                 type Error = ::volo_grpc::status::Status;
-                type Future<'cx> = impl ::std::future::Future<Output = ::std::result::Result<Self::Response, Self::Error>>;
+                type Future<'cx> = impl ::std::future::Future<Output = ::std::result::Result<Self::Response, Self::Error>> + 'cx;
 
                 fn call<'cx, 's>(&'s mut self, cx: &'cx mut ::volo_grpc::context::ServerContext, req: ::volo_grpc::Request<#req_enum_name_recv>) -> Self::Future<'cx>
                 where


### PR DESCRIPTION

## Motivation
fix: cx is not used in parameter list of the `impl Trait` type alias


