### PR TITLE
param lifetime follow with self in discovery trait

### DIFF
--- a/volo/src/discovery/mod.rs
+++ b/volo/src/discovery/mod.rs
@@ -35,7 +35,7 @@ pub trait Discover: Send + Sync + 'static {
     type DiscFut<'future>: Future<Output = Result<Vec<Arc<Instance>>, Self::Error>> + Send + 'future;
 
     /// `discover` allows to request an endpoint and return a discover future.
-    fn discover(&self, endpoint: &Endpoint) -> Self::DiscFut<'_>;
+    fn discover<'s>(&'s self, endpoint: &'s Endpoint) -> Self::DiscFut<'s>;
     /// `key` should return a key suitable for cache.
     fn key(&self, endpoint: &Endpoint) -> Self::Key;
     /// `watch` should return a [`async_broadcast::Receiver`] which can be used to subscribe


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/volo/blob/main/CONTRIBUTING.md
-->

## Motivation

the reference of discover parameter would be used in the future, so it would follow with self.
