### PR TITLE
fix: remove filename extension when using it as default namespace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2023,7 +2023,7 @@ dependencies = [
 
 [[package]]
 name = "volo-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/volo-cli/Cargo.toml
+++ b/volo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-cli"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-cli/src/init.rs
+++ b/volo-cli/src/init.rs
@@ -101,16 +101,7 @@ impl Init {
 
         let namespace = res
             .package
-            .map(|p| p.segments.iter().map(|s| &**s).join("::"))
-            .or_else(|| {
-                Some(
-                    res.path
-                        .file_name()?
-                        .to_string_lossy()
-                        .trim_end_matches(".rs")
-                        .to_string(),
-                )
-            });
+            .map(|p| p.segments.iter().map(|s| &**s).join("::"));
         Ok((service_name, namespace))
     }
 
@@ -268,7 +259,7 @@ impl CliCommand for Init {
             } else {
                 self.copy_thrift_template(
                     contents,
-                    self.idl.file_name().unwrap().to_str().unwrap(),
+                    self.idl.file_stem().unwrap().to_str().unwrap(),
                 )?;
             }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/volo/blob/main/CONTRIBUTING.md
-->

## Motivation
Remove .thrift extension