### PR TITLE
add tracing span provider trait

### DIFF
--- a/volo-build/src/thrift_backend.rs
+++ b/volo-build/src/thrift_backend.rs
@@ -534,7 +534,7 @@ impl pilota_build::CodegenBackend for VoloThriftBackend {
 
 
             impl<S> {server_name}<S> where S: {service_name} + ::core::marker::Send + ::core::marker::Sync + 'static {{
-                pub fn new(inner: S) -> ::volo_thrift::server::Server<Self, ::volo::layer::Identity, {req_recv_name}, ::volo_thrift::codec::default::DefaultMakeCodec<::volo_thrift::codec::default::ttheader::MakeTTHeaderCodec<::volo_thrift::codec::default::framed::MakeFramedCodec<::volo_thrift::codec::default::thrift::MakeThriftCodec>>>> {{
+                pub fn new(inner: S) -> ::volo_thrift::server::Server<Self, ::volo::layer::Identity, {req_recv_name}, ::volo_thrift::codec::default::DefaultMakeCodec<::volo_thrift::codec::default::ttheader::MakeTTHeaderCodec<::volo_thrift::codec::default::framed::MakeFramedCodec<::volo_thrift::codec::default::thrift::MakeThriftCodec>>>, ::volo_thrift::tracing::DefaultProvider> {{
                     ::volo_thrift::server::Server::new(Self {{
                         inner,
                     }})

--- a/volo-thrift/src/tracing.rs
+++ b/volo-thrift/src/tracing.rs
@@ -1,15 +1,34 @@
-pub struct ServerState(&'static str);
+use tracing::Span;
 
-impl ServerState {
-    pub const DECODE: &'static str = "volo-server-decode";
-    pub const HANDLE: &'static str = "volo-server-handle";
-    pub const ENCODE: &'static str = "volo-server-encode";
-    pub const SERVE: &'static str = "volo-server-serve";
+use crate::context::ServerContext;
+
+pub trait SpanProvider: 'static + Send + Sync + Clone {
+    fn on_serve(&self) -> Span {
+        Span::none()
+    }
+
+    fn on_decode(&self) -> Span {
+        Span::none()
+    }
+
+    fn on_encode(&self) -> Span {
+        Span::none()
+    }
+
+    fn leave_decode(&self, context: &ServerContext) {
+        let _ = context;
+    }
+
+    fn leave_encode(&self, context: &ServerContext) {
+        let _ = context;
+    }
+
+    fn leave_serve(&self, context: &ServerContext) {
+        let _ = context;
+    }
 }
 
-pub struct ServerField(&'static str);
+#[derive(Clone)]
+pub struct DefaultProvider;
 
-impl ServerField {
-    pub const SEND_SIZE: &'static str = "volo-server-send-size";
-    pub const RECV_SIZE: &'static str = "volo-server-recv-size";
-}
+impl SpanProvider for DefaultProvider {}


### PR DESCRIPTION
Becuase `tracing` should register span field when span creation, there should be a hook to register span provider instead of creating span by volo itself.