### PR TITLE
feat: refactor rpcinfo to eliminate useless unwrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3a318f1f38d2418400f8209655bfd825785afd25aa30bb7ba6cc792e4596748"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -127,7 +127,7 @@ checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -149,7 +149,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -160,7 +160,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -304,7 +304,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -321,11 +321,10 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
-version = "2.0.4"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
 dependencies = [
- "is-terminal",
  "lazy_static",
  "windows-sys 0.48.0",
 ]
@@ -557,9 +556,9 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "faststr"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284eac9300ad17d2492e1e87219768b8ab97fb2c74a61cdbc0ced31d3f711159"
+checksum = "c6aec286890de502e74704b319a9246c95221f90de25112eabece1011b7ad55e"
 dependencies = [
  "bytes",
  "serde",
@@ -677,7 +676,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -859,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
  "http 0.2.11",
@@ -921,7 +920,7 @@ dependencies = [
  "futures-util",
  "h2 0.3.22",
  "http 0.2.11",
- "http-body 0.4.5",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1107,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "jobserver"
@@ -1137,9 +1136,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "libgit2-sys"
@@ -1287,9 +1286,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
  "wasi",
@@ -1423,7 +1422,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1437,9 +1436,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oorandom"
@@ -1470,7 +1469,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1615,7 +1614,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1676,7 +1675,7 @@ dependencies = [
  "scoped-tls",
  "serde",
  "serde_yaml",
- "syn 2.0.39",
+ "syn 2.0.41",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -1708,7 +1707,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1747,11 +1746,12 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
+checksum = "97dc5fea232fc28d2f597b37c4876b348a40e33f3b02cc975c8d006d78d94b1a"
 dependencies = [
- "toml_edit 0.20.7",
+ "toml_datetime",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1979,7 +1979,7 @@ dependencies = [
  "futures-util",
  "h2 0.3.22",
  "http 0.2.11",
- "http-body 0.4.5",
+ "http-body 0.4.6",
  "hyper 0.14.27",
  "hyper-rustls",
  "ipnet",
@@ -2008,9 +2008,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.6"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684d5e6e18f669ccebf64a92236bb7db9a34f07be010e3627368182027180866"
+checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
 dependencies = [
  "cc",
  "getrandom",
@@ -2043,9 +2043,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.26"
+version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9470c4bf8246c8daf25f9598dca807fb6510347b1e1cfa55749113850c79d88a"
+checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -2056,9 +2056,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.9"
+version = "0.21.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629648aced5775d558af50b2b4c7b02983a04b312126d45eeead26e7caa498b9"
+checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
  "ring",
@@ -2099,9 +2099,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "salsa"
@@ -2218,7 +2218,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -2356,9 +2356,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2435,7 +2435,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -2465,9 +2465,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.34.0"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
+checksum = "841d45b238a16291a4e1584e61820b8ae57d696cc5015c459c229ccc6990cc1c"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2500,7 +2500,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -2551,41 +2551,30 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.8"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
+checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.21.0",
+ "toml_edit",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.20.7"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
-dependencies = [
- "indexmap 2.1.0",
- "toml_datetime",
- "winnow",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap 2.1.0",
  "serde",
@@ -2646,7 +2635,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -2690,9 +2679,9 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unarray"
@@ -2702,9 +2691,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+checksum = "6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416"
 
 [[package]]
 name = "unicode-ident"
@@ -2814,7 +2803,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "volo"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-broadcast",
  "dashmap",
@@ -2842,7 +2831,7 @@ dependencies = [
 
 [[package]]
 name = "volo-build"
-version = "0.8.6"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2869,7 +2858,7 @@ dependencies = [
 
 [[package]]
 name = "volo-cli"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2906,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "volo-grpc"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2919,7 +2908,7 @@ dependencies = [
  "h2 0.3.22",
  "hex",
  "http 0.2.11",
- "http-body 0.4.5",
+ "http-body 0.4.6",
  "hyper 0.14.27",
  "hyper-timeout",
  "matchit",
@@ -2967,11 +2956,11 @@ dependencies = [
 
 [[package]]
 name = "volo-macros"
-version = "0.8.0"
+version = "0.9.0"
 
 [[package]]
 name = "volo-thrift"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3049,7 +3038,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
  "wasm-bindgen-shared",
 ]
 
@@ -3083,7 +3072,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3296,9 +3285,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.24"
+version = "0.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0383266b19108dfc6314a56047aa545a1b4d1be60e799b4dbdd407b56402704b"
+checksum = "6c830786f7720c2fd27a1a0e27a709dbd3c4d009b56d098fc742d4f4eab91fe2"
 dependencies = [
  "memchr",
 ]
@@ -3315,20 +3304,20 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.28"
+version = "0.7.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6f15f7ade05d2a4935e34a457b936c23dc70a05cc1d97133dc99e7a3fe0f0e"
+checksum = "306dca4455518f1f31635ec308b6b3e4eb1b11758cefafc782827d0aa7acb5c7"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.28"
+version = "0.7.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbbad221e3f78500350ecbd7dfa4e63ef945c05f4c61cb7f4d3f84cd0bba649b"
+checksum = "be912bf68235a88fbefd1b73415cb218405958d1655b2ece9035a19920bdf6ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]

--- a/volo-build/Cargo.toml
+++ b/volo-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-build"
-version = "0.8.6"
+version = "0.9.0"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
@@ -17,7 +17,7 @@ keywords = ["thrift", "grpc", "protobuf", "volo", "build"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-volo = { version = "0.8", path = "../volo" }
+volo = { version = "0.9", path = "../volo" }
 
 pilota-build.workspace = true
 

--- a/volo-build/src/grpc_backend.rs
+++ b/volo-build/src/grpc_backend.rs
@@ -550,7 +550,7 @@ impl CodegenBackend for VoloGrpcBackend {
 
                 async fn call<'s, 'cx>(&'s self, cx: &'cx mut ::volo_grpc::context::ServerContext, req: ::volo_grpc::Request<{req_enum_name_recv}>) -> ::std::result::Result<Self::Response, Self::Error> {{
                     let inner = self.inner.clone();
-                    match cx.rpc_info.method().unwrap().as_str() {{
+                    match cx.rpc_info.method().as_str() {{
                         {req_matches}
                         path => {{
                             let path = path.to_string();

--- a/volo-cli/Cargo.toml
+++ b/volo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-cli"
-version = "0.8.3"
+version = "0.9.0"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
@@ -22,7 +22,7 @@ keywords = ["thrift", "grpc", "protobuf", "volo", "cli"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-volo-build = { version = "0.8", path = "../volo-build" }
+volo-build = { version = "0.9", path = "../volo-build" }
 pilota-thrift-parser.workspace = true
 
 anyhow.workspace = true

--- a/volo-grpc/Cargo.toml
+++ b/volo-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-grpc"
-version = "0.8.0"
+version = "0.9.0"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
@@ -22,7 +22,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 pilota.workspace = true
-volo = { version = "0.8", path = "../volo" }
+volo = { version = "0.9", path = "../volo" }
 motore = { workspace = true, features = ["tower"] }
 metainfo.workspace = true
 

--- a/volo-grpc/src/client/callopt.rs
+++ b/volo-grpc/src/client/callopt.rs
@@ -66,7 +66,7 @@ impl volo::client::Apply<crate::context::ClientContext> for CallOpt {
     type Error = crate::Status;
 
     fn apply(self, cx: &mut crate::context::ClientContext) -> Result<(), Self::Error> {
-        let caller = cx.rpc_info.caller_mut().unwrap();
+        let caller = cx.rpc_info.caller_mut();
         if !self.caller_faststr_tags.is_empty() {
             caller.faststr_tags.extend(self.caller_faststr_tags);
         }
@@ -74,7 +74,7 @@ impl volo::client::Apply<crate::context::ClientContext> for CallOpt {
             caller.tags.extend(self.caller_tags);
         }
 
-        let callee = cx.rpc_info.callee_mut().unwrap();
+        let callee = cx.rpc_info.callee_mut();
         if !self.callee_faststr_tags.is_empty() {
             callee.faststr_tags.extend(self.callee_faststr_tags);
         }
@@ -84,7 +84,7 @@ impl volo::client::Apply<crate::context::ClientContext> for CallOpt {
         if let Some(addr) = self.address {
             callee.set_address(addr);
         }
-        cx.rpc_info.config_mut().unwrap().merge(self.config);
+        cx.rpc_info.config_mut().merge(self.config);
         Ok(())
     }
 }

--- a/volo-grpc/src/client/meta.rs
+++ b/volo-grpc/src/client/meta.rs
@@ -61,17 +61,14 @@ where
             }
 
             // caller
-            if let Some(caller) = cx.rpc_info.caller.as_ref() {
-                metadata.insert(SOURCE_SERVICE, caller.service_name().parse()?);
-            }
+            metadata.insert(SOURCE_SERVICE, cx.rpc_info.caller().service_name().parse()?);
 
             // callee
-            if let Some(callee) = cx.rpc_info.callee.as_ref() {
-                metadata.insert(DESTINATION_SERVICE, callee.service_name().parse()?);
-                if let Some(method) = cx.rpc_info.method() {
-                    metadata.insert(DESTINATION_METHOD, method.parse()?);
-                }
-            }
+            metadata.insert(
+                DESTINATION_SERVICE,
+                cx.rpc_info.callee().service_name().parse()?,
+            );
+            metadata.insert(DESTINATION_METHOD, cx.rpc_info.method().parse()?);
 
             Ok::<(), Status>(())
         });
@@ -85,8 +82,10 @@ where
             // callee
             if let Some(ad) = metadata.remove(HEADER_TRANS_REMOTE_ADDR) {
                 let maybe_addr = ad.to_str()?.parse::<SocketAddr>();
-                if let (Some(callee), Ok(addr)) = (cx.rpc_info_mut().callee.as_mut(), maybe_addr) {
-                    callee.set_address(volo::net::Address::from(addr));
+                if let Ok(addr) = maybe_addr {
+                    cx.rpc_info_mut()
+                        .callee_mut()
+                        .set_address(volo::net::Address::from(addr));
                 }
             }
 

--- a/volo-grpc/src/context.rs
+++ b/volo-grpc/src/context.rs
@@ -80,6 +80,20 @@ pub struct Config {
     pub(crate) send_compressions: Option<Vec<CompressionEncoding>>,
 }
 
+impl Reusable for Config {
+    fn clear(&mut self) {
+        self.connect_timeout = None;
+        self.read_timeout = None;
+        self.write_timeout = None;
+        if let Some(v) = self.accept_compressions.as_mut() {
+            v.clear();
+        }
+        if let Some(v) = self.send_compressions.as_mut() {
+            v.clear();
+        }
+    }
+}
+
 impl Config {
     pub fn merge(&mut self, other: Self) {
         if let Some(t) = other.connect_timeout {

--- a/volo-grpc/src/layer/loadbalance/mod.rs
+++ b/volo-grpc/src/layer/loadbalance/mod.rs
@@ -6,7 +6,7 @@ use volo::{
     context::Context,
     discovery::Discover,
     loadbalance::{error::LoadBalanceError, LoadBalance, MkLbLayer},
-    Layer, Unwrap,
+    Layer,
 };
 
 use crate::Request;
@@ -92,11 +92,7 @@ where
         cx: &'cx mut Cx,
         req: Request<T>,
     ) -> Result<Self::Response, Self::Error> {
-        debug_assert!(
-            cx.rpc_info().callee.is_some(),
-            "must set callee endpoint before load balance service"
-        );
-        let callee = cx.rpc_info().callee().volo_unwrap();
+        let callee = cx.rpc_info().callee();
 
         let mut picker = match &callee.address {
             None => self
@@ -110,9 +106,7 @@ where
         };
 
         if let Some(addr) = picker.next() {
-            if let Some(callee) = cx.rpc_info_mut().callee_mut() {
-                callee.address = Some(addr.clone())
-            }
+            cx.rpc_info_mut().callee_mut().address = Some(addr.clone());
 
             return match self.service.call(cx, req).await {
                 Ok(resp) => Ok(resp),

--- a/volo-grpc/src/server/router.rs
+++ b/volo-grpc/src/server/router.rs
@@ -98,7 +98,7 @@ where
         cx: &'cx mut ServerContext,
         req: Request<B>,
     ) -> Result<Self::Response, Self::Error> {
-        let path = cx.rpc_info.method.as_ref().unwrap();
+        let path = cx.rpc_info.method();
         match self.node.at(path) {
             Ok(match_) => {
                 let id = match_.value;

--- a/volo-grpc/src/server/service.rs
+++ b/volo-grpc/src/server/service.rs
@@ -143,7 +143,7 @@ where
         )?;
 
         let message = T::from_body(
-            cx.rpc_info.method.as_deref(),
+            Some(cx.rpc_info.method().as_str()),
             body,
             Kind::Request,
             recv_compression,

--- a/volo-grpc/src/transport/client.rs
+++ b/volo-grpc/src/transport/client.rs
@@ -7,7 +7,7 @@ use http::{
 use hyper::Client as HyperClient;
 use motore::Service;
 use tower::{util::ServiceExt, Service as TowerService};
-use volo::{net::Address, Unwrap};
+use volo::net::Address;
 
 use super::connect::Connector;
 use crate::{
@@ -114,18 +114,13 @@ where
         let mut http_client = self.http_client.clone();
         // SAFETY: parameters controlled by volo-grpc are guaranteed to be valid.
         // get the call address from the context
-        let target = cx
-            .rpc_info
-            .callee()
-            .volo_unwrap()
-            .address()
-            .ok_or_else(|| {
-                io::Error::new(std::io::ErrorKind::InvalidData, "address is required")
-            })?;
+        let target = cx.rpc_info.callee().address().ok_or_else(|| {
+            io::Error::new(std::io::ErrorKind::InvalidData, "address is required")
+        })?;
 
         let (metadata, extensions, message) = volo_req.into_parts();
-        let path = cx.rpc_info.method().volo_unwrap();
-        let rpc_config = cx.rpc_info.config().volo_unwrap();
+        let path = cx.rpc_info.method();
+        let rpc_config = cx.rpc_info.config();
         let accept_compressions = &rpc_config.accept_compressions;
 
         // select the compression algorithm with the highest priority by user's config

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["async", "rpc", "http"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-volo = { version = "0.8", path = "../volo" }
+volo = { version = "0.9", path = "../volo" }
 
 http-body-util = "0.1"
 hyper = { version = "1", features = ["server", "http1", "http2"] }

--- a/volo-macros/Cargo.toml
+++ b/volo-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-macros"
-version = "0.8.0"
+version = "0.9.0"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-thrift/Cargo.toml
+++ b/volo-thrift/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-thrift"
-version = "0.8.4"
+version = "0.9.0"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
@@ -18,7 +18,7 @@ keywords = ["async", "rpc", "thrift"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-volo = { version = "0.8", path = "../volo" }
+volo = { version = "0.9", path = "../volo" }
 pilota.workspace = true
 motore.workspace = true
 metainfo.workspace = true

--- a/volo-thrift/src/client/layer/timeout.rs
+++ b/volo-thrift/src/client/layer/timeout.rs
@@ -26,31 +26,27 @@ where
         cx: &'cx mut ClientContext,
         req: Req,
     ) -> Result<Self::Response, Self::Error> {
-        if let Some(config) = cx.rpc_info.config() {
-            match config.rpc_timeout() {
-                Some(duration) => {
-                    let start = std::time::Instant::now();
-                    match tokio::time::timeout(duration, self.inner.call(cx, req)).await {
-                        Ok(r) => r.map_err(Into::into),
-                        Err(_) => {
-                            let msg = format!(
-                                "[VOLO] thrift rpc call timeout, rpcinfo: {:?}, elpased: {:?}, \
-                                 timeout config: {:?}",
-                                cx.rpc_info,
-                                start.elapsed(),
-                                duration
-                            );
-                            warn!(msg);
-                            Err(crate::Error::Transport(
-                                std::io::Error::new(std::io::ErrorKind::TimedOut, msg).into(),
-                            ))
-                        }
+        match cx.rpc_info.config().rpc_timeout() {
+            Some(duration) => {
+                let start = std::time::Instant::now();
+                match tokio::time::timeout(duration, self.inner.call(cx, req)).await {
+                    Ok(r) => r.map_err(Into::into),
+                    Err(_) => {
+                        let msg = format!(
+                            "[VOLO] thrift rpc call timeout, rpcinfo: {:?}, elpased: {:?}, \
+                             timeout config: {:?}",
+                            cx.rpc_info,
+                            start.elapsed(),
+                            duration
+                        );
+                        warn!(msg);
+                        Err(crate::Error::Transport(
+                            std::io::Error::new(std::io::ErrorKind::TimedOut, msg).into(),
+                        ))
                     }
                 }
-                None => self.inner.call(cx, req).await.map_err(Into::into),
             }
-        } else {
-            unreachable!("rpc_info.config should never be None")
+            None => self.inner.call(cx, req).await.map_err(Into::into),
         }
     }
 }

--- a/volo-thrift/src/client/mod.rs
+++ b/volo-thrift/src/client/mod.rs
@@ -622,20 +622,16 @@ impl<S> Client<S> {
                     // reset rpc_info
                     cx.rpc_info_mut()
                         .caller_mut()
-                        .unwrap()
                         .set_service_name(self.inner.caller_name.clone());
                     cx.rpc_info_mut()
                         .callee_mut()
-                        .unwrap()
                         .set_service_name(self.inner.callee_name.clone());
                     if let Some(target) = &self.inner.address {
-                        cx.rpc_info_mut()
-                            .callee_mut()
-                            .unwrap()
-                            .set_address(target.clone());
+                        cx.rpc_info_mut().callee_mut().set_address(target.clone());
                     }
-                    cx.rpc_info_mut().config = Some(self.inner.config);
-                    cx.rpc_info_mut().method = Some(FastStr::from_static_str(method));
+                    cx.rpc_info_mut().set_config(self.inner.config);
+                    cx.rpc_info_mut()
+                        .set_method(FastStr::from_static_str(method));
                     Some(cx)
                 })
                 .unwrap_or_else(|| {

--- a/volo-thrift/src/message_wrapper.rs
+++ b/volo-thrift/src/message_wrapper.rs
@@ -59,7 +59,7 @@ impl<M> ThriftMessage<M> {
     ) -> Result<Self, crate::Error> {
         let meta = MessageMeta {
             msg_type: cx.message_type,
-            method: cx.rpc_info.method.clone().unwrap(),
+            method: cx.rpc_info.method().clone(),
             seq_id: cx.seq_id,
         };
         Ok(Self { data: msg, meta })
@@ -75,7 +75,7 @@ impl<M> ThriftMessage<M> {
                 Ok(_) => TMessageType::Reply,
                 Err(_) => TMessageType::Exception,
             },
-            method: cx.rpc_info.method.clone().unwrap_or_else(|| "".into()),
+            method: cx.rpc_info.method().clone(),
             seq_id: cx.seq_id.unwrap_or(0),
         };
         Ok(Self { data: msg, meta })

--- a/volo-thrift/src/transport/multiplex/client.rs
+++ b/volo-thrift/src/transport/multiplex/client.rs
@@ -2,10 +2,7 @@ use std::{io, marker::PhantomData};
 
 use motore::service::{Service, UnaryService};
 use pilota::thrift::TransportErrorKind;
-use volo::{
-    net::{dial::MakeTransport, Address},
-    Unwrap,
-};
+use volo::net::{dial::MakeTransport, Address};
 
 use crate::{
     codec::MakeCodec,
@@ -134,7 +131,7 @@ where
         req: ThriftMessage<Req>,
     ) -> Result<Self::Response, Self::Error> {
         let rpc_info = &cx.rpc_info;
-        let target = rpc_info.callee().volo_unwrap().address().ok_or_else(|| {
+        let target = rpc_info.callee().address().ok_or_else(|| {
             let msg = format!("address is required, rpcinfo: {:?}", rpc_info);
             crate::Error::Transport(io::Error::new(io::ErrorKind::InvalidData, msg).into())
         })?;

--- a/volo-thrift/src/transport/multiplex/server.rs
+++ b/volo-thrift/src/transport/multiplex/server.rs
@@ -8,7 +8,7 @@ use metainfo::MetaInfo;
 use motore::service::Service;
 use tokio::sync::{futures::Notified, mpsc};
 use tracing::*;
-use volo::{context::Endpoint, net::Address, volo_unreachable};
+use volo::{context::Context, net::Address, volo_unreachable};
 
 use crate::{
     codec::{Decoder, Encoder},
@@ -98,9 +98,7 @@ pub async fn serve<Svc, Req, Resp, E, D>(
                 // new context
                 let mut cx = ServerContext::default();
                 if let Some(peer_addr) = &peer_addr {
-                    let mut caller = Endpoint::new("-".into());
-                    caller.set_address(peer_addr.clone());
-                    cx.rpc_info.caller = Some(caller);
+                    cx.rpc_info_mut().caller_mut().set_address(peer_addr.clone());
                 }
 
                 tokio::select! {

--- a/volo-thrift/src/transport/pingpong/client.rs
+++ b/volo-thrift/src/transport/pingpong/client.rs
@@ -2,10 +2,7 @@ use std::{io, marker::PhantomData};
 
 use motore::service::{Service, UnaryService};
 use pilota::thrift::{TransportError, TransportErrorKind};
-use volo::{
-    net::{dial::MakeTransport, Address},
-    Unwrap,
-};
+use volo::net::{dial::MakeTransport, Address};
 
 use crate::{
     codec::MakeCodec,
@@ -115,7 +112,7 @@ where
         req: ThriftMessage<Req>,
     ) -> Result<Self::Response, Self::Error> {
         let rpc_info = &cx.rpc_info;
-        let target = rpc_info.callee().volo_unwrap().address().ok_or_else(|| {
+        let target = rpc_info.callee().address().ok_or_else(|| {
             TransportError::from(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("address is required, rpc_info: {:?}", rpc_info),

--- a/volo-thrift/src/transport/pingpong/server.rs
+++ b/volo-thrift/src/transport/pingpong/server.rs
@@ -8,7 +8,7 @@ use metainfo::MetaInfo;
 use motore::service::Service;
 use tokio::sync::futures::Notified;
 use tracing::*;
-use volo::{context::Endpoint, net::Address, volo_unreachable};
+use volo::{net::Address, volo_unreachable};
 
 use crate::{
     codec::{Decoder, Encoder},
@@ -47,15 +47,7 @@ pub async fn serve<Svc, Req, Resp, E, D, SP>(
                     cache.pop().unwrap_or_default()
                 });
                 if let Some(peer_addr) = &peer_addr {
-                    if let Some(caller) = cx.rpc_info.caller_mut() {
-                        caller.set_address(peer_addr.clone());
-                    } else {
-                        let mut caller = Endpoint::new("-".into());
-                        caller.set_address(peer_addr.clone());
-                        cx.rpc_info.caller = Some(caller);
-                    }
-                } else if cx.rpc_info.caller().is_none() {
-                    cx.rpc_info.caller = Some(Endpoint::new("-".into()));
+                    cx.rpc_info.caller_mut().set_address(peer_addr.clone());
                 }
 
                 let msg = tokio::select! {

--- a/volo/Cargo.toml
+++ b/volo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo"
-version = "0.8.0"
+version = "0.9.0"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Motivation

Previously, all the fields in `volo::context::RpcInfo` are Option, which may lead to many useless `unwrap` calls and this can lead to a lot of branch prediction.

## Solution

This PR removes the Option, and can slightly improve the performance.

Note this is a BREAKING CHANGE.