### PR TITLE
fix(volo-build/volo-cli): git should use relative path instead of absolute path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "volo-build"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2827,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "volo-cli"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/volo-build/Cargo.toml
+++ b/volo-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-build"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-build/src/util.rs
+++ b/volo-build/src/util.rs
@@ -94,7 +94,8 @@ pub fn get_or_download_idl(idl: Idl, target_dir: impl AsRef<Path>) -> anyhow::Re
         download_files_from_git(task).with_context(|| format!("download repo {repo}"))?;
 
         (
-            dir.join(&idl.path),
+            // git should use relative path instead of absolute path
+            dir.join(strip_slash_prefix(idl.path.as_path())),
             idl.includes
                 .unwrap_or_default()
                 .into_iter()
@@ -296,6 +297,15 @@ pub fn git_repo_init(path: &Path) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+pub fn strip_slash_prefix(p: &Path) -> PathBuf {
+    if p.starts_with("/") {
+        // remove the "/" prefix to the start of idl path
+        p.strip_prefix("/").unwrap().to_path_buf()
+    } else {
+        p.to_path_buf()
+    }
 }
 
 #[cfg(test)]

--- a/volo-cli/Cargo.toml
+++ b/volo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-cli"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-cli/src/idl/add.rs
+++ b/volo-cli/src/idl/add.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use clap::{value_parser, Parser};
 use volo_build::{
     model::{Entry, GitSource, Idl, Source},
-    util::get_repo_latest_commit_id,
+    util::{get_repo_latest_commit_id, strip_slash_prefix},
 };
 
 use crate::{command::CliCommand, context::Context};
@@ -69,7 +69,7 @@ impl CliCommand for Add {
                             lock: Some(lock),
                         }),
                         touch: vec![],
-                        path: self.idl.clone(),
+                        path: strip_slash_prefix(self.idl.as_path()),
                         includes: self.includes.clone(),
                         keep_unknown_fields: false,
                     }

--- a/volo-cli/src/idl/update.rs
+++ b/volo-cli/src/idl/update.rs
@@ -1,7 +1,10 @@
 use std::collections::HashSet;
 
 use clap::Parser;
-use volo_build::model::{GitSource, Source};
+use volo_build::{
+    model::{GitSource, Source},
+    util::strip_slash_prefix,
+};
 
 use crate::{command::CliCommand, context::Context};
 
@@ -22,7 +25,8 @@ impl CliCommand for Update {
             let entry = config.entries.get_mut(&cx.entry_name).unwrap();
             let mut exists = HashSet::new();
 
-            entry.idls.iter().for_each(|idl| {
+            entry.idls.iter_mut().for_each(|idl| {
+                idl.path = strip_slash_prefix(idl.path.as_path());
                 if let Source::Git(ref git) = idl.source {
                     exists.insert(git.repo.clone());
                 }

--- a/volo-cli/src/init.rs
+++ b/volo-cli/src/init.rs
@@ -4,7 +4,7 @@ use clap::{value_parser, Parser};
 use volo_build::{
     config_builder::InitBuilder,
     model::{Entry, GitSource, Idl, Source, DEFAULT_FILENAME},
-    util::{get_repo_latest_commit_id, git_repo_init, DEFAULT_CONFIG_FILE},
+    util::{get_repo_latest_commit_id, git_repo_init, strip_slash_prefix, DEFAULT_CONFIG_FILE},
 };
 
 use crate::command::CliCommand;
@@ -197,8 +197,13 @@ impl CliCommand for Init {
                     lock,
                 });
             }
-            idl.path = self.idl.clone();
-            idl.ensure_readable()?;
+            if self.git.is_some() {
+                idl.path = strip_slash_prefix(&self.idl);
+            } else {
+                idl.path = self.idl.clone();
+                // only ensure readable when idl is from local
+                idl.ensure_readable()?;
+            }
 
             let mut entry = Entry {
                 protocol: idl.protocol(),


### PR DESCRIPTION
## Motivation

Previously we didn't defend for users using absolute path in git mode, and this will cause panic such as `normalize path failed`

## Solution

This PR fixed that by strip leading slash in git mode.
