### PR TITLE
feat(volo-http): refactor `HttpContext` with `RpcCx`

### DIFF
--- a/examples/src/http/simple.rs
+++ b/examples/src/http/simple.rs
@@ -11,8 +11,8 @@ use volo_http::{
     middleware::{self, Next},
     response::IntoResponse,
     route::{from_handler, get, post, service_fn, MethodRouter, Router},
-    Address, BodyIncoming, ConnectionInfo, CookieJar, HttpContext, Json, MaybeInvalid, Method,
-    Params, Response, Server, StatusCode, Uri,
+    Address, BodyIncoming, ConnectionInfo, CookieJar, Json, MaybeInvalid, Method, Params, Response,
+    Server, ServerContext, StatusCode, Uri,
 };
 
 async fn hello() -> &'static str {
@@ -118,7 +118,10 @@ async fn extension(Extension(state): Extension<Arc<State>>) -> String {
     format!("State {{ foo: {}, bar: {} }}\n", state.foo, state.bar)
 }
 
-async fn service_fn_test(cx: &mut HttpContext, req: BodyIncoming) -> Result<Response, Infallible> {
+async fn service_fn_test(
+    cx: &mut ServerContext,
+    req: BodyIncoming,
+) -> Result<Response, Infallible> {
     Ok(format!("cx: {cx:?}, req: {req:?}").into_response())
 }
 
@@ -222,7 +225,7 @@ async fn tracing_from_fn(
     uri: Uri,
     peer: Address,
     cookie_jar: CookieJar,
-    cx: &mut HttpContext,
+    cx: &mut ServerContext,
     req: BodyIncoming,
     next: Next,
 ) -> Response {

--- a/volo-http/src/cookie.rs
+++ b/volo-http/src/cookie.rs
@@ -3,7 +3,7 @@ use std::{convert::Infallible, ops::Deref};
 pub use cookie::{time::Duration, Cookie};
 use hyper::http::{header, HeaderMap};
 
-use crate::{context::HttpContext, extract::FromContext};
+use crate::{context::ServerContext, extract::FromContext};
 
 pub struct CookieJar {
     inner: cookie::CookieJar,
@@ -37,7 +37,7 @@ impl Deref for CookieJar {
 impl<S: Sync> FromContext<S> for CookieJar {
     type Rejection = Infallible;
 
-    async fn from_context(cx: &mut HttpContext, _state: &S) -> Result<Self, Self::Rejection> {
+    async fn from_context(cx: &mut ServerContext, _state: &S) -> Result<Self, Self::Rejection> {
         Ok(Self::from_header(&cx.headers))
     }
 }

--- a/volo-http/src/json.rs
+++ b/volo-http/src/json.rs
@@ -17,7 +17,7 @@ pub use sonic_rs::Error;
 use crate::{
     extract::{FromRequest, RejectionError},
     response::IntoResponse,
-    HttpContext, Response,
+    Response, ServerContext,
 };
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -48,7 +48,7 @@ where
     type Rejection = RejectionError;
 
     async fn from_request(
-        cx: &mut HttpContext,
+        cx: &mut ServerContext,
         body: Incoming,
         state: &S,
     ) -> Result<Self, Self::Rejection> {

--- a/volo-http/src/layer.rs
+++ b/volo-http/src/layer.rs
@@ -4,9 +4,9 @@ use hyper::body::Incoming;
 use motore::{layer::Layer, service::Service};
 
 use crate::{
+    context::ServerContext,
     handler::HandlerWithoutRequest,
     response::{IntoResponse, Response},
-    HttpContext,
 };
 
 #[derive(Clone)]
@@ -48,9 +48,9 @@ pub struct Filter<S, H, R, T> {
     _marker: PhantomData<(R, T)>,
 }
 
-impl<S, H, R, T> Service<HttpContext, Incoming> for Filter<S, H, R, T>
+impl<S, H, R, T> Service<ServerContext, Incoming> for Filter<S, H, R, T>
 where
-    S: Service<HttpContext, Incoming, Response = Response, Error = Infallible>
+    S: Service<ServerContext, Incoming, Response = Response, Error = Infallible>
         + Send
         + Sync
         + 'static,
@@ -64,7 +64,7 @@ where
 
     async fn call<'s, 'cx>(
         &'s self,
-        cx: &'cx mut HttpContext,
+        cx: &'cx mut ServerContext,
         req: Incoming,
     ) -> Result<Self::Response, Self::Error> {
         match self.handler.clone().call(cx).await {
@@ -128,9 +128,9 @@ pub struct Timeout<S, H, R, T> {
     _marker: PhantomData<(R, T)>,
 }
 
-impl<S, H, R, T> Service<HttpContext, Incoming> for Timeout<S, H, R, T>
+impl<S, H, R, T> Service<ServerContext, Incoming> for Timeout<S, H, R, T>
 where
-    S: Service<HttpContext, Incoming, Response = Response, Error = Infallible>
+    S: Service<ServerContext, Incoming, Response = Response, Error = Infallible>
         + Send
         + Sync
         + 'static,
@@ -144,7 +144,7 @@ where
 
     async fn call<'s, 'cx>(
         &'s self,
-        cx: &'cx mut HttpContext,
+        cx: &'cx mut ServerContext,
         req: Incoming,
     ) -> Result<Self::Response, Self::Error> {
         let fut_service = self.service.call(cx, req);

--- a/volo-http/src/lib.rs
+++ b/volo-http/src/lib.rs
@@ -33,7 +33,7 @@ pub mod prelude {
     #[cfg(any(feature = "serde_json", feature = "sonic_json"))]
     pub use crate::json::Json;
     pub use crate::{
-        context::{ConnectionInfo, HttpContext},
+        context::{ConnectionInfo, HttpContext, ServerContext},
         extension::Extension,
         extract::{Form, MaybeInvalid, Query, State},
         param::Params,
@@ -44,7 +44,7 @@ pub mod prelude {
     };
 
     pub type DynService =
-        motore::BoxCloneService<HttpContext, BodyIncoming, Response, std::convert::Infallible>;
+        motore::BoxCloneService<ServerContext, BodyIncoming, Response, std::convert::Infallible>;
 }
 
 pub use prelude::*;

--- a/volo-http/src/middleware.rs
+++ b/volo-http/src/middleware.rs
@@ -4,9 +4,10 @@ use hyper::body::Incoming;
 use motore::{layer::Layer, service::Service};
 
 use crate::{
+    context::ServerContext,
     handler::{MiddlewareHandlerFromFn, MiddlewareHandlerMapResponse},
     response::{IntoResponse, Response},
-    DynService, HttpContext,
+    DynService,
 };
 
 pub struct FromFnLayer<F, S, T> {
@@ -81,9 +82,9 @@ where
     }
 }
 
-impl<I, F, S, T> Service<HttpContext, Incoming> for FromFn<I, F, S, T>
+impl<I, F, S, T> Service<ServerContext, Incoming> for FromFn<I, F, S, T>
 where
-    I: Service<HttpContext, Incoming, Response = Response, Error = Infallible>
+    I: Service<ServerContext, Incoming, Response = Response, Error = Infallible>
         + Clone
         + Send
         + Sync
@@ -96,7 +97,7 @@ where
 
     async fn call<'s, 'cx>(
         &'s self,
-        cx: &'cx mut HttpContext,
+        cx: &'cx mut ServerContext,
         req: Incoming,
     ) -> Result<Self::Response, Self::Error> {
         let next = Next {
@@ -113,7 +114,7 @@ pub struct Next {
 }
 
 impl Next {
-    pub async fn run(self, cx: &mut HttpContext, req: Incoming) -> Result<Response, Infallible> {
+    pub async fn run(self, cx: &mut ServerContext, req: Incoming) -> Result<Response, Infallible> {
         self.inner.call(cx, req).await
     }
 }
@@ -190,9 +191,9 @@ where
     }
 }
 
-impl<I, F, S, T> Service<HttpContext, Incoming> for MapResponse<I, F, S, T>
+impl<I, F, S, T> Service<ServerContext, Incoming> for MapResponse<I, F, S, T>
 where
-    I: Service<HttpContext, Incoming, Response = Response, Error = Infallible>
+    I: Service<ServerContext, Incoming, Response = Response, Error = Infallible>
         + Clone
         + Send
         + Sync
@@ -205,7 +206,7 @@ where
 
     async fn call<'s, 'cx>(
         &'s self,
-        cx: &'cx mut HttpContext,
+        cx: &'cx mut ServerContext,
         req: Incoming,
     ) -> Result<Self::Response, Self::Error> {
         let response = match self.inner.call(cx, req).await {

--- a/volo-http/src/route.rs
+++ b/volo-http/src/route.rs
@@ -171,7 +171,7 @@ impl Service<HttpContext, Incoming> for Router<()> {
         cx: &'cx mut HttpContext,
         req: Incoming,
     ) -> Result<Self::Response, Self::Error> {
-        if let Ok(matched) = self.matcher.at(cx.uri.path()) {
+        if let Ok(matched) = self.matcher.at(cx.uri.clone().path()) {
             if let Some(srv) = self.routes.get(matched.value) {
                 cx.params.extend(matched.params);
                 return srv.call_with_state(cx, req, ()).await;

--- a/volo-http/src/server.rs
+++ b/volo-http/src/server.rs
@@ -17,7 +17,6 @@ use tracing::{info, trace};
 use volo::net::{conn::Conn, incoming::Incoming, Address, MakeIncoming};
 
 use crate::{
-    param::Params,
     response::{IntoResponse, RespBody, Response},
     HttpContext,
 };
@@ -252,15 +251,7 @@ async fn handle_conn<S>(
             async move {
                 let (parts, req) = req.into_parts();
                 let req = req.into();
-                let mut cx = HttpContext {
-                    peer,
-                    method: parts.method,
-                    uri: parts.uri,
-                    version: parts.version,
-                    headers: parts.headers,
-                    extensions: parts.extensions,
-                    params: Params::default(),
-                };
+                let mut cx = HttpContext::new(peer, parts);
                 let resp = match service.call(&mut cx, req).await {
                     Ok(resp) => resp,
                     Err(inf) => inf.into_response(),

--- a/volo-http/src/server.rs
+++ b/volo-http/src/server.rs
@@ -17,8 +17,8 @@ use tracing::{info, trace};
 use volo::net::{conn::Conn, incoming::Incoming, Address, MakeIncoming};
 
 use crate::{
+    context::ServerContext,
     response::{IntoResponse, RespBody, Response},
-    HttpContext,
 };
 
 pub struct Server<S, L> {
@@ -30,7 +30,7 @@ pub struct Server<S, L> {
 impl<S> Server<S, Identity> {
     pub fn new(service: S) -> Self
     where
-        S: Service<HttpContext, BodyIncoming, Response = Response, Error = Infallible>,
+        S: Service<ServerContext, BodyIncoming, Response = Response, Error = Infallible>,
     {
         Self {
             service,
@@ -93,9 +93,9 @@ impl<S, L> Server<S, L> {
 
     pub async fn run<MI: MakeIncoming>(self, mk_incoming: MI) -> Result<(), BoxError>
     where
-        S: Service<HttpContext, BodyIncoming, Response = Response, Error = Infallible>,
+        S: Service<ServerContext, BodyIncoming, Response = Response, Error = Infallible>,
         L: Layer<S>,
-        L::Service: Service<HttpContext, BodyIncoming, Response = Response, Error = Infallible>
+        L::Service: Service<ServerContext, BodyIncoming, Response = Response, Error = Infallible>
             + Send
             + Sync
             + 'static,
@@ -234,7 +234,7 @@ async fn handle_conn<S>(
     conn_cnt: Arc<std::sync::atomic::AtomicUsize>,
     peer: Address,
 ) where
-    S: Service<HttpContext, BodyIncoming, Response = Response, Error = Infallible>
+    S: Service<ServerContext, BodyIncoming, Response = Response, Error = Infallible>
         + Clone
         + Send
         + Sync
@@ -251,7 +251,7 @@ async fn handle_conn<S>(
             async move {
                 let (parts, req) = req.into_parts();
                 let req = req.into();
-                let mut cx = HttpContext::new(peer, parts);
+                let mut cx = ServerContext::new(peer, parts);
                 let resp = match service.call(&mut cx, req).await {
                     Ok(resp) => resp,
                     Err(inf) => inf.into_response(),


### PR DESCRIPTION
This PR deletes the original `HttpContext` and creates a new type `ServerContext` using `RpcCx`. The current `HttpContext` is just an alias of `ServerContext`.

Because `HttpContext` is an alias of `ServerContext`, and `ServerContext`, `RpcCx`, `ServerCxInner` all implement `Deref` + `DerefMut`, no breaking changes are expected.