### PR TITLE
WIP: Patch/bric - build to wasm32-wasi target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -195,21 +196,6 @@ name = "base64"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -1154,12 +1140,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libm"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
-
-[[package]]
 name = "libredox"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,7 +1372,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -1630,9 +1609,9 @@ dependencies = [
 [[package]]
 name = "pilota"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "682b3db6679a97ec07efc81fe5b5d0ad090cf698c9728f6b0969ca66515b9c28"
+source = "git+https://github.com/cloudwego/pilota?branch=main#8c7feb5f5b210cac22bcee15418835a57c940be3"
 dependencies = [
+ "ahash",
  "anyhow",
  "async-recursion",
  "bytes",
@@ -1642,7 +1621,6 @@ dependencies = [
  "lazy_static",
  "linkedbytes",
  "paste",
- "proptest",
  "serde",
  "smallvec",
  "thiserror",
@@ -1652,8 +1630,7 @@ dependencies = [
 [[package]]
 name = "pilota-build"
 version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68aba7abce083335d96a9088d2fde39910f284cd829becdb943dab5848112644"
+source = "git+https://github.com/cloudwego/pilota?branch=main#8c7feb5f5b210cac22bcee15418835a57c940be3"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -1685,8 +1662,7 @@ dependencies = [
 [[package]]
 name = "pilota-thrift-parser"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4781d3302b216e3285cfc2411add31d2e1c11c0c55f4616423433da3623c978b"
+source = "git+https://github.com/cloudwego/pilota?branch=main#8c7feb5f5b210cac22bcee15418835a57c940be3"
 dependencies = [
  "nom",
 ]
@@ -1765,26 +1741,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proptest"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
-dependencies = [
- "bit-set",
- "bit-vec",
- "bitflags 2.4.1",
- "lazy_static",
- "num-traits",
- "rand",
- "rand_chacha",
- "rand_xorshift",
- "regex-syntax 0.8.2",
- "rusty-fork",
- "tempfile",
- "unarray",
-]
-
-[[package]]
 name = "protobuf-parse2"
 version = "4.0.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1819,12 +1775,6 @@ dependencies = [
  "protobuf-support2",
  "thiserror",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -1863,15 +1813,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]
@@ -2084,18 +2025,6 @@ checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "rusty-fork"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
 ]
 
 [[package]]
@@ -2675,12 +2604,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2974,15 +2897,6 @@ dependencies = [
  "tokio",
  "tracing",
  "volo",
-]
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,11 +771,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"
-version = "0.5.5"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -854,9 +854,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.27"
+version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -869,7 +869,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -878,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f9214f3e703236b221f1a9cd88ec8b4adfa5296de01ab96216361f4692f56"
+checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -904,7 +904,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.11",
- "hyper 0.14.27",
+ "hyper 0.14.28",
  "rustls",
  "tokio",
  "tokio-rustls",
@@ -916,7 +916,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14a42d172d2298d46ed0feb19c457a1959c776719894660c4532739d430235d2"
 dependencies = [
- "hyper 1.0.1",
+ "hyper 1.1.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -934,9 +934,9 @@ dependencies = [
  "futures-util",
  "http 1.0.0",
  "http-body 1.0.0",
- "hyper 1.0.1",
+ "hyper 1.1.0",
  "pin-project-lite",
- "socket2 0.5.5",
+ "socket2",
  "tokio",
  "tower",
  "tower-service",
@@ -1129,9 +1129,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linkedbytes"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a196eed38906d45351c7ed2cced83bb31e48637449d30ef397f6d35c09190d"
+checksum = "487640b2e3f554987c1345fc71c3eda34d6d750fba63a39147205ccc93f920cd"
 dependencies = [
  "bytes",
  "faststr",
@@ -1863,9 +1863,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.22"
+version = "0.11.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
+checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
 dependencies = [
  "base64 0.21.5",
  "bytes",
@@ -1875,7 +1875,7 @@ dependencies = [
  "h2 0.3.22",
  "http 0.2.11",
  "http-body 0.4.6",
- "hyper 0.14.27",
+ "hyper 0.14.28",
  "hyper-rustls",
  "ipnet",
  "js-sys",
@@ -2196,16 +2196,6 @@ checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
@@ -2303,18 +2293,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "f11c217e1416d6f036b870f14e0413d480dbf28edbee1f877abaf0206af43bb7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2360,7 +2350,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -2685,7 +2675,7 @@ dependencies = [
  "pin-project",
  "rand",
  "rustls",
- "socket2 0.5.5",
+ "socket2",
  "thiserror",
  "tokio",
  "tokio-native-tls",
@@ -2776,7 +2766,7 @@ dependencies = [
  "http 1.0.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.0.1",
+ "hyper 1.1.0",
  "hyper-timeout",
  "hyper-util",
  "matchit",
@@ -2805,7 +2795,7 @@ dependencies = [
  "futures",
  "futures-util",
  "http-body-util",
- "hyper 1.0.1",
+ "hyper 1.1.0",
  "hyper-util",
  "matchit",
  "mime",
@@ -3144,9 +3134,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.28"
+version = "0.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c830786f7720c2fd27a1a0e27a709dbd3c4d009b56d098fc742d4f4eab91fe2"
+checksum = "9b5c3db89721d50d0e2a673f5043fc4722f76dcc352d7b1ab8b8288bed4ed2c5"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,17 +110,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
-name = "async-broadcast"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "334d75cf09b33bede6cbc20e52515853ae7bee3d4eadd9540e13ce92af983d34"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "futures-core",
-]
-
-[[package]]
 name = "async-recursion"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,15 +305,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,27 +463,6 @@ checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "event-listener"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c97b4e30ea7e4b7e7b429d6e2d8510433ba8cee4e70dfb3243794e539d29fd"
-dependencies = [
- "event-listener",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -1481,12 +1440,6 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
-name = "parking"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
@@ -2719,7 +2672,6 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 name = "volo"
 version = "0.9.0"
 dependencies = [
- "async-broadcast",
  "dashmap",
  "faststr",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ motore = "0.4"
 metainfo = "0.7"
 
 anyhow = "1"
-async-broadcast = "0.6"
+# async-broadcast = "0.6"
 async-stream = "0.3"
 base64 = "0.13"
 bytes = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,12 @@ repository = "https://github.com/cloudwego/volo"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
-pilota = "0.9"
-pilota-build = "0.9"
-pilota-thrift-parser = "0.9"
-#pilota = { git = "https://github.com/cloudwego/pilota", branch = "main" }
-#pilota-build = { git = "https://github.com/cloudwego/pilota", branch = "main" }
-#pilota-thrift-parser = { git = "https://github.com/cloudwego/pilota", branch = "main" }
+# pilota = "0.9"
+# pilota-build = "0.9"
+# pilota-thrift-parser = "0.9"
+pilota = { git = "https://github.com/cloudwego/pilota", branch = "main" }
+pilota-build = { git = "https://github.com/cloudwego/pilota", branch = "main" }
+pilota-thrift-parser = { git = "https://github.com/cloudwego/pilota", branch = "main" }
 
 motore = "0.4"
 # motore = { git = "https://github.com/cloudwego/motore", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,9 +96,19 @@ socket2 = "0.5"
 syn = "1"
 tempfile = "3"
 thiserror = "1"
-tokio = "1"
-tokio-stream = "0.1"
-tokio-util = "0.7"
+tokio = { version = "1.29.1", default-features = false, features = [
+  "sync",
+  "macros",
+  "io-util",
+  "rt",
+  "time",
+] }
+tokio-stream = { version = "0.1", default-features = false, features = [
+  "time",
+] }
+
+tokio-util = { version = "0.7", default-features = false, features = [] }
+
 tower = "0.4"
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/volo-grpc/Cargo.toml
+++ b/volo-grpc/Cargo.toml
@@ -45,7 +45,7 @@ hyper-util.workspace = true
 matchit.workspace = true
 percent-encoding.workspace = true
 pin-project.workspace = true
-tokio = { workspace = true, features = ["time", "rt", "net", "sync", "signal"] }
+tokio = { workspace = true }
 tokio-stream.workspace = true
 tokio-util = { workspace = true, features = ["codec", "compat"] }
 tower = { workspace = true, features = [

--- a/volo-grpc/src/layer/loadbalance/mod.rs
+++ b/volo-grpc/src/layer/loadbalance/mod.rs
@@ -62,8 +62,8 @@ where
             tokio::spawn(async move {
                 loop {
                     match channel.recv().await {
-                        Ok(recv) => lb.rebalance(recv),
-                        Err(err) => warn!("[VOLO] discovering subscription error {:?}", err),
+                        Some(recv) => lb.rebalance(recv),
+                        None => warn!("[VOLO] discovering subscription error"),
                     }
                 }
             });

--- a/volo-thrift/Cargo.toml
+++ b/volo-thrift/Cargo.toml
@@ -36,12 +36,11 @@ parking_lot.workspace = true
 paste.workspace = true
 pin-project.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = [
+tokio = { workspace = true, default-features = false, features = [
+    "net",
     "time",
-    "macros",
-    "rt",
-    "signal",
-    "parking_lot",
+    "sync",
+    "io-util",
 ] }
 tracing.workspace = true
 

--- a/volo-thrift/Cargo.toml
+++ b/volo-thrift/Cargo.toml
@@ -45,7 +45,10 @@ tokio = { workspace = true, default-features = false, features = [
 tracing.workspace = true
 
 [features]
+# default = ["async_broadcast"]
+# wasi = []
 default = []
+
 # multiplex is unstable and we don't provide backward compatibility
 multiplex = []
 # unsafe-codec can achieve better performance for thrift binary protocol, but may cause undefined behavior

--- a/volo-thrift/src/message_wrapper.rs
+++ b/volo-thrift/src/message_wrapper.rs
@@ -117,7 +117,7 @@ where
     U: EntryMessage + Send,
 {
     #[inline]
-    pub(crate) fn encode<T: TOutputProtocol>(&self, protocol: &mut T) -> Result<(), EncodeError> {
+    pub fn encode<T: TOutputProtocol>(&self, protocol: &mut T) -> Result<(), EncodeError> {
         let ident = TMessageIdentifier::new(
             self.meta.method.clone(),
             self.meta.msg_type,
@@ -151,7 +151,7 @@ where
     }
 
     #[inline]
-    pub(crate) fn decode<Cx: ThriftContext, T: TInputProtocol>(
+    pub fn decode<Cx: ThriftContext, T: TInputProtocol>(
         protocol: &mut T,
         cx: &mut Cx,
     ) -> Result<Self, DecodeError> {

--- a/volo/Cargo.toml
+++ b/volo/Cargo.toml
@@ -25,7 +25,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 motore.workspace = true
 
-async-broadcast.workspace = true
+# async-broadcast.workspace = true
 dashmap.workspace = true
 faststr.workspace = true
 futures.workspace = true

--- a/volo/Cargo.toml
+++ b/volo/Cargo.toml
@@ -45,7 +45,12 @@ pin-project.workspace = true
 rand.workspace = true
 socket2 = { workspace = true, features = ["all"] }
 thiserror.workspace = true
-tokio = { workspace = true, features = ["net", "time", "sync", "io-util"] }
+tokio = { workspace = true, default-features = false, features = [
+    "net",
+    "time",
+    "sync",
+    "io-util",
+] }
 tokio-stream = { workspace = true, features = ["net"] }
 tower.workspace = true
 tracing.workspace = true

--- a/volo/src/discovery/mod.rs
+++ b/volo/src/discovery/mod.rs
@@ -13,7 +13,9 @@ use std::{
     sync::Arc,
 };
 
-use async_broadcast::Receiver;
+// #[cfg(not(target_os = "wasi"))]
+// use async_broadcast::Receiver;
+use tokio::sync::mpsc::UnboundedReceiver;
 
 use crate::{context::Endpoint, loadbalance::error::LoadBalanceError, net::Address};
 
@@ -41,7 +43,7 @@ pub trait Discover: Send + Sync + 'static {
     fn key(&self, endpoint: &Endpoint) -> Self::Key;
     /// `watch` should return a [`async_broadcast::Receiver`] which can be used to subscribe
     /// [`Change`].
-    fn watch(&self, keys: Option<&[Self::Key]>) -> Option<Receiver<Change<Self::Key>>>;
+    fn watch(&self, keys: Option<&[Self::Key]>) -> Option<UnboundedReceiver<Change<Self::Key>>>;
 }
 
 /// Change indicates the change of the service discover.
@@ -158,7 +160,7 @@ impl Discover for StaticDiscover {
 
     fn key(&self, _: &Endpoint) -> Self::Key {}
 
-    fn watch(&self, _keys: Option<&[Self::Key]>) -> Option<Receiver<Change<Self::Key>>> {
+    fn watch(&self, _keys: Option<&[Self::Key]>) -> Option<UnboundedReceiver<Change<Self::Key>>> {
         None
     }
 }
@@ -179,7 +181,7 @@ impl Discover for DummyDiscover {
 
     fn key(&self, _: &Endpoint) {}
 
-    fn watch(&self, _keys: Option<&[Self::Key]>) -> Option<Receiver<Change<Self::Key>>> {
+    fn watch(&self, _keys: Option<&[Self::Key]>) -> Option<UnboundedReceiver<Change<Self::Key>>> {
         None
     }
 }

--- a/volo/src/loadbalance/layer.rs
+++ b/volo/src/loadbalance/layer.rs
@@ -33,8 +33,8 @@ where
             tokio::spawn(async move {
                 loop {
                     match channel.recv().await {
-                        Ok(recv) => lb.rebalance(recv),
-                        Err(err) => warn!("[VOLO] discovering subscription error: {:?}", err),
+                        Some(recv) => lb.rebalance(recv),
+                        None => warn!("[VOLO] discovering subscription error"),
                     }
                 }
             });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/volo/blob/main/CONTRIBUTING.md
-->

## Motivation

* allow user to perform `encoding` / `decoding` of thrift messages on their end
* allow building `volo-thrift` to `wasm32-target`

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

* use alternative libraries or feature flags to allow building to `wasm32-wasi` target
* make some encoding / decoding methods public by default

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
