### PR TITLE
feat(volo-http): support `service_fn` 

### DIFF
--- a/volo-http/src/context.rs
+++ b/volo-http/src/context.rs
@@ -14,6 +14,7 @@ use crate::param::Params;
 static X_FORWARDED_HOST: HeaderName = HeaderName::from_static("x-forwarded-host");
 static X_FORWARDED_PROTO: HeaderName = HeaderName::from_static("x-forwarded-proto");
 
+#[derive(Debug)]
 pub struct HttpContext {
     pub peer: Address,
     pub method: Method,

--- a/volo-http/src/extract.rs
+++ b/volo-http/src/extract.rs
@@ -6,7 +6,7 @@ use futures_util::Future;
 use http_body_util::BodyExt;
 use hyper::{
     body::Incoming,
-    http::{header, HeaderMap, Method, StatusCode, Uri},
+    http::{header, Method, StatusCode, Uri},
 };
 use serde::de::DeserializeOwned;
 use volo::net::Address;
@@ -141,13 +141,6 @@ impl<S: Sync> FromContext<S> for ConnectionInfo {
     type Rejection = Infallible;
     async fn from_context(cx: &mut HttpContext, _state: &S) -> Result<Self, Self::Rejection> {
         Ok(cx.get_connection_info())
-    }
-}
-
-impl<S: Sync> FromContext<S> for HeaderMap {
-    type Rejection = Infallible;
-    async fn from_context(cx: &mut HttpContext, _state: &S) -> Result<Self, Self::Rejection> {
-        Ok(cx.headers.clone())
     }
 }
 

--- a/volo-http/src/lib.rs
+++ b/volo-http/src/lib.rs
@@ -13,6 +13,7 @@ pub mod request;
 pub mod response;
 pub mod route;
 pub mod server;
+pub(crate) mod service_fn;
 
 mod macros;
 

--- a/volo-http/src/param.rs
+++ b/volo-http/src/param.rs
@@ -2,7 +2,7 @@ use std::slice::Iter;
 
 use bytes::{BufMut, Bytes, BytesMut};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Params {
     pub(crate) inner: Vec<(Bytes, Bytes)>,
 }

--- a/volo-http/src/service_fn.rs
+++ b/volo-http/src/service_fn.rs
@@ -1,0 +1,66 @@
+use std::{convert::Infallible, fmt, future::Future};
+
+use hyper::body::Incoming;
+use motore::service::Service;
+
+use crate::{HttpContext, Response};
+
+/// Returns a new [`ServiceFn`] with the given closure.
+///
+/// This lets you build a [`Service`] from an async function that returns a [`Result`].
+pub fn service_fn<F>(f: F) -> ServiceFn<F> {
+    ServiceFn { f }
+}
+
+/// A [`Service`] implemented by a closure. See the docs for [`service_fn`] for more details.
+#[derive(Copy, Clone)]
+pub struct ServiceFn<F> {
+    f: F,
+}
+
+impl<F> Service<HttpContext, Incoming> for ServiceFn<F>
+where
+    F: for<'r> Callback<'r>,
+{
+    type Response = Response;
+    type Error = Infallible;
+
+    fn call<'s, 'cx>(
+        &'s self,
+        cx: &'cx mut HttpContext,
+        req: Incoming,
+    ) -> impl Future<Output = Result<Self::Response, Self::Error>> {
+        (self.f).call(cx, req)
+    }
+}
+
+impl<F> fmt::Debug for ServiceFn<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ServiceFn")
+            .field("f", &format_args!("{}", std::any::type_name::<F>()))
+            .finish()
+    }
+}
+
+/// [`Service`] for binding lifetime to return value while using closure.
+/// This is just a temporary workaround for lifetime issues.
+///
+/// Related issue: https://github.com/rust-lang/rust/issues/70263.
+/// Related RFC: https://github.com/rust-lang/rfcs/pull/3216.
+pub trait Callback<'r> {
+    type Future: Future<Output = Result<Response, Infallible>> + Send + 'r;
+
+    fn call(&self, cx: &'r mut HttpContext, req: Incoming) -> Self::Future;
+}
+
+impl<'r, F, Fut> Callback<'r> for F
+where
+    F: Fn(&'r mut HttpContext, Incoming) -> Fut,
+    Fut: Future<Output = Result<Response, Infallible>> + Send + 'r,
+{
+    type Future = Fut;
+
+    fn call(&self, cx: &'r mut HttpContext, req: Incoming) -> Self::Future {
+        self(cx, req)
+    }
+}


### PR DESCRIPTION
## Motivation

The previous code can extract the `HeaderMap` through `clone`, which may take a long time.

## Solution

This PR introduces `service_fn`, through which `HeaderMap` can be obtained from `HttpContext`.
