### PR TITLE
feat(volo-cli): init for generated codes as a git repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,7 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -718,6 +719,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
+name = "git2"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf97ba92db08df386e10c8ede66a2a0369bd277090afd8710e19e38de9ec0cd"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,6 +993,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
+name = "jobserver"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,10 +1023,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.16.1+1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2a2bb3680b094add03bb3732ec520ece34da31a8cd2d633d1389d0f0fb60d0c"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "libz-sys"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -2672,6 +2719,7 @@ version = "0.8.3"
 dependencies = [
  "anyhow",
  "dirs",
+ "git2",
  "heck 0.4.1",
  "itertools",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ futures = "0.3"
 futures-util = "0.3"
 flate2 = "1"
 fxhash = "0.2"
+git2 = { version = "0.18", default-features = false }
 h2 = "0.3"
 heck = "0.4"
 hex = "0.4"

--- a/volo-build/Cargo.toml
+++ b/volo-build/Cargo.toml
@@ -23,6 +23,7 @@ pilota-build.workspace = true
 
 anyhow.workspace = true
 dirs.workspace = true
+git2.workspace = true
 heck.workspace = true
 itertools.workspace = true
 lazy_static.workspace = true

--- a/volo-cli/src/init.rs
+++ b/volo-cli/src/init.rs
@@ -4,7 +4,7 @@ use clap::{value_parser, Parser};
 use volo_build::{
     config_builder::InitBuilder,
     model::{Entry, GitSource, Idl, Source, DEFAULT_FILENAME},
-    util::{get_repo_latest_commit_id, DEFAULT_CONFIG_FILE},
+    util::{get_repo_latest_commit_id, git_repo_init, DEFAULT_CONFIG_FILE},
 };
 
 use crate::command::CliCommand;
@@ -274,6 +274,9 @@ impl CliCommand for Init {
         )?;
 
         let _ = Command::new("cargo").arg("fmt").arg("--all").output()?;
+
+        let cwd = std::env::current_dir()?;
+        git_repo_init(&cwd)?;
 
         Ok(())
     }


### PR DESCRIPTION
## Motivation

The command `cargo new` can create a small project and initialize it as a repository using the specified version control software (`git` by default).

The `volo init` needs a same function and this PR does it.

## Solution

The implementation of this PR refers to the source code of `cargo`. After generating codes, the current directory will be initialized as a git repository if it is not in an existing git repository, or is in a git repository but conforms to its "gitignore" rules.

Reference: <https://github.com/rust-lang/cargo/blob/0.74.0/src/cargo/util/vcs.rs>