### PR TITLE
remove `Service: Clone` bound for thrift client

### DIFF
--- a/examples/src/hello/thrift_client.rs
+++ b/examples/src/hello/thrift_client.rs
@@ -21,11 +21,7 @@ async fn main() {
     let req = volo_gen::thrift_gen::hello::HelloRequest {
         name: "volo".into(),
     };
-    let resp = CLIENT
-        .clone()
-        .with_callopt(CallOpt::default())
-        .hello(req)
-        .await;
+    let resp = CLIENT.with_callopt(CallOpt::default()).hello(req).await;
     match resp {
         Ok(info) => println!("{info:?}"),
         Err(e) => eprintln!("{e:?}"),

--- a/volo-build/src/grpc_backend.rs
+++ b/volo-build/src/grpc_backend.rs
@@ -415,7 +415,7 @@ impl CodegenBackend for VoloGrpcBackend {
             pub struct #oneshot_client_name<S>(pub ::volo_grpc::Client<S>);
 
             impl<S> #generic_client_name<S> where S: ::volo::service::Service<::volo_grpc::context::ClientContext, ::volo_grpc::Request<#req_enum_name_send>, Response=::volo_grpc::Response<#resp_enum_name_recv>, Error = ::volo_grpc::Status> + Sync + Send + 'static {
-                pub fn with_callopt<Opt: ::volo::client::Apply<::volo_grpc::context::ClientContext>>(self, opt: Opt) -> #oneshot_client_name<::volo::client::WithOptService<S, Opt>> {
+                pub fn with_callopt<Opt: ::volo::client::Apply<::volo_grpc::context::ClientContext>>(&self, opt: Opt) -> #oneshot_client_name<::volo::client::WithOptService<'_, S, Opt>> {
                     #oneshot_client_name(self.0.with_opt(opt))
                 }
 

--- a/volo-build/src/thrift_backend.rs
+++ b/volo-build/src/thrift_backend.rs
@@ -426,7 +426,7 @@ impl pilota_build::CodegenBackend for VoloThriftBackend {
 
             pub struct #mk_client_name;
 
-            pub type #client_name = #generic_client_name<::volo::service::BoxCloneService<::volo_thrift::context::ClientContext, #req_send_name, ::std::option::Option<#res_name>, ::volo_thrift::Error>>;
+            pub type #client_name = #generic_client_name<::volo::service::BoxService<::volo_thrift::context::ClientContext, #req_send_name, ::std::option::Option<#res_name>, ::volo_thrift::Error>>;
 
             impl<S> ::volo::client::MkClient<::volo_thrift::Client<S>> for #mk_client_name {
                 type Target = #generic_client_name<S>;
@@ -441,7 +441,7 @@ impl pilota_build::CodegenBackend for VoloThriftBackend {
             pub struct #oneshot_client_name<S>(pub ::volo_thrift::Client<S>);
 
             impl<S: ::volo::service::Service<::volo_thrift::context::ClientContext, #req_send_name, Response = ::std::option::Option<#res_name>, Error = ::volo_thrift::Error> + Send + Sync + 'static> #generic_client_name<S> {
-                pub fn with_callopt<Opt: ::volo::client::Apply<::volo_thrift::context::ClientContext>>(self, opt: Opt) -> #oneshot_client_name<::volo::client::WithOptService<S, Opt>> {
+                pub fn with_callopt<Opt: ::volo::client::Apply<::volo_thrift::context::ClientContext>>(&self, opt: Opt) -> #oneshot_client_name<::volo::client::WithOptService<'_, S, Opt>> {
                     #oneshot_client_name(self.0.with_opt(opt))
                 }
 

--- a/volo-grpc/src/client/mod.rs
+++ b/volo-grpc/src/client/mod.rs
@@ -486,10 +486,10 @@ impl<S> Client<S> {
         )
     }
 
-    pub fn with_opt<Opt>(self, opt: Opt) -> Client<WithOptService<S, Opt>> {
+    pub fn with_opt<Opt>(&self, opt: Opt) -> Client<WithOptService<'_, S, Opt>> {
         Client {
-            transport: WithOptService::new(self.transport, opt),
-            inner: self.inner,
+            transport: WithOptService::new(&self.transport, opt),
+            inner: self.inner.clone(),
         }
     }
 }

--- a/volo/src/client.rs
+++ b/volo/src/client.rs
@@ -3,13 +3,13 @@ use motore::Service;
 
 pub trait ClientService<Cx, Req>: Service<Cx, Req> {}
 
-pub struct WithOptService<S, Opt> {
-    inner: S,
+pub struct WithOptService<'s, S, Opt> {
+    inner: &'s S,
     opt: Opt,
 }
 
-impl<S, Opt> WithOptService<S, Opt> {
-    pub fn new(inner: S, opt: Opt) -> Self {
+impl<'s, S, Opt> WithOptService<'s, S, Opt> {
+    pub fn new(inner: &'s S, opt: Opt) -> Self {
         Self { inner, opt }
     }
 }
@@ -38,7 +38,7 @@ pub trait OneShotService<Cx, Request> {
         Self: 'cx;
 }
 
-impl<S, Cx, Req, Opt> OneShotService<Cx, Req> for WithOptService<S, Opt>
+impl<'s, S, Cx, Req, Opt> OneShotService<Cx, Req> for WithOptService<'s, S, Opt>
 where
     Cx: 'static + Send,
     Opt: 'static + Send + Sync + Apply<Cx, Error = S::Error>,


### PR DESCRIPTION
## Motivation
remove `Service: Clone` bound for thrift client

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
