### PR TITLE
feat(volo-cli): add subcmd for creating http project

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2882,7 +2882,7 @@ dependencies = [
 
 [[package]]
 name = "volo-cli"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2956,7 +2956,7 @@ dependencies = [
 
 [[package]]
 name = "volo-http"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "bytes",
  "cookie",

--- a/examples/src/http/simple.rs
+++ b/examples/src/http/simple.rs
@@ -100,7 +100,7 @@ async fn extension(Extension(state): Extension<Arc<State>>) -> String {
     format!("State {{ foo: {}, bar: {} }}\n", state.foo, state.bar)
 }
 
-fn timeout_handler(uri: Uri, peer: Address) -> StatusCode {
+async fn timeout_handler(uri: Uri, peer: Address) -> StatusCode {
     tracing::info!("Timeout on `{}`, peer: {}", uri, peer);
     StatusCode::INTERNAL_SERVER_ERROR
 }
@@ -238,7 +238,7 @@ async fn main() {
         })))
         .layer(middleware::from_fn(tracing_from_fn))
         .layer(middleware::map_response(headers_map_response))
-        .layer(TimeoutLayer::new(Duration::from_secs(5), || {
+        .layer(TimeoutLayer::new(Duration::from_secs(5), || async {
             StatusCode::INTERNAL_SERVER_ERROR
         }));
 

--- a/volo-cli/Cargo.toml
+++ b/volo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-cli"
-version = "0.9.1"
+version = "0.9.2"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-cli/src/http.rs
+++ b/volo-cli/src/http.rs
@@ -1,0 +1,75 @@
+use std::{fs::create_dir_all, process::Command};
+
+use clap::Parser;
+use volo_build::util::git_repo_init;
+
+use crate::{command::CliCommand, context::Context};
+
+define_commands!(Subcommand { Init });
+
+#[derive(Parser, Debug)]
+#[command(about = "manage your http project")]
+pub struct Http {
+    #[command(subcommand)]
+    subcmd: Subcommand,
+}
+
+impl CliCommand for Http {
+    fn run(&self, cx: Context) -> anyhow::Result<()> {
+        self.subcmd.run(cx)
+    }
+}
+
+#[derive(Parser, Debug)]
+#[command(about = "init your http project")]
+pub struct Init {
+    #[arg(help = "The name of project")]
+    pub name: String,
+}
+
+impl Init {
+    fn copy_template(&self) -> anyhow::Result<()> {
+        let name = self.name.replace(['.', '-'], "_");
+        let cwd = std::env::current_dir()?;
+        let folder = cwd.as_path();
+
+        // root dirs
+        crate::templates_to_target_file!(
+            folder,
+            "templates/http/rust-toolchain_toml",
+            "rust-toolchain.toml"
+        );
+        crate::templates_to_target_file!(folder, "templates/http/gitignore", ".gitignore");
+        crate::templates_to_target_file!(
+            folder,
+            "templates/http/cargo_toml",
+            "Cargo.toml",
+            name = &name
+        );
+
+        // src dirs
+        create_dir_all(folder.join("src/bin"))?;
+        crate::templates_to_target_file!(
+            folder,
+            "templates/http/src/bin/server_rs",
+            "src/bin/server.rs",
+            name = &name,
+        );
+        crate::templates_to_target_file!(folder, "templates/http/src/lib_rs", "src/lib.rs",);
+
+        Ok(())
+    }
+}
+
+impl CliCommand for Init {
+    fn run(&self, _: Context) -> anyhow::Result<()> {
+        self.copy_template()?;
+
+        let _ = Command::new("cargo").arg("fmt").arg("--all").output()?;
+
+        let cwd = std::env::current_dir()?;
+        git_repo_init(&cwd)?;
+
+        Ok(())
+    }
+}

--- a/volo-cli/src/init.rs
+++ b/volo-cli/src/init.rs
@@ -10,7 +10,7 @@ use volo_build::{
 use crate::command::CliCommand;
 
 #[derive(Parser, Debug)]
-#[command(about = "init your project")]
+#[command(about = "init your thrift or grpc project")]
 pub struct Init {
     #[arg(help = "The name of project")]
     pub name: String,

--- a/volo-cli/src/lib.rs
+++ b/volo-cli/src/lib.rs
@@ -6,6 +6,7 @@
 #[macro_use]
 mod command;
 pub mod context;
+mod http;
 mod idl;
 mod init;
 pub mod model;

--- a/volo-cli/src/model.rs
+++ b/volo-cli/src/model.rs
@@ -2,9 +2,9 @@ use anyhow::Result;
 use clap::{ArgAction, Parser};
 use volo_build::model::DEFAULT_ENTRY_NAME;
 
-use crate::{command::CliCommand, context::Context, idl::Idl, init::Init};
+use crate::{command::CliCommand, context::Context, http::Http, idl::Idl, init::Init};
 
-define_commands!(Subcommand { Init, Idl });
+define_commands!(Subcommand { Init, Idl, Http });
 
 #[derive(Parser, Debug)]
 #[command(

--- a/volo-cli/src/templates/http/cargo_toml
+++ b/volo-cli/src/templates/http/cargo_toml
@@ -1,0 +1,24 @@
+[package]
+name = "{name}"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+# we recommend to use the latest framework version for new features and bug fixes
+volo = "*"
+volo-http = "*"
+
+tokio = {{ version = "1", features = ["full"] }}
+
+[profile.release]
+opt-level = 3
+debug = true
+debug-assertions = false
+overflow-checks = false
+lto = true
+panic = 'unwind'
+incremental = false
+codegen-units = 1
+rpath = false

--- a/volo-cli/src/templates/http/gitignore
+++ b/volo-cli/src/templates/http/gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+.idea/
+.vscode/
+target/
+*.code-workspace

--- a/volo-cli/src/templates/http/rust-toolchain_toml
+++ b/volo-cli/src/templates/http/rust-toolchain_toml
@@ -1,0 +1,3 @@
+[toolchain]
+# TODO: we can remove this toolchain file when AFIT and RPITIT hits stable.
+channel = "nightly"

--- a/volo-cli/src/templates/http/src/bin/server_rs
+++ b/volo-cli/src/templates/http/src/bin/server_rs
@@ -1,0 +1,22 @@
+use std::{{net::SocketAddr, time::Duration}};
+
+use volo_http::{{layer::TimeoutLayer, route::Router, server::Server, Address, StatusCode}};
+use {name}::example_router;
+
+async fn timeout_handler() -> (StatusCode, &'static str) {{
+    (StatusCode::INTERNAL_SERVER_ERROR, "Timeout!\n")
+}}
+
+#[volo::main]
+async fn main() {{
+    let app = Router::new()
+        .merge(example_router())
+        .layer(TimeoutLayer::new(Duration::from_secs(1), timeout_handler));
+
+    let addr = "[::]:8080".parse::<SocketAddr>().unwrap();
+    let addr = Address::from(addr);
+
+    println!("Listening on {{addr}}");
+
+    Server::new(app).run(addr).await.unwrap();
+}}

--- a/volo-cli/src/templates/http/src/lib_rs
+++ b/volo-cli/src/templates/http/src/lib_rs
@@ -1,0 +1,9 @@
+use volo_http::route::{{get, Router}};
+
+async fn index_handler() -> &'static str {{
+    "It Works!\n"
+}}
+
+pub fn example_router() -> Router {{
+    Router::new().route("/", get(index_handler))
+}}

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-http"
-version = "0.1.6"
+version = "0.1.7"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Motivation

This PR adds a sub-command in `volo-cli` for creating a http project with `volo-http`.

Usage: `volo http init <PROJ-NAME>`

For example:

```bash
mkdir -p volo-http-test && cd volo-http-test
volo http init volo-http-test
```
