### PR TITLE
feat(volo-http): add `layer`, `layer_front` and shutdown hooks for http server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2945,6 +2945,7 @@ version = "0.1.1"
 dependencies = [
  "bytes",
  "faststr",
+ "futures",
  "futures-util",
  "http-body-util",
  "hyper 1.0.1",

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-http"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -26,6 +26,7 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 
 bytes.workspace = true
 faststr.workspace = true
+futures.workspace = true
 futures-util.workspace = true
 matchit.workspace = true
 mime.workspace = true


### PR DESCRIPTION
## Motivation

Add `layer`, `layer_front` and shutdown hooks for http server.  These have been supported by `volo-thrift` and `volo-grpc`.
