### PR TITLE
feat(volo-http): support extension

### DIFF
--- a/volo-http/src/extension.rs
+++ b/volo-http/src/extension.rs
@@ -1,0 +1,75 @@
+use std::convert::Infallible;
+
+use hyper::{body::Incoming, StatusCode};
+use motore::{layer::Layer, service::Service};
+
+use crate::{extract::FromContext, response::IntoResponse, HttpContext, Response};
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Extension<T>(pub T);
+
+impl<S, T> Layer<S> for Extension<T>
+where
+    S: Service<HttpContext, Incoming, Response = Response> + Send + Sync + 'static,
+    T: Sync,
+{
+    type Service = ExtensionService<S, T>;
+
+    fn layer(self, inner: S) -> Self::Service {
+        ExtensionService { inner, ext: self.0 }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ExtensionService<I, T> {
+    inner: I,
+    ext: T,
+}
+
+impl<S, T> Service<HttpContext, Incoming> for ExtensionService<S, T>
+where
+    S: Service<HttpContext, Incoming, Response = Response, Error = Infallible>
+        + Send
+        + Sync
+        + 'static,
+    T: Clone + Send + Sync + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+
+    async fn call<'s, 'cx>(
+        &'s self,
+        cx: &'cx mut HttpContext,
+        req: Incoming,
+    ) -> Result<Self::Response, Self::Error> {
+        cx.extensions.insert(self.ext.clone());
+        self.inner.call(cx, req).await
+    }
+}
+
+impl<T, S> FromContext<S> for Extension<T>
+where
+    T: Clone + Send + Sync + 'static,
+    S: Sync,
+{
+    type Rejection = ExtensionRejection;
+
+    async fn from_context(context: &HttpContext, _state: &S) -> Result<Self, Self::Rejection> {
+        context
+            .extensions
+            .get::<T>()
+            .map(T::clone)
+            .map(Extension)
+            .ok_or(ExtensionRejection::NotExist)
+    }
+}
+
+pub enum ExtensionRejection {
+    NotExist,
+}
+
+impl IntoResponse for ExtensionRejection {
+    fn into_response(self) -> Response {
+        StatusCode::INTERNAL_SERVER_ERROR.into_response()
+    }
+}

--- a/volo-http/src/lib.rs
+++ b/volo-http/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod context;
+pub mod extension;
 pub mod extract;
 pub mod handler;
 pub mod layer;
@@ -17,14 +18,13 @@ pub use bytes::Bytes;
 pub use hyper::{
     self,
     body::Incoming as BodyIncoming,
-    http::{
-        self, Extensions, HeaderMap, HeaderName, HeaderValue, Method, StatusCode, Uri, Version,
-    },
+    http::{self, HeaderMap, HeaderName, HeaderValue, Method, StatusCode, Uri, Version},
 };
 pub use volo::net::Address;
 
 pub use crate::{
     context::{ConnectionInfo, HttpContext},
+    extension::Extension,
     extract::{Form, Json, MaybeInvalid, Query, State},
     param::Params,
     request::Request,


### PR DESCRIPTION
This PR adds `Extension` for appending an extension into context.

The `Extension` can be a layer or an extractor, e.g.,

```rust
struct State {
    foo: String,
}

async fn index(Extension(state): Extension<Arc<State>>) -> String {
    state.foo.clone()
}

Router::new()
    .route("/", get(index))
    .layer(Extension(Arc::new(State { foo: "114514".to_string() })));
```