### PR TITLE
fix(volo-thrift): client RpcCx didn't clear extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2964,7 +2964,7 @@ version = "0.8.0"
 
 [[package]]
 name = "volo-thrift"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "bytes",

--- a/volo-thrift/Cargo.toml
+++ b/volo-thrift/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-thrift"
-version = "0.8.1"
+version = "0.8.2"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-thrift/src/context.rs
+++ b/volo-thrift/src/context.rs
@@ -209,12 +209,13 @@ impl ClientContext {
 
     #[inline]
     pub fn reset(&mut self, seq_id: i32, msg_type: TMessageType) {
-        self.rpc_info.clear();
         self.seq_id = seq_id;
         self.message_type = msg_type;
         self.transport.should_reuse = true;
         self.stats.reset();
         self.common_stats.reset();
+        // self.0 is RpcCx, this reset will clear rpcinfo and extension
+        self.0.reset(self.0.inner);
     }
 }
 


### PR DESCRIPTION
Previously we only clear the `rpcinfo` and `inner` part of `RpcCx` in the client `make_cx` method, and didn't clear the `extension`, this pr fixes that.