### PR TITLE
remove useless liftetime paramenter in LoadBalance:: InstanceIter

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,15 +12,15 @@ publish = false
 [[bin]]
 name = "hello-grpc-server"
 path = "src/hello/grpc_server.rs"
-# [[bin]]
-# name = "hello-grpc-client"
-# path = "src/hello/grpc_client.rs"
+[[bin]]
+name = "hello-grpc-client"
+path = "src/hello/grpc_client.rs"
 [[bin]]
 name = "hello-thrift-server"
 path = "src/hello/thrift_server.rs"
-# [[bin]]
-# name = "hello-thrift-client"
-# path = "src/hello/thrift_client.rs"
+[[bin]]
+name = "hello-thrift-client"
+path = "src/hello/thrift_client.rs"
 
 [dependencies]
 anyhow.workspace = true

--- a/examples/src/hello/grpc_client.rs
+++ b/examples/src/hello/grpc_client.rs
@@ -15,7 +15,9 @@ lazy_static! {
 
 #[volo::main]
 async fn main() {
-    let req = volo_gen::proto_gen::hello::HelloRequest { name: "Volo".to_string() };
+    let req = volo_gen::proto_gen::hello::HelloRequest {
+        name: "Volo".to_string(),
+    };
     let resp = CLIENT.clone().hello(req).await;
     match resp {
         Ok(info) => println!("{:?}", info),

--- a/volo-grpc/src/layer/loadbalance/mod.rs
+++ b/volo-grpc/src/layer/loadbalance/mod.rs
@@ -82,7 +82,6 @@ where
     LoadBalanceError: Into<S::Error>,
     S::Error: Debug,
     T: Send + 'static,
-    for<'future, 'iter> LB::GetFut<'future, 'iter>: Send, /* add this temporarily via https://github.com/rust-lang/rust/issues/100013 */
 {
     type Response = S::Response;
 

--- a/volo/src/loadbalance/layer.rs
+++ b/volo/src/loadbalance/layer.rs
@@ -45,7 +45,6 @@ where
 
 impl<Cx, Req, D, LB, S> Service<Cx, Req> for LoadBalanceService<D, LB, S>
 where
-    <Cx as Context>::Config: std::marker::Sync,
     Cx: 'static + Context + Send + Sync,
     D: Discover,
     LB: LoadBalance<D>,
@@ -53,7 +52,6 @@ where
     LoadBalanceError: Into<S::Error>,
     S::Error: Debug + Retryable,
     Req: Clone + Send + Sync + 'static,
-    for<'future, 'iter> LB::GetFut<'future, 'iter>: Send, /* add this temporarily via https://github.com/rust-lang/rust/issues/100013 */
 {
     type Response = S::Response;
 

--- a/volo/src/loadbalance/mod.rs
+++ b/volo/src/loadbalance/mod.rs
@@ -17,24 +17,24 @@ where
     D: Discover,
 {
     /// `InstanceIter` is an iterator of [`crate::discovery::Instance`].
-    type InstanceIter<'iter>: Iterator<Item = Address> + Send + 'iter;
+    type InstanceIter: Iterator<Item = Address> + Send;
 
     /// `GetFut` is the return type of `get_picker`.
-    type GetFut<'future, 'iter>: Future<Output = Result<Self::InstanceIter<'iter>, LoadBalanceError>>
+    type GetFut<'future>: Future<Output = Result<Self::InstanceIter, LoadBalanceError>>
         + Send
         + 'future
     where
-        'iter: 'future;
+        Self: 'future;
 
     /// `get_picker` allows to get an instance iterator of a specified endpoint from self or
     /// service discovery.
-    fn get_picker<'future, 'iter>(
-        &'iter self,
+    fn get_picker<'future>(
+        &'future self,
         endpoint: &'future Endpoint,
         discover: &'future D,
-    ) -> Self::GetFut<'future, 'iter>
+    ) -> Self::GetFut<'future>
     where
-        'iter: 'future;
+        Self: 'future;
     /// `rebalance` is the callback method be used in service discovering subscription.
     fn rebalance(&self, changes: Change<D::Key>);
 }

--- a/volo/src/loadbalance/random.rs
+++ b/volo/src/loadbalance/random.rs
@@ -115,20 +115,20 @@ impl<D> LoadBalance<D> for WeightedRandomBalance<D::Key>
 where
     D: Discover,
 {
-    type InstanceIter<'iter> = InstancePicker;
+    type InstanceIter = InstancePicker;
 
-    type GetFut<'future, 'iter> =
-        impl Future<Output = Result<Self::InstanceIter<'iter>, LoadBalanceError>> + Send + 'future
+    type GetFut<'future> =
+        impl Future<Output = Result<Self::InstanceIter, LoadBalanceError>> + Send + 'future
         where
-            'iter: 'future;
+            Self: 'future;
 
-    fn get_picker<'future, 'iter>(
-        &'iter self,
+    fn get_picker<'future>(
+        &'future self,
         endpoint: &'future Endpoint,
         discover: &'future D,
-    ) -> Self::GetFut<'future, 'iter>
+    ) -> Self::GetFut<'future>
     where
-        'iter: 'future,
+        Self: 'future,
     {
         async {
             let key = discover.key(endpoint);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/volo/blob/main/CONTRIBUTING.md
-->

## Motivation

Because Loadbalance always get the discovery result like `Arc<Vec<Instance>>`, it should be `'static` and does not need to give it a lifetime paramenter, it is useful to walkaround compiler issue https://github.com/rust-lang/rust/issues/100013?notification_referrer_id=NT_kwDOALpTXLM0MTA2NTQ5OTcxOjEyMjExMDM2.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Modify service trait like this:

```rust
pub trait LoadBalance<D>: Send + Sync + 'static
where
    D: Discover,
{
    type InstanceIter: Iterator<Item = Address> + Send;
    type GetFut<'future>: Future<Output = Result<Self::InstanceIter, LoadBalanceError>>
        + Send
        + 'future
    where
        Self: 'future;
}
```
