### PR TITLE
chore(volo-http): add `Rejection` for traits in extract mod

### DIFF
--- a/volo-http/src/handler.rs
+++ b/volo-http/src/handler.rs
@@ -65,7 +65,7 @@ macro_rules! impl_handler {
                 )*
                 let $last = match $last::from(context, req, state).await {
                     Ok(value) => value,
-                    Err(rejection) => return rejection,
+                    Err(rejection) => return rejection.into_response(),
                 };
                 self($($ty,)* $last).await.into_response()
             }


### PR DESCRIPTION
## Motivation

The previous `FromContext` returns `Result<Self, Infallible>` and the `FromRequest` returns `Result<Self, Response>`, which is not flexible.

## Solution

This PR adds a type `Rejection` for those traits and the `Rejection` should impl the `IntoResponse`.

With the `Rejection`, the `FromRequest` for `Json` can return an `JsonRejection` with more details.
