### PR TITLE
feat(volo-http): add middleware layers `from_fn` and `map_response`

### DIFF
--- a/examples/src/http/simple.rs
+++ b/examples/src/http/simple.rs
@@ -4,8 +4,10 @@ use faststr::FastStr;
 use serde::{Deserialize, Serialize};
 use volo_http::{
     layer::TimeoutLayer,
+    middleware::{self, Next},
     route::{get, post, MethodRouter, Router},
-    Address, Bytes, ConnectionInfo, Json, MaybeInvalid, Method, Params, Server, StatusCode, Uri,
+    Address, Bytes, ConnectionInfo, HttpContext, Incoming, Json, MaybeInvalid, Method, Params,
+    Server, StatusCode, Uri,
 };
 
 async fn hello() -> &'static str {
@@ -106,6 +108,20 @@ fn test_router() -> Router {
         .route("/test/conn_show", get(conn_show))
 }
 
+async fn middleware_noarg_test(cx: &mut HttpContext, req: Incoming, next: Next) -> StatusCode {
+    let _ = next.run(cx, req).await;
+    StatusCode::OK
+}
+
+async fn middleware_arg_test(
+    _uri: Uri,
+    _cx: &mut HttpContext,
+    _req: Incoming,
+    _next: Next,
+) -> StatusCode {
+    StatusCode::NOT_FOUND
+}
+
 #[tokio::main(flavor = "multi_thread")]
 async fn main() {
     let subscriber = tracing_subscriber::FmtSubscriber::builder()
@@ -118,6 +134,8 @@ async fn main() {
         .merge(index_router())
         .merge(user_router())
         .merge(test_router())
+        .layer(middleware::from_fn(middleware_noarg_test))
+        .layer(middleware::from_fn(middleware_arg_test))
         .layer(TimeoutLayer::new(Duration::from_secs(5), || {
             StatusCode::INTERNAL_SERVER_ERROR
         }));

--- a/volo-http/src/handler.rs
+++ b/volo-http/src/handler.rs
@@ -1,11 +1,19 @@
-use std::{convert::Infallible, future::Future, marker::PhantomData};
+use std::{
+    convert::Infallible,
+    future::Future,
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
+use futures_util::future::BoxFuture;
 use hyper::body::Incoming;
 use motore::Service;
 
 use crate::{
     extract::{FromContext, FromRequest},
     macros::{all_the_tuples, all_the_tuples_no_last_special_case},
+    middleware::Next,
     response::{IntoResponse, Response},
     DynService, HttpContext,
 };
@@ -282,3 +290,82 @@ macro_rules! impl_handler_without_request {
 }
 
 all_the_tuples_no_last_special_case!(impl_handler_without_request);
+
+pub trait MiddlewareHandlerFromFn<'r, T, S>: Sized {
+    // type Response: IntoResponse;
+    type Future: Future<Output = Response> + Send + 'r;
+
+    fn call(
+        &self,
+        context: &'r mut HttpContext,
+        req: Incoming,
+        state: &'r S,
+        next: Next,
+    ) -> Self::Future;
+}
+
+macro_rules! impl_middleware_handler_from_fn {
+    (
+        [$($ty:ident),*], $last:ident
+    ) => {
+        #[allow(non_snake_case, unused_mut, unused_variables)]
+        impl<'r, F, Fut, Res, M, S, $($ty,)* $last> MiddlewareHandlerFromFn<'r, (M, $($ty,)* $last), S> for F
+        where
+            F: Fn($($ty,)* &'r mut HttpContext, $last, Next) -> Fut + Copy + Send + Sync + 'static,
+            Fut: Future<Output = Res> + Send + 'r,
+            Res: IntoResponse + 'r,
+            S: Send + Sync + 'r,
+            $( $ty: FromContext<S> + Send + 'r, )*
+            $last: FromRequest<S, M> + Send + 'r,
+        {
+            // type Response = Response;
+            type Future = ResponseFuture<'r, Response>;
+
+            fn call(
+                &self,
+                context: &'r mut HttpContext,
+                req: Incoming,
+                state: &'r S,
+                next: Next,
+            ) -> Self::Future {
+                let f = *self;
+
+                let future = Box::pin(async move {
+                    $(
+                        let $ty = match $ty::from_context(context, state).await {
+                            Ok(value) => value,
+                            Err(rejection) => return rejection.into_response(),
+                        };
+                    )*
+                    let $last = match $last::from(context, req, state).await {
+                        Ok(value) => value,
+                        Err(rejection) => return rejection.into_response(),
+                    };
+                    f($($ty,)* context, $last, next).await.into_response()
+                });
+
+                ResponseFuture {
+                    inner: future,
+                }
+            }
+        }
+    };
+}
+
+all_the_tuples!(impl_middleware_handler_from_fn);
+
+/// Response future for [`MapResponse`].
+pub struct ResponseFuture<'r, Res> {
+    inner: BoxFuture<'r, Res>,
+}
+
+impl<'r, Res> Future for ResponseFuture<'r, Res>
+where
+    Res: 'r,
+{
+    type Output = Res;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.inner.as_mut().poll(cx)
+    }
+}

--- a/volo-http/src/lib.rs
+++ b/volo-http/src/lib.rs
@@ -2,6 +2,7 @@ pub mod context;
 pub mod extract;
 pub mod handler;
 pub mod layer;
+pub mod middleware;
 pub mod param;
 pub mod request;
 pub mod response;

--- a/volo-http/src/middleware.rs
+++ b/volo-http/src/middleware.rs
@@ -3,7 +3,11 @@ use std::{convert::Infallible, marker::PhantomData};
 use hyper::body::Incoming;
 use motore::{layer::Layer, service::Service};
 
-use crate::{handler::MiddlewareHandlerFromFn, response::Response, DynService, HttpContext};
+use crate::{
+    handler::{MiddlewareHandlerFromFn, MiddlewareHandlerMapResponse},
+    response::{IntoResponse, Response},
+    DynService, HttpContext,
+};
 
 pub struct FromFnLayer<F, S, T> {
     f: F,
@@ -111,5 +115,104 @@ pub struct Next {
 impl Next {
     pub async fn run(self, cx: &mut HttpContext, req: Incoming) -> Result<Response, Infallible> {
         self.inner.call(cx, req).await
+    }
+}
+
+pub struct MapResponseLayer<F, S, T> {
+    f: F,
+    state: S,
+    _marker: PhantomData<fn(T)>,
+}
+
+impl<F, S, T> Clone for MapResponseLayer<F, S, T>
+where
+    F: Clone,
+    S: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            f: self.f.clone(),
+            state: self.state.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+pub fn map_response<F, T>(f: F) -> MapResponseLayer<F, (), T> {
+    map_response_with_state(f, ())
+}
+
+fn map_response_with_state<F, S, T>(f: F, state: S) -> MapResponseLayer<F, S, T> {
+    MapResponseLayer {
+        f,
+        state,
+        _marker: PhantomData,
+    }
+}
+
+impl<I, F, S, T> Layer<I> for MapResponseLayer<F, S, T>
+where
+    F: Clone,
+    S: Clone,
+{
+    type Service = MapResponse<I, F, S, T>;
+
+    fn layer(self, inner: I) -> Self::Service {
+        MapResponse {
+            inner,
+            f: self.f.clone(),
+            state: self.state.clone(),
+            _marker: self._marker,
+        }
+    }
+}
+
+pub struct MapResponse<I, F, S, T> {
+    inner: I,
+    f: F,
+    state: S,
+    _marker: PhantomData<fn(T)>,
+}
+
+impl<I, F, S, T> Clone for MapResponse<I, F, S, T>
+where
+    I: Clone,
+    F: Clone,
+    S: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            f: self.f.clone(),
+            state: self.state.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<I, F, S, T> Service<HttpContext, Incoming> for MapResponse<I, F, S, T>
+where
+    I: Service<HttpContext, Incoming, Response = Response, Error = Infallible>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+    F: for<'r> MiddlewareHandlerMapResponse<'r, T, S> + Clone + Sync,
+    S: Clone + Sync,
+{
+    type Response = I::Response;
+    type Error = I::Error;
+
+    async fn call<'s, 'cx>(
+        &'s self,
+        cx: &'cx mut HttpContext,
+        req: Incoming,
+    ) -> Result<Self::Response, Self::Error> {
+        let response = match self.inner.call(cx, req).await {
+            Ok(resp) => resp,
+            Err(e) => e.into_response(),
+        };
+
+        Ok(self.f.call(cx, &self.state, response).await)
     }
 }

--- a/volo-http/src/middleware.rs
+++ b/volo-http/src/middleware.rs
@@ -1,0 +1,115 @@
+use std::{convert::Infallible, marker::PhantomData};
+
+use hyper::body::Incoming;
+use motore::{layer::Layer, service::Service};
+
+use crate::{handler::MiddlewareHandlerFromFn, response::Response, DynService, HttpContext};
+
+pub struct FromFnLayer<F, S, T> {
+    f: F,
+    state: S,
+    _marker: PhantomData<fn(T)>,
+}
+
+impl<F, S, T> Clone for FromFnLayer<F, S, T>
+where
+    F: Clone,
+    S: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            f: self.f.clone(),
+            state: self.state.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+pub fn from_fn<F, T>(f: F) -> FromFnLayer<F, (), T> {
+    from_fn_with_state(f, ())
+}
+
+fn from_fn_with_state<F, S, T>(f: F, state: S) -> FromFnLayer<F, S, T> {
+    FromFnLayer {
+        f,
+        state,
+        _marker: PhantomData,
+    }
+}
+
+impl<I, F, S, T> Layer<I> for FromFnLayer<F, S, T>
+where
+    F: Clone,
+    S: Clone,
+{
+    type Service = FromFn<I, F, S, T>;
+
+    fn layer(self, inner: I) -> Self::Service {
+        FromFn {
+            inner,
+            f: self.f.clone(),
+            state: self.state.clone(),
+            _marker: self._marker,
+        }
+    }
+}
+
+pub struct FromFn<I, F, S, T> {
+    inner: I,
+    f: F,
+    state: S,
+    _marker: PhantomData<fn(T)>,
+}
+
+impl<I, F, S, T> Clone for FromFn<I, F, S, T>
+where
+    I: Clone,
+    F: Clone,
+    S: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            f: self.f.clone(),
+            state: self.state.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<I, F, S, T> Service<HttpContext, Incoming> for FromFn<I, F, S, T>
+where
+    I: Service<HttpContext, Incoming, Response = Response, Error = Infallible>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+    F: for<'r> MiddlewareHandlerFromFn<'r, T, S> + Clone + Sync,
+    S: Clone + Sync,
+{
+    type Response = I::Response;
+    type Error = I::Error;
+
+    async fn call<'s, 'cx>(
+        &'s self,
+        cx: &'cx mut HttpContext,
+        req: Incoming,
+    ) -> Result<Self::Response, Self::Error> {
+        let next = Next {
+            inner: DynService::new(self.inner.clone()),
+        };
+        Ok(
+            self.f.call(cx, req, &self.state, next).await, // .into_response()
+        )
+    }
+}
+
+pub struct Next {
+    inner: DynService,
+}
+
+impl Next {
+    pub async fn run(self, cx: &mut HttpContext, req: Incoming) -> Result<Response, Infallible> {
+        self.inner.call(cx, req).await
+    }
+}

--- a/volo-http/src/route.rs
+++ b/volo-http/src/route.rs
@@ -117,6 +117,8 @@ where
             + Send
             + Sync
             + 'static,
+        <L::Service as Service<HttpContext, Incoming>>::Response: Send + 'static,
+        <L::Service as Service<HttpContext, Incoming>>::Error: Send + 'static,
     {
         let routes = self
             .routes


### PR DESCRIPTION
## Motivation

Middleware is important for microservices. In volo and its upstream frameworks, middleware exists in the form of layers, but developing a layer is complex.

This PR refers to `axum` and provide the functions of `from_fn` and `map_response`, they wrap a function into a layer and use it as a middleware.  Additionaly, extractors can also be used for functions wrapped by the middleware layer.

This PR references `axum` and provides the functions `from_fn` and `map_response`, which can wrap a function into a layer and use it as middleware. Additionally, extractors can also be used as arguments of the middleware function.
