### PR TITLE
feat(volo-http): refactor `HttpContext` and extractor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "volo-http"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "bytes",
  "cookie",

--- a/examples/src/http/simple.rs
+++ b/examples/src/http/simple.rs
@@ -11,7 +11,7 @@ use volo_http::{
     middleware::{self, Next},
     response::IntoResponse,
     route::{get, post, MethodRouter, Router},
-    Address, BodyIncoming, Bytes, ConnectionInfo, CookieJar, HttpContext, Json, MaybeInvalid,
+    Address, BodyIncoming, ConnectionInfo, CookieJar, HttpContext, Json, MaybeInvalid,
     Method, Params, Response, Server, StatusCode, Uri,
 };
 
@@ -85,9 +85,9 @@ async fn timeout_test() {
     tokio::time::sleep(Duration::from_secs(10)).await
 }
 
-async fn echo(params: Params) -> Result<Bytes, StatusCode> {
+async fn echo(params: Params) -> Result<FastStr, StatusCode> {
     if let Some(echo) = params.get("echo") {
-        return Ok(echo.clone());
+        return Ok(echo);
     }
     Err(StatusCode::BAD_REQUEST)
 }

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-http"
-version = "0.1.8"
+version = "0.1.9"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-http/src/cookie.rs
+++ b/volo-http/src/cookie.rs
@@ -37,7 +37,7 @@ impl Deref for CookieJar {
 impl<S: Sync> FromContext<S> for CookieJar {
     type Rejection = Infallible;
 
-    async fn from_context(context: &HttpContext, _state: &S) -> Result<Self, Self::Rejection> {
-        Ok(Self::from_header(&context.headers))
+    async fn from_context(cx: &mut HttpContext, _state: &S) -> Result<Self, Self::Rejection> {
+        Ok(Self::from_header(cx.headers()))
     }
 }

--- a/volo-http/src/extension.rs
+++ b/volo-http/src/extension.rs
@@ -42,7 +42,7 @@ where
         cx: &'cx mut HttpContext,
         req: Incoming,
     ) -> Result<Self::Response, Self::Error> {
-        cx.extensions.insert(self.ext.clone());
+        cx.extensions_mut().insert(self.ext.clone());
         self.inner.call(cx, req).await
     }
 }
@@ -54,9 +54,8 @@ where
 {
     type Rejection = ExtensionRejection;
 
-    async fn from_context(context: &HttpContext, _state: &S) -> Result<Self, Self::Rejection> {
-        context
-            .extensions
+    async fn from_context(cx: &mut HttpContext, _state: &S) -> Result<Self, Self::Rejection> {
+        cx.extensions()
             .get::<T>()
             .map(T::clone)
             .map(Extension)

--- a/volo-http/src/handler.rs
+++ b/volo-http/src/handler.rs
@@ -21,7 +21,7 @@ use crate::{
 pub trait Handler<T, S>: Sized {
     fn call(
         self,
-        context: &mut HttpContext,
+        cx: &mut HttpContext,
         req: Incoming,
         state: &S,
     ) -> impl Future<Output = Response> + Send;
@@ -45,7 +45,7 @@ where
     Res: IntoResponse,
     S: Send + Sync,
 {
-    async fn call(self, _context: &mut HttpContext, _req: Incoming, _state: &S) -> Response {
+    async fn call(self, _cx: &mut HttpContext, _req: Incoming, _state: &S) -> Response {
         self().await.into_response()
     }
 }
@@ -64,14 +64,14 @@ macro_rules! impl_handler {
             $( for<'r> $ty: FromContext<S> + Send + 'r, )*
             for<'r> $last: FromRequest<S, M> + Send + 'r,
         {
-            async fn call(self, context: &mut HttpContext, req: Incoming, state: &S) -> Response {
+            async fn call(self, cx: &mut HttpContext, req: Incoming, state: &S) -> Response {
                 $(
-                    let $ty = match $ty::from_context(context, state).await {
+                    let $ty = match $ty::from_context(cx, state).await {
                         Ok(value) => value,
                         Err(rejection) => return rejection.into_response(),
                     };
                 )*
-                let $last = match $last::from_request(context, req, state).await {
+                let $last = match $last::from_request(cx, req, state).await {
                     Ok(value) => value,
                     Err(rejection) => return rejection.into_response(),
                 };
@@ -252,7 +252,7 @@ where
 }
 
 pub trait HandlerWithoutRequest<T>: Sized {
-    fn call(self, context: &HttpContext) -> impl Future<Output = Response> + Send;
+    fn call(self, cx: &mut HttpContext) -> impl Future<Output = Response> + Send;
 }
 
 impl<F, Fut, Res> HandlerWithoutRequest<()> for F
@@ -261,7 +261,7 @@ where
     Fut: Future<Output = Res> + Send,
     Res: IntoResponse,
 {
-    async fn call(self, _context: &HttpContext) -> Response {
+    async fn call(self, _cx: &mut HttpContext) -> Response {
         self().await.into_response()
     }
 }
@@ -278,9 +278,9 @@ macro_rules! impl_handler_without_request {
             Res: IntoResponse,
             $( for<'r> $ty: FromContext<()> + Send + 'r, )*
         {
-            async fn call(self, context: &HttpContext) -> Response {
+            async fn call(self, cx: &mut HttpContext) -> Response {
                 $(
-                    let $ty = match $ty::from_context(context, &()).await {
+                    let $ty = match $ty::from_context(cx, &()).await {
                         Ok(value) => value,
                         Err(rejection) => return rejection.into_response(),
                     };
@@ -299,7 +299,7 @@ pub trait MiddlewareHandlerFromFn<'r, T, S>: Sized {
 
     fn call(
         &self,
-        context: &'r mut HttpContext,
+        cx: &'r mut HttpContext,
         req: Incoming,
         state: &'r S,
         next: Next,
@@ -325,7 +325,7 @@ macro_rules! impl_middleware_handler_from_fn {
 
             fn call(
                 &self,
-                context: &'r mut HttpContext,
+                cx: &'r mut HttpContext,
                 req: Incoming,
                 state: &'r S,
                 next: Next,
@@ -334,16 +334,16 @@ macro_rules! impl_middleware_handler_from_fn {
 
                 let future = Box::pin(async move {
                     $(
-                        let $ty = match $ty::from_context(context, state).await {
+                        let $ty = match $ty::from_context(cx, state).await {
                             Ok(value) => value,
                             Err(rejection) => return rejection.into_response(),
                         };
                     )*
-                    let $last = match $last::from_request(context, req, state).await {
+                    let $last = match $last::from_request(cx, req, state).await {
                         Ok(value) => value,
                         Err(rejection) => return rejection.into_response(),
                     };
-                    f($($ty,)* context, $last, next).await.into_response()
+                    f($($ty,)* cx, $last, next).await.into_response()
                 });
 
                 ResponseFuture {
@@ -360,7 +360,7 @@ pub trait MiddlewareHandlerMapResponse<'r, T, S>: Sized {
     // type Response: IntoResponse;
     type Future: Future<Output = Response> + Send + 'r;
 
-    fn call(&self, context: &'r HttpContext, state: &'r S, response: Response) -> Self::Future;
+    fn call(&self, cx: &'r mut HttpContext, state: &'r S, response: Response) -> Self::Future;
 }
 
 impl<'r, F, Fut, Res, S> MiddlewareHandlerMapResponse<'r, ((),), S> for F
@@ -373,7 +373,7 @@ where
     // type Response = Response;
     type Future = ResponseFuture<'r, Response>;
 
-    fn call(&self, _context: &'r HttpContext, _state: &'r S, response: Response) -> Self::Future {
+    fn call(&self, _cx: &'r mut HttpContext, _state: &'r S, response: Response) -> Self::Future {
         let f = *self;
 
         let future = Box::pin(async move { f(response).await.into_response() });
@@ -400,7 +400,7 @@ macro_rules! impl_middleware_handler_map_response {
 
             fn call(
                 &self,
-                context: &'r HttpContext,
+                cx: &'r mut HttpContext,
                 state: &'r S,
                 response: Response,
             ) -> Self::Future {
@@ -408,7 +408,7 @@ macro_rules! impl_middleware_handler_map_response {
 
                 let future = Box::pin(async move {
                     $(
-                        let $ty = match $ty::from_context(context, state).await {
+                        let $ty = match $ty::from_context(cx, state).await {
                             Ok(value) => value,
                             Err(rejection) => return rejection.into_response(),
                         };

--- a/volo-http/src/json.rs
+++ b/volo-http/src/json.rs
@@ -48,11 +48,11 @@ where
     type Rejection = RejectionError;
 
     async fn from_request(
-        cx: &HttpContext,
+        cx: &mut HttpContext,
         body: Incoming,
         state: &S,
     ) -> Result<Self, Self::Rejection> {
-        if !json_content_type(&cx.headers) {
+        if !json_content_type(cx.headers()) {
             return Err(RejectionError::InvalidContentType);
         }
 

--- a/volo-http/src/layer.rs
+++ b/volo-http/src/layer.rs
@@ -22,7 +22,7 @@ pub trait LayerExt {
         Self: Sized,
     {
         self.filter(Box::new(move |cx: &mut HttpContext, _: &Request| {
-            if cx.method == method {
+            if cx.method() == method {
                 Ok(())
             } else {
                 Err(StatusCode::METHOD_NOT_ALLOWED)

--- a/volo-http/src/response.rs
+++ b/volo-http/src/response.rs
@@ -5,6 +5,7 @@ use std::{
     task::{Context, Poll},
 };
 
+use faststr::FastStr;
 use futures_util::ready;
 use http_body_util::Full;
 use hyper::{
@@ -90,6 +91,14 @@ impl From<Bytes> for RespBody {
 
 impl From<String> for RespBody {
     fn from(value: String) -> Self {
+        Self {
+            inner: Full::new(value.into()),
+        }
+    }
+}
+
+impl From<FastStr> for RespBody {
+    fn from(value: FastStr) -> Self {
         Self {
             inner: Full::new(value.into()),
         }

--- a/volo-http/src/route.rs
+++ b/volo-http/src/route.rs
@@ -173,7 +173,7 @@ impl Service<HttpContext, Incoming> for Router<()> {
     ) -> Result<Self::Response, Self::Error> {
         if let Ok(matched) = self.matcher.at(cx.uri.path()) {
             if let Some(srv) = self.routes.get(matched.value) {
-                cx.params = matched.params.into();
+                cx.params.extend(matched.params);
                 return srv.call_with_state(cx, req, ()).await;
             }
         }
@@ -337,16 +337,16 @@ where
     where
         S: 'cx,
     {
-        let handler = match cx.method {
-            Method::OPTIONS => Some(&self.options),
-            Method::GET => Some(&self.get),
-            Method::POST => Some(&self.post),
-            Method::PUT => Some(&self.put),
-            Method::DELETE => Some(&self.delete),
-            Method::HEAD => Some(&self.head),
-            Method::TRACE => Some(&self.trace),
-            Method::CONNECT => Some(&self.connect),
-            Method::PATCH => Some(&self.patch),
+        let handler = match cx.method() {
+            &Method::OPTIONS => Some(&self.options),
+            &Method::GET => Some(&self.get),
+            &Method::POST => Some(&self.post),
+            &Method::PUT => Some(&self.put),
+            &Method::DELETE => Some(&self.delete),
+            &Method::HEAD => Some(&self.head),
+            &Method::TRACE => Some(&self.trace),
+            &Method::CONNECT => Some(&self.connect),
+            &Method::PATCH => Some(&self.patch),
             _ => None,
         };
 

--- a/volo-http/src/server.rs
+++ b/volo-http/src/server.rs
@@ -17,7 +17,6 @@ use tracing::{info, trace};
 use volo::net::{conn::Conn, incoming::Incoming, Address, MakeIncoming};
 
 use crate::{
-    param::Params,
     response::{IntoResponse, RespBody, Response},
     HttpContext,
 };
@@ -252,17 +251,7 @@ async fn handle_conn<S>(
             async move {
                 let (parts, req) = req.into_parts();
                 let req = req.into();
-                let mut cx = HttpContext {
-                    peer,
-                    method: parts.method,
-                    uri: parts.uri,
-                    version: parts.version,
-                    headers: parts.headers,
-                    extensions: parts.extensions,
-                    params: Params {
-                        inner: Vec::with_capacity(0),
-                    },
-                };
+                let mut cx = HttpContext::from_parts(peer, parts);
                 let resp = match service.call(&mut cx, req).await {
                     Ok(resp) => resp,
                     Err(inf) => inf.into_response(),


### PR DESCRIPTION
## Motivation

The original design of `HttpContext` and extractor (`FromRequest`, `FromContext`) has some issues, this PR refactors them.

Note that there are some break changes:

1. Updates type of argument from `&HttpContext` to `&mut HttpContext` in `FromRequest` and `FromContext`, `impl`s for them should be updated.
2. Contents from `HttpContext` are private now, and they should be got by function, e.g., `cx.uri()` instead of `cx.uri`.
3. Data in `Params` has been updated from `Bytes` to `FastStr`.
