### PR TITLE
Format generated codes and make err outputs readable for `volo-cli`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "volo-build"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2694,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "volo-cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/volo-build/Cargo.toml
+++ b/volo-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-build"
-version = "0.8.2"
+version = "0.8.3"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-build/src/grpc_backend.rs
+++ b/volo-build/src/grpc_backend.rs
@@ -626,9 +626,15 @@ impl CodegenBackend for VoloGrpcBackend {
         let name = self.cx().rust_name(method.def_id);
 
         format!(
-            r#"async fn {name}(&self, {args}) -> ::std::result::Result<{ret_ty}>{{
-				{default_result}
-			}}"#
+            r#"
+    async fn {name}(
+        &self,
+        {args},
+    ) -> ::std::result::Result<{ret_ty}>
+    {{
+        {default_result}
+    }}
+"#
         )
     }
 

--- a/volo-build/src/model.rs
+++ b/volo-build/src/model.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, path::PathBuf};
 
+use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 
 use crate::util::get_repo_latest_commit_id;
@@ -48,10 +49,34 @@ impl Idl {
             Source::Local => Ok(()),
         }
     }
+
+    pub fn ensure_readable(&self) -> anyhow::Result<()> {
+        // We should ensure that:
+        //   1. All the files exist (`ENOENT` may occur)
+        //   2. All the files can be accessed by the current user (`EPERM` may occur)
+        //   3. All the files can be read by the current user (`EPERM` may occur)
+        // The simplest method is opening it with read perm (`O_RDONLY`)
+
+        try_open_readonly(&self.path)
+            .map_err(|e| anyhow!("{}: {}", self.path.to_str().unwrap(), e))?;
+
+        if let Some(includes) = &self.includes {
+            for inc in includes.iter() {
+                try_open_readonly(inc).map_err(|e| anyhow!("{}: {}", inc.to_str().unwrap(), e))?;
+            }
+        }
+
+        Ok(())
+    }
 }
 
 fn default_keep_unknown_fields() -> bool {
     false
+}
+
+fn try_open_readonly<P: AsRef<std::path::Path>>(path: P) -> std::io::Result<()> {
+    let _ = std::fs::OpenOptions::new().read(true).open(path)?;
+    Ok(())
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/volo-build/src/thrift_backend.rs
+++ b/volo-build/src/thrift_backend.rs
@@ -670,9 +670,15 @@ impl pilota_build::CodegenBackend for VoloThriftBackend {
         };
 
         format!(
-            r#"async fn {name}(&self, {args}) -> ::core::result::Result<{ret_ty}, {exception}>{{
-					Ok(Default::default())
-				}}"#
+            r#"
+    async fn {name}(
+        &self,
+        {args},
+    ) -> ::core::result::Result<{ret_ty}, {exception}>
+    {{
+        Ok(Default::default())
+    }}
+"#
         )
     }
 

--- a/volo-cli/Cargo.toml
+++ b/volo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-cli"
-version = "0.8.0"
+version = "0.8.1"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-cli/src/bin/volo.rs
+++ b/volo-cli/src/bin/volo.rs
@@ -1,11 +1,10 @@
-use anyhow::Result;
 use clap::Parser;
 use colored::*;
 use log::{debug, error};
 use update_informer::{registry, Check};
 use volo_cli::model;
 
-fn main() -> Result<()> {
+fn main() {
     // set default log level if not set
     if std::env::var("RUST_LOG").is_err() {
         std::env::set_var("RUST_LOG", "WARN");
@@ -46,5 +45,7 @@ fn main() -> Result<()> {
         println!("\n{outdated_msg}\n{update_msg}");
     }
 
-    res
+    if res.is_err() {
+        std::process::exit(1);
+    }
 }

--- a/volo-cli/src/init.rs
+++ b/volo-cli/src/init.rs
@@ -198,6 +198,7 @@ impl CliCommand for Init {
                 });
             }
             idl.path = self.idl.clone();
+            idl.ensure_readable()?;
 
             let mut entry = Entry {
                 protocol: idl.protocol(),

--- a/volo-cli/src/init.rs
+++ b/volo-cli/src/init.rs
@@ -1,4 +1,4 @@
-use std::{fs::create_dir_all, path::PathBuf};
+use std::{fs::create_dir_all, path::PathBuf, process::Command};
 
 use clap::{value_parser, Parser};
 use volo_build::{
@@ -272,6 +272,8 @@ impl CliCommand for Init {
             DEFAULT_CONFIG_FILE,
             PathBuf::from("./volo-gen/").join(DEFAULT_CONFIG_FILE),
         )?;
+
+        let _ = Command::new("cargo").arg("fmt").arg("--all").output()?;
 
         Ok(())
     }

--- a/volo-cli/src/templates/grpc/src/bin/server_rs
+++ b/volo-cli/src/templates/grpc/src/bin/server_rs
@@ -1,5 +1,3 @@
-
-
 use std::net::SocketAddr;
 
 use volo_grpc::server::{{Server, ServiceBuilder}};

--- a/volo-cli/src/templates/grpc/src/lib_rs
+++ b/volo-cli/src/templates/grpc/src/lib_rs
@@ -1,7 +1,3 @@
-
-
 pub struct S;
 
-impl volo_gen::{service_global_name} for S {{
-	{methods}
-}}
+impl volo_gen::{service_global_name} for S {{{methods}}}

--- a/volo-cli/src/templates/thrift/src/bin/server_rs
+++ b/volo-cli/src/templates/thrift/src/bin/server_rs
@@ -1,8 +1,6 @@
-
-
 use std::net::SocketAddr;
 
-use {name}::{{S}};
+use {name}::S;
 
 #[volo::main]
 async fn main() {{

--- a/volo-cli/src/templates/thrift/src/lib_rs
+++ b/volo-cli/src/templates/thrift/src/lib_rs
@@ -1,7 +1,3 @@
-
-
 pub struct S;
 
-impl volo_gen::{service_global_name} for S {{
-	{methods}
-}}
+impl volo_gen::{service_global_name} for S {{{methods}}}

--- a/volo-cli/src/templates/thrift/volo-gen/src/lib_rs
+++ b/volo-cli/src/templates/thrift/volo-gen/src/lib_rs
@@ -1,5 +1,3 @@
-
-
 mod gen {{
     volo::include_service!("volo_gen.rs");
 }}


### PR DESCRIPTION
## Motivation

The previous `volo-cli` will panic when the input idl file does not exist or cannot be accessed by the current user:

```
$ volo init volo-example idl/file-not-exist.thrift
thread 'main' panicked at /home/****/.cargo/registry/src/rsproxy.cn-0dccff568467c15b/pilota-build-0.9.0/src/parser/thrift/mod.rs:662:49:
normalize path failed: idl/file-not-exist.thrift
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

```
$ volo init volo-example idl/file-without-permission.thrift
thread 'main' panicked at /home/****/.cargo/registry/src/rsproxy.cn-0dccff568467c15b/pilota-build-0.9.0/src/parser/thrift/mod.rs:29:72:
called `Result::unwrap()` on an `Err` value: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Even if the `volo-cli` does not panic, the error message is output twice:

```
$ volo init volo-example idl/empty-file.thrift
cargo:rerun-if-changed=/home/****/****/volo-example/idl/empty-file.thrift
 ERROR volo > No service found.
Error: No service found.
```

Also, the templates that generate the codes have some empty lines, this PR also removes them and runs `cargo fmt --all` after generating codes.

## Solution

1. Check whether the idl files exist and handle errors before reading them,
2. Do not return `Result` in `main`, call `std::process::exit` directly
3. Run `cargo fmt --all` after generating codes