### PR TITLE
feat(volo-http): support cookie

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,6 +325,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd91cf61412820176e137621345ee43b3f4423e589e7ae4e50d601d93e35ef8"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +403,15 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core 0.9.9",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eb30d70a07a3b04884d2677f06bec33509dc67ca60d92949e5535352d3191dc"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -1700,6 +1720,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2423,6 +2449,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
+dependencies = [
+ "deranged",
+ "itoa",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
+dependencies = [
+ "time-core",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2904,6 +2959,7 @@ name = "volo-http"
 version = "0.1.5"
 dependencies = [
  "bytes",
+ "cookie",
  "faststr",
  "futures",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ chrono = { version = "0.4", default-features = false, features = [
 ] }
 clap = "4"
 colored = "2"
+cookie = "0.18"
 dashmap = "5"
 dirs = "5"
 faststr = "0.2"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -95,7 +95,7 @@ pilota.workspace = true
 volo = { path = "../volo" }
 volo-grpc = { path = "../volo-grpc" }
 volo-thrift = { path = "../volo-thrift" }
-volo-http = { path = "../volo-http" }
+volo-http = { path = "../volo-http", features = ["cookie"] }
 
 volo-gen = { path = "./volo-gen" }
 

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -25,6 +25,7 @@ hyper = { version = "1", features = ["server", "http1", "http2"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 
 bytes.workspace = true
+cookie = { workspace = true, optional = true, features = ["percent-encode"] }
 faststr.workspace = true
 futures.workspace = true
 futures-util.workspace = true
@@ -51,3 +52,7 @@ url.workspace = true
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
+
+[features]
+default = []
+cookie = ["dep:cookie"]

--- a/volo-http/src/cookie.rs
+++ b/volo-http/src/cookie.rs
@@ -1,0 +1,43 @@
+use std::{convert::Infallible, ops::Deref};
+
+pub use cookie::{time::Duration, Cookie};
+use hyper::http::{header, HeaderMap};
+
+use crate::{extract::FromContext, HttpContext};
+
+pub struct CookieJar {
+    inner: cookie::CookieJar,
+}
+
+impl CookieJar {
+    pub fn from_header(headers: &HeaderMap) -> Self {
+        let mut jar = cookie::CookieJar::new();
+        for cookie in headers
+            .get_all(header::COOKIE)
+            .into_iter()
+            .filter_map(|val| val.to_str().ok())
+            .flat_map(|val| val.split(';'))
+            .filter_map(|cookie| Cookie::parse_encoded(cookie.to_owned()).ok())
+        {
+            jar.add_original(cookie);
+        }
+
+        Self { inner: jar }
+    }
+}
+
+impl Deref for CookieJar {
+    type Target = cookie::CookieJar;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<S: Sync> FromContext<S> for CookieJar {
+    type Rejection = Infallible;
+
+    async fn from_context(context: &HttpContext, _state: &S) -> Result<Self, Self::Rejection> {
+        Ok(Self::from_header(&context.headers))
+    }
+}

--- a/volo-http/src/lib.rs
+++ b/volo-http/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod context;
+#[cfg(feature = "cookie")]
+pub mod cookie;
 pub mod extension;
 pub mod extract;
 pub mod handler;
@@ -15,6 +17,7 @@ mod macros;
 use std::convert::Infallible;
 
 pub use bytes::Bytes;
+#[cfg(feature = "cookie")]
 pub use hyper::{
     self,
     body::Incoming as BodyIncoming,
@@ -22,6 +25,8 @@ pub use hyper::{
 };
 pub use volo::net::Address;
 
+#[cfg(feature = "cookie")]
+pub use crate::cookie::CookieJar;
 pub use crate::{
     context::{ConnectionInfo, HttpContext},
     extension::Extension,


### PR DESCRIPTION
This PR introduces a new feature `cookie` and a new type `CookieJar`, extractor is also available for it.

Also, example has also been updated in [`examples/src/http/simple.rs`](examples/src/http/simple.rs).