### PR TITLE
fix: enable the code index for volo gen code

### DIFF
--- a/examples/volo-gen/src/lib.rs
+++ b/examples/volo-gen/src/lib.rs
@@ -1,6 +1,6 @@
 mod gen {
-    volo::include_service!("thrift_gen.rs");
-    volo::include_service!("proto_gen.rs");
+    include!(concat!(env!("OUT_DIR"), "/thrift_gen.rs"));
+    include!(concat!(env!("OUT_DIR"), "/proto_gen.rs"));
 }
 
 pub use gen::*;

--- a/volo-cli/src/templates/grpc/volo-gen/src/lib_rs
+++ b/volo-cli/src/templates/grpc/volo-gen/src/lib_rs
@@ -1,7 +1,7 @@
 
 
 mod gen {{
-    volo::include_service!("volo_gen.rs");
+    include!(concat!(env!("OUT_DIR"), "/volo_gen.rs"));
 }}
 
 pub use gen::volo_gen::*;

--- a/volo-cli/src/templates/thrift/volo-gen/src/lib_rs
+++ b/volo-cli/src/templates/thrift/volo-gen/src/lib_rs
@@ -1,5 +1,5 @@
 mod gen {{
-    volo::include_service!("volo_gen.rs");
+    include!(concat!(env!("OUT_DIR"), "/volo_gen.rs"));
 }}
 
 pub use gen::volo_gen::*;

--- a/volo/src/macros.rs
+++ b/volo/src/macros.rs
@@ -18,6 +18,7 @@ macro_rules! volo_unreachable {
 }
 
 #[macro_export]
+#[deprecated(since = "0.8.1", note = "use `include!` instead")]
 macro_rules! include_service {
     ($service: tt) => {
         include!(concat!(env!("OUT_DIR"), concat!("/", $service)));


### PR DESCRIPTION
## Motivation
`include_service!` macro can't be recognized by rust-analyzer, so that the code generated by volo can't enable the code index provided by ra.

## Solution

Replace `include_service!` with `include!` to enable the code index provided by ra.
