### PR TITLE
remove `Clone` trait bound for services in server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -854,21 +854,21 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "motore"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c162abbbfc7d50998334532e5c5e8e9dcf9fc3bafd326cad76746a625633541"
+checksum = "41fa4ce435ed5803d6967d2893ccf4891972c83a0f6b80ed495e6ffa3e58e7d7"
 dependencies = [
  "futures",
  "motore-macros",
@@ -969,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "oorandom"
@@ -1111,8 +1111,8 @@ dependencies = [
 
 [[package]]
 name = "pilota"
-version = "0.4.0"
-source = "git+https://github.com/cloudwego/pilota?branch=main#56335f1907d95fa38daa044f65dc0e328c5a72db"
+version = "0.5.0"
+source = "git+https://github.com/cloudwego/pilota?branch=main#65cb698f7f054a765f2c5ca7e2a09b24e0585e76"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -1131,8 +1131,8 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.4.2"
-source = "git+https://github.com/cloudwego/pilota?branch=main#56335f1907d95fa38daa044f65dc0e328c5a72db"
+version = "0.5.0"
+source = "git+https://github.com/cloudwego/pilota?branch=main#65cb698f7f054a765f2c5ca7e2a09b24e0585e76"
 dependencies = [
  "faststr",
  "fxhash",
@@ -1158,7 +1158,7 @@ dependencies = [
 [[package]]
 name = "pilota-thrift-parser"
 version = "0.4.0"
-source = "git+https://github.com/cloudwego/pilota?branch=main#56335f1907d95fa38daa044f65dc0e328c5a72db"
+source = "git+https://github.com/cloudwego/pilota?branch=main#65cb698f7f054a765f2c5ca7e2a09b24e0585e76"
 dependencies = [
  "nom",
 ]
@@ -1707,12 +1707,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb20089a8ba2b69debd491f8d2d023761cbf196e999218c591fa1e7e15a21907"
+checksum = "4c9afddd2cec1c0909f06b00ef33f94ab2cc0578c4a610aa208ddfec8aa2b43a"
 dependencies = [
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]

--- a/volo-build/src/thrift_backend.rs
+++ b/volo-build/src/thrift_backend.rs
@@ -305,7 +305,7 @@ impl pilota_build::CodegenBackend for VoloThriftBackend {
                     None => unreachable!()
                 }
             };
-            let req_field_names = m.args.iter().map(|a| format_ident!("{}", a.name)).collect_vec();
+            let req_field_names = m.args.iter().map(|a| self.cx.rust_name(a.def_id).as_syn_ident()).collect_vec();
             let anonymous_args_send_name = self.method_args_path(&service_name, m, true);
             let exception = if let Some(p) = &m.exceptions {
                 let path = self.cx.cur_related_item_path(p.did);
@@ -370,7 +370,7 @@ impl pilota_build::CodegenBackend for VoloThriftBackend {
 
         let user_handler = all_methods.iter().map(|m| {
             let name = self.cx.rust_name(m.def_id).as_syn_ident();
-            let args = m.args.iter().map(|a| format_ident!("{}", a.name));
+            let args = m.args.iter().map(|a| self.cx.rust_name(a.def_id).as_syn_ident());
             let has_exception = m.exceptions.is_some();
             let method_result_path = self.method_result_path(&service_name, m);
 


### PR DESCRIPTION
## Motivation
remove `Clone` trait bound for services in server.
we can not remove `Clone` for client. because `with_callopt` needs clone for now

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
