### PR TITLE
chore: fix clippy warnings and check it in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,6 @@ jobs:
         with:
           components: rustfmt
           toolchain: ${{matrix.rust}}
-      # - uses: Swatinem/rust-cache@v1
       - name: Run tests
         run: |
           cargo check --features multiplex
@@ -53,7 +52,6 @@ jobs:
         with:
           components: rustfmt
           toolchain: ${{matrix.rust}}
-      # - uses: Swatinem/rust-cache@v1
       - name: Run tests
         run: |
           cargo check --features multiplex
@@ -110,10 +108,10 @@ jobs:
         with:
           components: rustfmt
           toolchain: ${{matrix.rust}}
-      # - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Format check
         run: |
           cargo fmt -- --check
+          cargo clippy -- --deny warnings

--- a/examples/src/http/example-http-server.rs
+++ b/examples/src/http/example-http-server.rs
@@ -121,11 +121,7 @@ async fn conn_show(conn: ConnectionInfo) -> String {
 
 async fn stream_test() -> Body {
     // build a `Vec<u8>` by a string
-    let resp = "Hello, this is a stream.\n"
-        .as_bytes()
-        .iter()
-        .map(|&ch| ch)
-        .collect::<Vec<u8>>();
+    let resp = "Hello, this is a stream.\n".as_bytes().iter().copied();
     // convert each byte to a `Bytes`
     let stream = stream! {
         for ch in resp.into_iter() {

--- a/volo-build/src/util.rs
+++ b/volo-build/src/util.rs
@@ -61,6 +61,7 @@ pub fn ensure_file(filename: &Path) -> std::io::Result<File> {
         .read(true)
         .write(true)
         .create(true)
+        .truncate(false)
         .open(filename)
 }
 

--- a/volo-grpc/src/lib.rs
+++ b/volo-grpc/src/lib.rs
@@ -3,6 +3,17 @@
 )]
 #![cfg_attr(not(doctest), doc = include_str!("../README.md"))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+// The clippy rule `unconditional_recursion` has a bug on `PartialEq` between `T` and `&T`, or
+// between `T` and something with `Deref<Target = &T>`.
+//
+// An issue has been brought up to the community, and a pull request is being reviewed.
+//
+// Once the issue is fixed, this line of code will be removed.
+//
+// Ref:
+// - https://github.com/rust-lang/rust-clippy/issues/12154
+// - https://github.com/rust-lang/rust-clippy/pull/12177
+#![allow(clippy::unconditional_recursion)]
 
 #[macro_use]
 mod cfg;

--- a/volo-grpc/src/server/meta.rs
+++ b/volo-grpc/src/server/meta.rs
@@ -62,7 +62,7 @@ where
 
                 let metadata = volo_req.metadata_mut();
 
-                status_to_http!(metainfo::METAINFO.with(|metainfo| {
+                let status = metainfo::METAINFO.with(|metainfo| {
                     let mut metainfo = metainfo.borrow_mut();
 
                     // caller
@@ -118,7 +118,8 @@ where
                     }
 
                     Ok::<(), Status>(())
-                }));
+                });
+                status_to_http!(status);
 
                 let volo_resp = match self.inner.call(cx, volo_req).await {
                     Ok(resp) => resp,
@@ -129,7 +130,7 @@ where
 
                 let (mut metadata, extensions, message) = volo_resp.into_parts();
 
-                status_to_http!(metainfo::METAINFO.with(|metainfo| {
+                let status = metainfo::METAINFO.with(|metainfo| {
                     let metainfo = metainfo.borrow_mut();
 
                     // backward
@@ -141,7 +142,8 @@ where
                     }
 
                     Ok::<(), Status>(())
-                }));
+                });
+                status_to_http!(status);
 
                 let mut resp = hyper::Response::new(message);
                 *resp.headers_mut() = metadata.into_headers();

--- a/volo-http/src/body.rs
+++ b/volo-http/src/body.rs
@@ -120,6 +120,10 @@ where
         }
     }
 
+    /// # Safety
+    ///
+    /// It is up to the caller to guarantee that the value really is valid. Using this when the
+    /// content is invalid causes immediate undefined behavior.
     unsafe fn into_string_unchecked(
         self,
     ) -> impl Future<Output = Result<String, ResponseConvertError>> + Send {
@@ -141,6 +145,10 @@ where
         }
     }
 
+    /// # Safety
+    ///
+    /// It is up to the caller to guarantee that the value really is valid. Using this when the
+    /// content is invalid causes immediate undefined behavior.
     unsafe fn into_faststr_unchecked(
         self,
     ) -> impl Future<Output = Result<FastStr, ResponseConvertError>> + Send {

--- a/volo-http/src/client/mod.rs
+++ b/volo-http/src/client/mod.rs
@@ -69,6 +69,12 @@ impl ClientBuilder<Identity, DefaultMkClient, DefaultMakeTransport> {
     }
 }
 
+impl Default for ClientBuilder<Identity, DefaultMkClient, DefaultMakeTransport> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<L, MkC, MkT> ClientBuilder<L, MkC, MkT> {
     pub fn client_maker<MkC2>(self, new_mk_client: MkC2) -> ClientBuilder<L, MkC2, MkT> {
         ClientBuilder {
@@ -244,11 +250,7 @@ impl<S> Client<S> {
     where
         U: IntoUri,
     {
-        Ok(RequestBuilder::new_with_method_and_uri(
-            self,
-            method,
-            uri.into_uri()?,
-        )?)
+        RequestBuilder::new_with_method_and_uri(self, method, uri.into_uri()?)
     }
 
     method_requests!(options);

--- a/volo-http/src/client/request_builder.rs
+++ b/volo-http/src/client/request_builder.rs
@@ -143,7 +143,7 @@ impl<'a, S> RequestBuilder<'a, S> {
     }
 
     pub fn body_ref(&self) -> &Body {
-        &self.request.body()
+        self.request.body()
     }
 }
 
@@ -155,7 +155,7 @@ where
         + 'static,
 {
     pub async fn send(self) -> Result<ClientResponse> {
-        let uri = self.uri.ok_or_else(|| no_uri())?;
+        let uri = self.uri.ok_or_else(no_uri)?;
         let request = self.request;
         let target = match self.target {
             Some(target) => target,
@@ -168,7 +168,7 @@ where
                     ) {
                         return Err(err);
                     }
-                    resolve(&uri).await?.next().ok_or_else(|| bad_host_name())?
+                    resolve(&uri).await?.next().ok_or_else(bad_host_name)?
                 }
             },
         };

--- a/volo-http/src/client/transport.rs
+++ b/volo-http/src/client/transport.rs
@@ -73,7 +73,7 @@ where
             }
         }
 
-        let target = cx.rpc_info.callee().address().ok_or_else(|| no_address())?;
+        let target = cx.rpc_info.callee().address().ok_or_else(no_address)?;
 
         cx.stats.record_transport_start_at();
         let resp = self.request(target, req).await;

--- a/volo-http/src/client/utils.rs
+++ b/volo-http/src/client/utils.rs
@@ -79,10 +79,10 @@ pub fn parse_address(uri: &Uri) -> Result<Address> {
 }
 
 pub async fn resolve(uri: &Uri) -> Result<impl Iterator<Item = Address>> {
-    let host = uri.host().ok_or_else(|| uri_without_host())?.to_owned();
+    let host = uri.host().ok_or_else(uri_without_host)?.to_owned();
     let port = get_port(uri)?;
     match lookup_host((host, port)).await {
-        Ok(addrs) => Ok(addrs.map(move |addr| Address::from(addr))),
+        Ok(addrs) => Ok(addrs.map(Address::from)),
         Err(e) => Err(builder_error(e)),
     }
 }

--- a/volo-http/src/context/client.rs
+++ b/volo-http/src/context/client.rs
@@ -62,17 +62,9 @@ impl ClientStats {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Config {
     pub(crate) host: Host,
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            host: Host::default(),
-        }
-    }
 }
 
 #[derive(Clone, Debug, Default)]

--- a/volo-http/src/extension.rs
+++ b/volo-http/src/extension.rs
@@ -58,7 +58,7 @@ where
     async fn from_context(cx: &mut ServerContext, _state: &S) -> Result<Self, Self::Rejection> {
         cx.extensions()
             .get::<T>()
-            .map(T::clone)
+            .cloned()
             .map(Extension)
             .ok_or(ExtensionRejection::NotExist)
     }

--- a/volo-http/src/extract.rs
+++ b/volo-http/src/extract.rs
@@ -52,12 +52,20 @@ pub struct Form<T>(pub T);
 pub struct MaybeInvalid<T>(Vec<u8>, PhantomData<T>);
 
 impl MaybeInvalid<String> {
+    /// # Safety
+    ///
+    /// It is up to the caller to guarantee that the value really is valid. Using this when the
+    /// content is invalid causes immediate undefined behavior.
     pub unsafe fn assume_valid(self) -> String {
         String::from_utf8_unchecked(self.0)
     }
 }
 
 impl MaybeInvalid<FastStr> {
+    /// # Safety
+    ///
+    /// It is up to the caller to guarantee that the value really is valid. Using this when the
+    /// content is invalid causes immediate undefined behavior.
     pub unsafe fn assume_valid(self) -> FastStr {
         FastStr::from_vec_u8_unchecked(self.0)
     }

--- a/volo-http/src/handler.rs
+++ b/volo-http/src/handler.rs
@@ -97,12 +97,12 @@ where
     type Response = Response;
     type Error = Infallible;
 
-    fn call(
+    async fn call(
         &self,
         cx: &mut ServerContext,
         req: Incoming,
-    ) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send {
-        async { Ok(self.handler.clone().handle(cx, req).await) }
+    ) -> Result<Self::Response, Self::Error> {
+        Ok(self.handler.clone().handle(cx, req).await)
     }
 }
 

--- a/volo-http/src/route.rs
+++ b/volo-http/src/route.rs
@@ -237,16 +237,16 @@ impl Service<ServerContext, Incoming> for MethodRouter {
     type Error = Infallible;
 
     async fn call(&self, cx: &mut ServerContext, req: Incoming) -> Result<Response, Infallible> {
-        let handler = match cx.method() {
-            &Method::OPTIONS => Some(&self.options),
-            &Method::GET => Some(&self.get),
-            &Method::POST => Some(&self.post),
-            &Method::PUT => Some(&self.put),
-            &Method::DELETE => Some(&self.delete),
-            &Method::HEAD => Some(&self.head),
-            &Method::TRACE => Some(&self.trace),
-            &Method::CONNECT => Some(&self.connect),
-            &Method::PATCH => Some(&self.patch),
+        let handler = match *cx.method() {
+            Method::OPTIONS => Some(&self.options),
+            Method::GET => Some(&self.get),
+            Method::POST => Some(&self.post),
+            Method::PUT => Some(&self.put),
+            Method::DELETE => Some(&self.delete),
+            Method::HEAD => Some(&self.head),
+            Method::TRACE => Some(&self.trace),
+            Method::CONNECT => Some(&self.connect),
+            Method::PATCH => Some(&self.patch),
             _ => None,
         };
 

--- a/volo-thrift/src/error.rs
+++ b/volo-thrift/src/error.rs
@@ -281,8 +281,7 @@ impl Message for ApplicationError {
                 }
                 2 => {
                     let remote_type_as_int = protocol.read_i32()?;
-                    let remote_kind: ApplicationErrorKind = TryFrom::try_from(remote_type_as_int)
-                        .unwrap_or(ApplicationErrorKind::UNKNOWN);
+                    let remote_kind: ApplicationErrorKind = From::from(remote_type_as_int);
                     protocol.read_field_end()?;
                     kind = remote_kind;
                 }
@@ -322,8 +321,7 @@ impl Message for ApplicationError {
                 }
                 2 => {
                     let remote_type_as_int = protocol.read_i32().await?;
-                    let remote_kind: ApplicationErrorKind = TryFrom::try_from(remote_type_as_int)
-                        .unwrap_or(ApplicationErrorKind::UNKNOWN);
+                    let remote_kind: ApplicationErrorKind = From::from(remote_type_as_int);
                     protocol.read_field_end().await?;
                     kind = remote_kind;
                 }

--- a/volo-thrift/src/transport/pingpong/server.rs
+++ b/volo-thrift/src/transport/pingpong/server.rs
@@ -18,6 +18,7 @@ use crate::{
     DummyMessage, EntryMessage, Error, ThriftMessage,
 };
 
+#[allow(clippy::too_many_arguments)]
 pub async fn serve<Svc, Req, Resp, E, D, SP>(
     mut encoder: E,
     mut decoder: D,

--- a/volo/src/net/incoming.rs
+++ b/volo/src/net/incoming.rs
@@ -153,7 +153,7 @@ mod unix_helper {
         let mut vi = 0;
 
         for &c in release.as_bytes() {
-            if b'0' <= c && c <= b'9' {
+            if c.is_ascii_digit() {
                 value = (value * 10) + ((c - b'0') as i32);
             } else {
                 values[vi] = value;
@@ -219,14 +219,14 @@ mod unix_helper {
         let file = File::open("/proc/sys/net/core/somaxconn");
         let file = match file {
             Ok(file) => file,
-            Err(_) => return libc::SOMAXCONN as i32,
+            Err(_) => return libc::SOMAXCONN,
         };
         let mut reader = BufReader::new(file);
         let mut line = String::new();
 
         let read_result = reader.read_line(&mut line);
         if read_result.is_err() || line.is_empty() {
-            return libc::SOMAXCONN as i32;
+            return libc::SOMAXCONN;
         }
         let fields = get_fields(&line);
         if let Ok(n) = fields[0].parse() {
@@ -236,7 +236,7 @@ mod unix_helper {
                 n
             }
         } else {
-            libc::SOMAXCONN as i32
+            libc::SOMAXCONN
         }
     }
 


### PR DESCRIPTION
This PR fixes all clippy warnings and add `cargo clippy -- --deny warnings` in GitHub CI.

Note that the clippy lint `unconditional_recursion` was just added a while ago and it has some bugs that we did encounter, e.g. https://github.com/rust-lang/rust-clippy/issues/12154.

For passing CI, `#![allow(clippy::unconditional_recursion)]` has been added into `volo-grpc` temporarily.  Once the issue is fixed, this `allow` will be removed.
