### PR TITLE
chore(volo-http): update service with wrapped `Request`, `Response` and `Infallible`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2938,7 +2938,6 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.0.0",
  "http-body-util",
  "hyper 1.0.1",
  "hyper-util",

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -20,7 +20,6 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 volo = { version = "0.8", path = "../volo" }
 
-http = "1"
 http-body-util = "0.1"
 hyper = { version = "1", features = ["server", "http1", "http2"] }
 hyper-util = { version = "0.1", features = ["tokio"] }

--- a/volo-http/src/extract.rs
+++ b/volo-http/src/extract.rs
@@ -1,15 +1,14 @@
 use futures_util::Future;
-use http::{Method, Response, Uri};
+use hyper::http::{Method, Uri};
 use volo::net::Address;
 
-use crate::{response::IntoResponse, HttpContext, Params, State};
+use crate::{response::Infallible, HttpContext, Params, State};
 
 pub trait FromContext<S>: Sized {
-    type Rejection: IntoResponse;
     fn from_context(
         context: &HttpContext,
         state: &S,
-    ) -> impl Future<Output = Result<Self, Self::Rejection>> + Send;
+    ) -> impl Future<Output = Result<Self, Infallible>> + Send;
 }
 
 impl<T, S> FromContext<S> for Option<T>
@@ -17,9 +16,7 @@ where
     T: FromContext<S>,
     S: Send + Sync,
 {
-    type Rejection = Response<()>; // Infallible
-
-    async fn from_context(context: &HttpContext, state: &S) -> Result<Self, Self::Rejection> {
+    async fn from_context(context: &HttpContext, state: &S) -> Result<Self, Infallible> {
         Ok(T::from_context(context, state).await.ok())
     }
 }
@@ -28,9 +25,7 @@ impl<S> FromContext<S> for Address
 where
     S: Send + Sync,
 {
-    type Rejection = Response<()>; // Infallible
-
-    async fn from_context(context: &HttpContext, _state: &S) -> Result<Address, Self::Rejection> {
+    async fn from_context(context: &HttpContext, _state: &S) -> Result<Address, Infallible> {
         Ok(context.peer.clone())
     }
 }
@@ -39,9 +34,7 @@ impl<S> FromContext<S> for Uri
 where
     S: Send + Sync,
 {
-    type Rejection = Response<()>; // Infallible
-
-    async fn from_context(context: &HttpContext, _state: &S) -> Result<Uri, Self::Rejection> {
+    async fn from_context(context: &HttpContext, _state: &S) -> Result<Uri, Infallible> {
         Ok(context.uri.clone())
     }
 }
@@ -50,9 +43,7 @@ impl<S> FromContext<S> for Method
 where
     S: Send + Sync,
 {
-    type Rejection = Response<()>; // Infallible
-
-    async fn from_context(context: &HttpContext, _state: &S) -> Result<Method, Self::Rejection> {
+    async fn from_context(context: &HttpContext, _state: &S) -> Result<Method, Infallible> {
         Ok(context.method.clone())
     }
 }
@@ -61,9 +52,7 @@ impl<S> FromContext<S> for Params
 where
     S: Send + Sync,
 {
-    type Rejection = Response<()>; // Infallible
-
-    async fn from_context(context: &HttpContext, _state: &S) -> Result<Params, Self::Rejection> {
+    async fn from_context(context: &HttpContext, _state: &S) -> Result<Params, Infallible> {
         Ok(context.params.clone())
     }
 }
@@ -72,9 +61,7 @@ impl<S> FromContext<S> for State<S>
 where
     S: Clone + Send + Sync,
 {
-    type Rejection = Response<()>; // Infallible
-
-    async fn from_context(_context: &HttpContext, state: &S) -> Result<Self, Self::Rejection> {
+    async fn from_context(_context: &HttpContext, state: &S) -> Result<Self, Infallible> {
         Ok(State(state.clone()))
     }
 }

--- a/volo-http/src/extract.rs
+++ b/volo-http/src/extract.rs
@@ -1,8 +1,10 @@
+use std::convert::Infallible;
+
 use futures_util::Future;
 use hyper::http::{Method, Uri};
 use volo::net::Address;
 
-use crate::{response::Infallible, HttpContext, Params, State};
+use crate::{HttpContext, Params, State};
 
 pub trait FromContext<S>: Sized {
     fn from_context(

--- a/volo-http/src/handler.rs
+++ b/volo-http/src/handler.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, marker::PhantomData};
+use std::{convert::Infallible, future::Future, marker::PhantomData};
 
 use hyper::body::Incoming;
 use motore::Service;
@@ -8,7 +8,7 @@ use crate::{
     macros::{all_the_tuples, all_the_tuples_no_last_special_case},
     request::FromRequest,
     response::{IntoResponse, Response},
-    DynError, DynService, HttpContext,
+    DynService, HttpContext,
 };
 
 pub trait Handler<T, S>: Sized {
@@ -126,7 +126,7 @@ where
         cx: &mut HttpContext,
         req: Incoming,
         state: S,
-    ) -> Result<Response, DynError> {
+    ) -> Result<Response, Infallible> {
         self.0.into_route(state).call(cx, req).await
     }
 }
@@ -233,7 +233,7 @@ where
     S: Sync,
 {
     type Response = Response;
-    type Error = DynError;
+    type Error = Infallible;
 
     async fn call<'s, 'cx>(
         &'s self,

--- a/volo-http/src/handler.rs
+++ b/volo-http/src/handler.rs
@@ -1,6 +1,5 @@
 use std::{future::Future, marker::PhantomData};
 
-use http::Response;
 use hyper::body::Incoming;
 use motore::Service;
 
@@ -8,7 +7,7 @@ use crate::{
     extract::FromContext,
     macros::{all_the_tuples, all_the_tuples_no_last_special_case},
     request::FromRequest,
-    response::{IntoResponse, RespBody},
+    response::{IntoResponse, Response},
     DynError, DynService, HttpContext,
 };
 
@@ -18,7 +17,7 @@ pub trait Handler<T, S>: Sized {
         context: &mut HttpContext,
         req: Incoming,
         state: &S,
-    ) -> impl Future<Output = Response<RespBody>> + Send;
+    ) -> impl Future<Output = Response> + Send;
 
     fn with_state(self, state: S) -> HandlerService<Self, S, T>
     where
@@ -39,12 +38,7 @@ where
     Res: IntoResponse,
     S: Send + Sync,
 {
-    async fn call(
-        self,
-        _context: &mut HttpContext,
-        _req: Incoming,
-        _state: &S,
-    ) -> Response<RespBody> {
+    async fn call(self, _context: &mut HttpContext, _req: Incoming, _state: &S) -> Response {
         self().await.into_response()
     }
 }
@@ -63,7 +57,7 @@ macro_rules! impl_handler {
             $( for<'r> $ty: FromContext<S> + Send + 'r, )*
             for<'r> $last: FromRequest<S, M> + Send + 'r,
         {
-            async fn call(self, context: &mut HttpContext, req: Incoming, state: &S) -> Response<RespBody> {
+            async fn call(self, context: &mut HttpContext, req: Incoming, state: &S) -> Response {
                 $(
                     let $ty = match $ty::from_context(context, state).await {
                         Ok(value) => value,
@@ -132,7 +126,7 @@ where
         cx: &mut HttpContext,
         req: Incoming,
         state: S,
-    ) -> Result<Response<RespBody>, DynError> {
+    ) -> Result<Response, DynError> {
         self.0.into_route(state).call(cx, req).await
     }
 }
@@ -238,7 +232,7 @@ where
     for<'r> H: Handler<T, S> + Clone + Send + Sync + 'r,
     S: Sync,
 {
-    type Response = Response<RespBody>;
+    type Response = Response;
     type Error = DynError;
 
     async fn call<'s, 'cx>(
@@ -251,7 +245,7 @@ where
 }
 
 pub trait HandlerWithoutRequest<T>: Sized {
-    fn call(self, context: &HttpContext) -> impl Future<Output = Response<RespBody>> + Send;
+    fn call(self, context: &HttpContext) -> impl Future<Output = Response> + Send;
 }
 
 impl<F, Res> HandlerWithoutRequest<()> for F
@@ -259,7 +253,7 @@ where
     F: FnOnce() -> Res + Clone + Send,
     Res: IntoResponse,
 {
-    async fn call(self, _context: &HttpContext) -> Response<RespBody> {
+    async fn call(self, _context: &HttpContext) -> Response {
         self().into_response()
     }
 }
@@ -275,7 +269,7 @@ macro_rules! impl_handler_without_request {
             Res: IntoResponse,
             $( for<'r> $ty: FromContext<()> + Send + 'r, )*
         {
-            async fn call(self, context: &HttpContext) -> Response<RespBody> {
+            async fn call(self, context: &HttpContext) -> Response {
                 $(
                     let $ty = match $ty::from_context(context, &()).await {
                         Ok(value) => value,

--- a/volo-http/src/lib.rs
+++ b/volo-http/src/lib.rs
@@ -12,17 +12,18 @@ mod macros;
 pub use bytes::Bytes;
 pub use hyper::{
     body::Incoming,
-    http::{
-        Extensions, HeaderMap, HeaderName, HeaderValue, Method, Request, Response, StatusCode, Uri,
-        Version,
-    },
+    http::{Extensions, HeaderMap, HeaderName, HeaderValue, Method, StatusCode, Uri, Version},
 };
 pub use volo::net::Address;
 
-pub use crate::{param::Params, request::Json, server::Server};
+pub use crate::{
+    param::Params,
+    request::{Json, Request},
+    response::{Infallible, Response},
+    server::Server,
+};
 
-pub type DynService =
-    motore::BoxCloneService<HttpContext, Incoming, Response<response::RespBody>, DynError>;
+pub type DynService = motore::BoxCloneService<HttpContext, Incoming, Response, DynError>;
 pub type DynError = Box<dyn std::error::Error + Send + Sync>;
 
 #[derive(Debug, Default, Clone, Copy)]

--- a/volo-http/src/lib.rs
+++ b/volo-http/src/lib.rs
@@ -9,6 +9,8 @@ pub mod server;
 
 mod macros;
 
+use std::convert::Infallible;
+
 pub use bytes::Bytes;
 pub use hyper::{
     body::Incoming,
@@ -19,12 +21,11 @@ pub use volo::net::Address;
 pub use crate::{
     param::Params,
     request::{Json, Request},
-    response::{Infallible, Response},
+    response::Response,
     server::Server,
 };
 
-pub type DynService = motore::BoxCloneService<HttpContext, Incoming, Response, DynError>;
-pub type DynError = Box<dyn std::error::Error + Send + Sync>;
+pub type DynService = motore::BoxCloneService<HttpContext, Incoming, Response, Infallible>;
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct State<S>(pub S);

--- a/volo-http/src/lib.rs
+++ b/volo-http/src/lib.rs
@@ -10,20 +10,16 @@ pub mod server;
 mod macros;
 
 pub use bytes::Bytes;
-use http::{Extensions, HeaderMap, HeaderValue, Version};
-pub use http::{Method, StatusCode, Uri};
-use hyper::{body::Incoming, Response};
+pub use hyper::{
+    body::Incoming,
+    http::{
+        Extensions, HeaderMap, HeaderName, HeaderValue, Method, Request, Response, StatusCode, Uri,
+        Version,
+    },
+};
 pub use volo::net::Address;
 
 pub use crate::{param::Params, request::Json, server::Server};
-
-mod private {
-    #[derive(Debug, Clone, Copy)]
-    pub enum ViaContext {}
-
-    #[derive(Debug, Clone, Copy)]
-    pub enum ViaRequest {}
-}
 
 pub type DynService =
     motore::BoxCloneService<HttpContext, Incoming, Response<response::RespBody>, DynError>;

--- a/volo-http/src/request.rs
+++ b/volo-http/src/request.rs
@@ -7,10 +7,17 @@ use serde::de::DeserializeOwned;
 
 use crate::{
     extract::FromContext,
-    private,
     response::{IntoResponse, RespBody},
     HttpContext,
 };
+
+mod private {
+    #[derive(Debug, Clone, Copy)]
+    pub enum ViaContext {}
+
+    #[derive(Debug, Clone, Copy)]
+    pub enum ViaRequest {}
+}
 
 pub trait FromRequest<S, M = private::ViaRequest>: Sized {
     fn from(

--- a/volo-http/src/response.rs
+++ b/volo-http/src/response.rs
@@ -1,4 +1,5 @@
 use std::{
+    convert::Infallible,
     ops::{Deref, DerefMut},
     pin::Pin,
     task::{Context, Poll},
@@ -12,14 +13,15 @@ use hyper::{
 };
 use pin_project::pin_project;
 
-use crate::DynError;
-
-pub struct Response(pub(crate) hyper::http::Response<RespBody>);
-pub struct Infallible;
+pub struct Response(hyper::http::Response<RespBody>);
 
 impl Response {
     pub fn builder() -> Builder {
         Builder::new()
+    }
+
+    pub(crate) fn inner(self) -> hyper::http::Response<RespBody> {
+        self.0
     }
 }
 
@@ -52,7 +54,7 @@ pub struct RespBody {
 impl Body for RespBody {
     type Data = Bytes;
 
-    type Error = DynError;
+    type Error = Infallible;
 
     fn poll_frame(
         self: Pin<&mut Self>,

--- a/volo-http/src/response.rs
+++ b/volo-http/src/response.rs
@@ -1,28 +1,52 @@
 use std::{
+    ops::{Deref, DerefMut},
     pin::Pin,
     task::{Context, Poll},
 };
 
-use futures_util::{ready, stream};
-use http::{Response, StatusCode};
-use http_body_util::{Full, StreamBody};
-use hyper::body::{Body, Bytes, Frame};
+use futures_util::ready;
+use http_body_util::Full;
+use hyper::{
+    body::{Body, Bytes, Frame},
+    http::{response::Builder, StatusCode},
+};
 use pin_project::pin_project;
 
 use crate::DynError;
 
-#[pin_project(project = RespBodyProj)]
-pub enum RespBody {
-    Stream {
-        #[pin]
-        inner: StreamBody<
-            stream::Iter<Box<dyn Iterator<Item = Result<Frame<Bytes>, DynError>> + Send + Sync>>,
-        >,
-    },
-    Full {
-        #[pin]
-        inner: Full<Bytes>,
-    },
+pub struct Response(pub(crate) hyper::http::Response<RespBody>);
+pub struct Infallible;
+
+impl Response {
+    pub fn builder() -> Builder {
+        Builder::new()
+    }
+}
+
+impl Deref for Response {
+    type Target = hyper::http::Response<RespBody>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Response {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<hyper::http::Response<RespBody>> for Response {
+    fn from(value: hyper::http::Response<RespBody>) -> Self {
+        Self(value)
+    }
+}
+
+#[pin_project]
+pub struct RespBody {
+    #[pin]
+    inner: Full<Bytes>,
 }
 
 impl Body for RespBody {
@@ -34,24 +58,19 @@ impl Body for RespBody {
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
-        match self.project() {
-            RespBodyProj::Stream { inner } => inner.poll_frame(cx),
-            RespBodyProj::Full { inner } => {
-                Poll::Ready(ready!(inner.poll_frame(cx)).map(|result| Ok(result.unwrap())))
-            }
-        }
+        Poll::Ready(ready!(self.project().inner.poll_frame(cx)).map(|result| Ok(result.unwrap())))
     }
 }
 
 impl From<Full<Bytes>> for RespBody {
     fn from(value: Full<Bytes>) -> Self {
-        Self::Full { inner: value }
+        Self { inner: value }
     }
 }
 
 impl From<Bytes> for RespBody {
     fn from(value: Bytes) -> Self {
-        Self::Full {
+        Self {
             inner: Full::new(value),
         }
     }
@@ -59,7 +78,7 @@ impl From<Bytes> for RespBody {
 
 impl From<String> for RespBody {
     fn from(value: String) -> Self {
-        Self::Full {
+        Self {
             inner: Full::new(value.into()),
         }
     }
@@ -67,7 +86,7 @@ impl From<String> for RespBody {
 
 impl From<&'static str> for RespBody {
     fn from(value: &'static str) -> Self {
-        Self::Full {
+        Self {
             inner: Full::new(value.into()),
         }
     }
@@ -75,23 +94,19 @@ impl From<&'static str> for RespBody {
 
 impl From<()> for RespBody {
     fn from(_: ()) -> Self {
-        Self::Full {
+        Self {
             inner: Full::new(Bytes::new()),
         }
     }
 }
 
 pub trait IntoResponse {
-    fn into_response(self) -> Response<RespBody>;
+    fn into_response(self) -> Response;
 }
 
-impl<T> IntoResponse for Response<T>
-where
-    T: Into<RespBody>,
-{
-    fn into_response(self) -> Response<RespBody> {
-        let (parts, body) = self.into_parts();
-        Response::from_parts(parts, body.into())
+impl IntoResponse for Infallible {
+    fn into_response(self) -> Response {
+        StatusCode::INTERNAL_SERVER_ERROR.into_response()
     }
 }
 
@@ -99,11 +114,12 @@ impl<T> IntoResponse for T
 where
     T: Into<RespBody>,
 {
-    fn into_response(self) -> Response<RespBody> {
+    fn into_response(self) -> Response {
         Response::builder()
             .status(StatusCode::OK)
             .body(self.into())
             .unwrap()
+            .into()
     }
 }
 
@@ -112,7 +128,7 @@ where
     R: IntoResponse,
     E: IntoResponse,
 {
-    fn into_response(self) -> Response<RespBody> {
+    fn into_response(self) -> Response {
         match self {
             Ok(value) => value.into_response(),
             Err(err) => err.into_response(),
@@ -124,18 +140,19 @@ impl<T> IntoResponse for (StatusCode, T)
 where
     T: IntoResponse,
 {
-    fn into_response(self) -> Response<RespBody> {
+    fn into_response(self) -> Response {
         let mut resp = self.1.into_response();
-        *resp.status_mut() = self.0;
+        *resp.0.status_mut() = self.0;
         resp
     }
 }
 
 impl IntoResponse for StatusCode {
-    fn into_response(self) -> Response<RespBody> {
+    fn into_response(self) -> Response {
         Response::builder()
             .status(self)
             .body(String::new().into())
             .unwrap()
+            .into()
     }
 }

--- a/volo-http/src/route.rs
+++ b/volo-http/src/route.rs
@@ -1,13 +1,15 @@
 use std::collections::HashMap;
 
-use http::{Method, Response, StatusCode};
-use hyper::body::Incoming;
+use hyper::{
+    body::Incoming,
+    http::{Method, StatusCode},
+};
 use motore::{layer::Layer, service::Service};
 
 use crate::{
     handler::{DynHandler, Handler},
-    response::{IntoResponse, RespBody},
-    DynError, DynService, HttpContext,
+    response::IntoResponse,
+    DynError, DynService, HttpContext, Response,
 };
 
 // The `matchit::Router` cannot be converted to `Iterator`, so using
@@ -70,7 +72,7 @@ where
     pub fn layer<L>(self, l: L) -> Self
     where
         L: Layer<DynService> + Clone + Send + Sync + 'static,
-        L::Service: Service<HttpContext, Incoming, Response = Response<RespBody>, Error = DynError>
+        L::Service: Service<HttpContext, Incoming, Response = Response, Error = DynError>
             + Clone
             + Send
             + Sync
@@ -116,7 +118,7 @@ where
 }
 
 impl Service<HttpContext, Incoming> for Router<()> {
-    type Response = Response<RespBody>;
+    type Response = Response;
 
     type Error = DynError;
 
@@ -177,7 +179,7 @@ where
     pub fn layer<L>(self, l: L) -> Self
     where
         L: Layer<DynService> + Clone + Send + Sync + 'static,
-        L::Service: Service<HttpContext, Incoming, Response = Response<RespBody>, Error = DynError>
+        L::Service: Service<HttpContext, Incoming, Response = Response, Error = DynError>
             + Clone
             + Send
             + Sync
@@ -244,7 +246,7 @@ where
         cx: &'cx mut HttpContext,
         req: Incoming,
         state: S,
-    ) -> Result<Response<RespBody>, DynError>
+    ) -> Result<Response, DynError>
     where
         S: 'cx,
     {
@@ -353,7 +355,7 @@ where
 
     pub fn from_service<Srv>(srv: Srv) -> MethodEndpoint<S>
     where
-        Srv: Service<HttpContext, Incoming, Response = Response<RespBody>, Error = DynError>
+        Srv: Service<HttpContext, Incoming, Response = Response, Error = DynError>
             + Clone
             + Send
             + Sync
@@ -409,7 +411,7 @@ where
 
     pub fn from_service<Srv>(srv: Srv) -> Fallback<S>
     where
-        Srv: Service<HttpContext, Incoming, Response = Response<RespBody>, Error = DynError>
+        Srv: Service<HttpContext, Incoming, Response = Response, Error = DynError>
             + Clone
             + Send
             + Sync
@@ -431,7 +433,7 @@ where
     pub(crate) fn layer<L>(self, l: L) -> Self
     where
         L: Layer<DynService> + Clone + Send + Sync + 'static,
-        L::Service: Service<HttpContext, Incoming, Response = Response<RespBody>, Error = DynError>
+        L::Service: Service<HttpContext, Incoming, Response = Response, Error = DynError>
             + Clone
             + Send
             + Sync
@@ -452,7 +454,7 @@ where
         cx: &'cx mut HttpContext,
         req: Incoming,
         state: S,
-    ) -> Result<Response<RespBody>, DynError>
+    ) -> Result<Response, DynError>
     where
         S: 'cx,
     {
@@ -474,7 +476,7 @@ where
 
 pub fn from_service<Srv, S>(srv: Srv) -> MethodEndpoint<S>
 where
-    Srv: Service<HttpContext, Incoming, Response = Response<RespBody>, Error = DynError>
+    Srv: Service<HttpContext, Incoming, Response = Response, Error = DynError>
         + Clone
         + Send
         + Sync
@@ -488,7 +490,7 @@ where
 struct RouteForStatusCode(StatusCode);
 
 impl Service<HttpContext, Incoming> for RouteForStatusCode {
-    type Response = Response<RespBody>;
+    type Response = Response;
     type Error = DynError;
 
     async fn call<'s, 'cx>(

--- a/volo-http/src/route.rs
+++ b/volo-http/src/route.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, convert::Infallible};
 
 use hyper::{
     body::Incoming,
@@ -9,7 +9,7 @@ use motore::{layer::Layer, service::Service};
 use crate::{
     handler::{DynHandler, Handler},
     response::IntoResponse,
-    DynError, DynService, HttpContext, Response,
+    DynService, HttpContext, Response,
 };
 
 // The `matchit::Router` cannot be converted to `Iterator`, so using
@@ -72,7 +72,7 @@ where
     pub fn layer<L>(self, l: L) -> Self
     where
         L: Layer<DynService> + Clone + Send + Sync + 'static,
-        L::Service: Service<HttpContext, Incoming, Response = Response, Error = DynError>
+        L::Service: Service<HttpContext, Incoming, Response = Response, Error = Infallible>
             + Clone
             + Send
             + Sync
@@ -120,7 +120,7 @@ where
 impl Service<HttpContext, Incoming> for Router<()> {
     type Response = Response;
 
-    type Error = DynError;
+    type Error = Infallible;
 
     async fn call<'s, 'cx>(
         &'s self,
@@ -179,7 +179,7 @@ where
     pub fn layer<L>(self, l: L) -> Self
     where
         L: Layer<DynService> + Clone + Send + Sync + 'static,
-        L::Service: Service<HttpContext, Incoming, Response = Response, Error = DynError>
+        L::Service: Service<HttpContext, Incoming, Response = Response, Error = Infallible>
             + Clone
             + Send
             + Sync
@@ -246,7 +246,7 @@ where
         cx: &'cx mut HttpContext,
         req: Incoming,
         state: S,
-    ) -> Result<Response, DynError>
+    ) -> Result<Response, Infallible>
     where
         S: 'cx,
     {
@@ -355,7 +355,7 @@ where
 
     pub fn from_service<Srv>(srv: Srv) -> MethodEndpoint<S>
     where
-        Srv: Service<HttpContext, Incoming, Response = Response, Error = DynError>
+        Srv: Service<HttpContext, Incoming, Response = Response, Error = Infallible>
             + Clone
             + Send
             + Sync
@@ -411,7 +411,7 @@ where
 
     pub fn from_service<Srv>(srv: Srv) -> Fallback<S>
     where
-        Srv: Service<HttpContext, Incoming, Response = Response, Error = DynError>
+        Srv: Service<HttpContext, Incoming, Response = Response, Error = Infallible>
             + Clone
             + Send
             + Sync
@@ -433,7 +433,7 @@ where
     pub(crate) fn layer<L>(self, l: L) -> Self
     where
         L: Layer<DynService> + Clone + Send + Sync + 'static,
-        L::Service: Service<HttpContext, Incoming, Response = Response, Error = DynError>
+        L::Service: Service<HttpContext, Incoming, Response = Response, Error = Infallible>
             + Clone
             + Send
             + Sync
@@ -454,7 +454,7 @@ where
         cx: &'cx mut HttpContext,
         req: Incoming,
         state: S,
-    ) -> Result<Response, DynError>
+    ) -> Result<Response, Infallible>
     where
         S: 'cx,
     {
@@ -476,7 +476,7 @@ where
 
 pub fn from_service<Srv, S>(srv: Srv) -> MethodEndpoint<S>
 where
-    Srv: Service<HttpContext, Incoming, Response = Response, Error = DynError>
+    Srv: Service<HttpContext, Incoming, Response = Response, Error = Infallible>
         + Clone
         + Send
         + Sync
@@ -491,7 +491,7 @@ struct RouteForStatusCode(StatusCode);
 
 impl Service<HttpContext, Incoming> for RouteForStatusCode {
     type Response = Response;
-    type Error = DynError;
+    type Error = Infallible;
 
     async fn call<'s, 'cx>(
         &'s self,


### PR DESCRIPTION
## Motivation

The previous type in `Service` is `Request<Incoming>`, `Response<RespBody>` and `DynError`.  The first two are fixed types and their names are too long, and the last one is not useful.

This PR wraps `Request<Incoming>` and `Response<RespBody>` into 2 new types `Request` and `Response`, and replaces `DynError` with `Infallible`, which can be converted to `StatusCode::INTERNAL_SERVER_ERROR`.

Also, this PR re-exports more types from `hyper` and `http`, and to prevent type conflicts, `volo-http` uses `hyper::http` instead of using `http` crate directly.