### PR TITLE
chore(volo-http): use `&mut HttpContext` for extractor

### DIFF
--- a/volo-http/src/cookie.rs
+++ b/volo-http/src/cookie.rs
@@ -3,7 +3,7 @@ use std::{convert::Infallible, ops::Deref};
 pub use cookie::{time::Duration, Cookie};
 use hyper::http::{header, HeaderMap};
 
-use crate::{extract::FromContext, HttpContext};
+use crate::{context::HttpContext, extract::FromContext};
 
 pub struct CookieJar {
     inner: cookie::CookieJar,
@@ -37,7 +37,7 @@ impl Deref for CookieJar {
 impl<S: Sync> FromContext<S> for CookieJar {
     type Rejection = Infallible;
 
-    async fn from_context(context: &HttpContext, _state: &S) -> Result<Self, Self::Rejection> {
-        Ok(Self::from_header(&context.headers))
+    async fn from_context(cx: &mut HttpContext, _state: &S) -> Result<Self, Self::Rejection> {
+        Ok(Self::from_header(&cx.headers))
     }
 }

--- a/volo-http/src/extension.rs
+++ b/volo-http/src/extension.rs
@@ -54,9 +54,8 @@ where
 {
     type Rejection = ExtensionRejection;
 
-    async fn from_context(context: &HttpContext, _state: &S) -> Result<Self, Self::Rejection> {
-        context
-            .extensions
+    async fn from_context(cx: &mut HttpContext, _state: &S) -> Result<Self, Self::Rejection> {
+        cx.extensions
             .get::<T>()
             .map(T::clone)
             .map(Extension)

--- a/volo-http/src/handler.rs
+++ b/volo-http/src/handler.rs
@@ -21,7 +21,7 @@ use crate::{
 pub trait Handler<T, S>: Sized {
     fn call(
         self,
-        context: &mut HttpContext,
+        cx: &mut HttpContext,
         req: Incoming,
         state: &S,
     ) -> impl Future<Output = Response> + Send;
@@ -64,14 +64,14 @@ macro_rules! impl_handler {
             $( for<'r> $ty: FromContext<S> + Send + 'r, )*
             for<'r> $last: FromRequest<S, M> + Send + 'r,
         {
-            async fn call(self, context: &mut HttpContext, req: Incoming, state: &S) -> Response {
+            async fn call(self, cx: &mut HttpContext, req: Incoming, state: &S) -> Response {
                 $(
-                    let $ty = match $ty::from_context(context, state).await {
+                    let $ty = match $ty::from_context(cx, state).await {
                         Ok(value) => value,
                         Err(rejection) => return rejection.into_response(),
                     };
                 )*
-                let $last = match $last::from_request(context, req, state).await {
+                let $last = match $last::from_request(cx, req, state).await {
                     Ok(value) => value,
                     Err(rejection) => return rejection.into_response(),
                 };
@@ -252,7 +252,7 @@ where
 }
 
 pub trait HandlerWithoutRequest<T>: Sized {
-    fn call(self, context: &HttpContext) -> impl Future<Output = Response> + Send;
+    fn call(self, cx: &mut HttpContext) -> impl Future<Output = Response> + Send;
 }
 
 impl<F, Fut, Res> HandlerWithoutRequest<()> for F
@@ -261,7 +261,7 @@ where
     Fut: Future<Output = Res> + Send,
     Res: IntoResponse,
 {
-    async fn call(self, _context: &HttpContext) -> Response {
+    async fn call(self, _context: &mut HttpContext) -> Response {
         self().await.into_response()
     }
 }
@@ -278,9 +278,9 @@ macro_rules! impl_handler_without_request {
             Res: IntoResponse,
             $( for<'r> $ty: FromContext<()> + Send + 'r, )*
         {
-            async fn call(self, context: &HttpContext) -> Response {
+            async fn call(self, cx: &mut HttpContext) -> Response {
                 $(
-                    let $ty = match $ty::from_context(context, &()).await {
+                    let $ty = match $ty::from_context(cx, &()).await {
                         Ok(value) => value,
                         Err(rejection) => return rejection.into_response(),
                     };
@@ -299,7 +299,7 @@ pub trait MiddlewareHandlerFromFn<'r, T, S>: Sized {
 
     fn call(
         &self,
-        context: &'r mut HttpContext,
+        cx: &'r mut HttpContext,
         req: Incoming,
         state: &'r S,
         next: Next,
@@ -325,7 +325,7 @@ macro_rules! impl_middleware_handler_from_fn {
 
             fn call(
                 &self,
-                context: &'r mut HttpContext,
+                cx: &'r mut HttpContext,
                 req: Incoming,
                 state: &'r S,
                 next: Next,
@@ -334,16 +334,16 @@ macro_rules! impl_middleware_handler_from_fn {
 
                 let future = Box::pin(async move {
                     $(
-                        let $ty = match $ty::from_context(context, state).await {
+                        let $ty = match $ty::from_context(cx, state).await {
                             Ok(value) => value,
                             Err(rejection) => return rejection.into_response(),
                         };
                     )*
-                    let $last = match $last::from_request(context, req, state).await {
+                    let $last = match $last::from_request(cx, req, state).await {
                         Ok(value) => value,
                         Err(rejection) => return rejection.into_response(),
                     };
-                    f($($ty,)* context, $last, next).await.into_response()
+                    f($($ty,)* cx, $last, next).await.into_response()
                 });
 
                 ResponseFuture {
@@ -360,7 +360,7 @@ pub trait MiddlewareHandlerMapResponse<'r, T, S>: Sized {
     // type Response: IntoResponse;
     type Future: Future<Output = Response> + Send + 'r;
 
-    fn call(&self, context: &'r HttpContext, state: &'r S, response: Response) -> Self::Future;
+    fn call(&self, cx: &'r mut HttpContext, state: &'r S, response: Response) -> Self::Future;
 }
 
 impl<'r, F, Fut, Res, S> MiddlewareHandlerMapResponse<'r, ((),), S> for F
@@ -373,7 +373,12 @@ where
     // type Response = Response;
     type Future = ResponseFuture<'r, Response>;
 
-    fn call(&self, _context: &'r HttpContext, _state: &'r S, response: Response) -> Self::Future {
+    fn call(
+        &self,
+        _context: &'r mut HttpContext,
+        _state: &'r S,
+        response: Response,
+    ) -> Self::Future {
         let f = *self;
 
         let future = Box::pin(async move { f(response).await.into_response() });
@@ -400,7 +405,7 @@ macro_rules! impl_middleware_handler_map_response {
 
             fn call(
                 &self,
-                context: &'r HttpContext,
+                cx: &'r mut HttpContext,
                 state: &'r S,
                 response: Response,
             ) -> Self::Future {
@@ -408,7 +413,7 @@ macro_rules! impl_middleware_handler_map_response {
 
                 let future = Box::pin(async move {
                     $(
-                        let $ty = match $ty::from_context(context, state).await {
+                        let $ty = match $ty::from_context(cx, state).await {
                             Ok(value) => value,
                             Err(rejection) => return rejection.into_response(),
                         };

--- a/volo-http/src/json.rs
+++ b/volo-http/src/json.rs
@@ -48,7 +48,7 @@ where
     type Rejection = RejectionError;
 
     async fn from_request(
-        cx: &HttpContext,
+        cx: &mut HttpContext,
         body: Incoming,
         state: &S,
     ) -> Result<Self, Self::Rejection> {


### PR DESCRIPTION
BREAK CHANGE: This PR updates type of argument from `&HttpContext` to `&mut HttpContext` in `FromRequest` and `FromContext`, `impl`s for them should be updated.
