### PR TITLE
fix(volo-thrift): delete max_frame_size option

### DIFF
--- a/volo-thrift/src/client/mod.rs
+++ b/volo-thrift/src/client/mod.rs
@@ -191,14 +191,6 @@ impl<IL, OL, C, Req, Resp, MkT, MkC, LB> ClientBuilder<IL, OL, C, Req, Resp, MkT
         self
     }
 
-    /// Sets the max frame size for the client.
-    ///
-    /// Defaults to 16MB.
-    pub fn max_frame_size(mut self, max_frame_size: u32) -> Self {
-        self.config.set_max_frame_size(max_frame_size);
-        self
-    }
-
     /// Sets the client's name sent to the server.
     pub fn caller_name(mut self, name: impl AsRef<str>) -> Self {
         self.caller_name = FastStr::new(name);

--- a/volo-thrift/src/context.rs
+++ b/volo-thrift/src/context.rs
@@ -362,8 +362,6 @@ impl ThriftContext for ServerContext {
     }
 }
 
-// defaults to 16M
-const DEFAULT_MAX_FRAME_SIZE: u32 = 1024 * 1024 * 16;
 const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(1);
 const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_millis(50);
 const DEFAULT_READ_WRITE_TIMEOUT: Duration = Duration::from_secs(1);
@@ -373,7 +371,6 @@ pub struct Config {
     rpc_timeout: Option<Duration>,
     connect_timeout: Option<Duration>,
     read_write_timeout: Option<Duration>,
-    max_frame_size: u32,
 }
 
 impl Config {
@@ -383,7 +380,6 @@ impl Config {
             rpc_timeout: None,
             connect_timeout: None,
             read_write_timeout: None,
-            max_frame_size: DEFAULT_MAX_FRAME_SIZE,
         }
     }
 
@@ -439,18 +435,7 @@ impl Config {
     }
 
     #[inline]
-    pub fn max_frame_size(&self) -> u32 {
-        self.max_frame_size
-    }
-
-    #[inline]
-    pub(crate) fn set_max_frame_size(&mut self, size: u32) {
-        self.max_frame_size = size
-    }
-
-    #[inline]
     pub fn merge(&mut self, other: Self) {
-        self.max_frame_size = other.max_frame_size;
         if let Some(t) = other.rpc_timeout {
             self.rpc_timeout = Some(t);
         }
@@ -468,7 +453,6 @@ impl Reusable for Config {
         self.rpc_timeout = None;
         self.connect_timeout = None;
         self.read_write_timeout = None;
-        self.max_frame_size = DEFAULT_MAX_FRAME_SIZE;
     }
 }
 
@@ -478,7 +462,6 @@ impl Default for Config {
             rpc_timeout: None,
             connect_timeout: None,
             read_write_timeout: None,
-            max_frame_size: DEFAULT_MAX_FRAME_SIZE,
         }
     }
 }


### PR DESCRIPTION
This option is not used now, we need to delete it to avoid misuse.