### PR TITLE
chore(volo): use unix `SocketAddr` for unix socket addr

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [nightly, beta, stable]
+        rust: [nightly, stable]
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
@@ -45,7 +45,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [nightly, beta, stable]
+        rust: [nightly, stable]
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
@@ -63,7 +63,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [nightly, beta, stable]
+        rust: [nightly, stable]
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
@@ -82,7 +82,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [nightly, beta, stable]
+        rust: [nightly, stable]
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master

--- a/volo-grpc/src/transport/connect.rs
+++ b/volo-grpc/src/transport/connect.rs
@@ -1,3 +1,5 @@
+#[cfg(target_family = "unix")]
+use std::os::unix::net::SocketAddr as UnixSocketAddr;
 use std::{
     io,
     net::SocketAddr,
@@ -101,16 +103,14 @@ impl tower::Service<hyper::Uri> for Connector {
                             "authority must be hex-encoded path",
                         )
                     })?;
-                    Address::Unix(std::borrow::Cow::Owned(
-                        String::from_utf8(bytes)
-                            .map_err(|_| {
-                                io::Error::new(
-                                    io::ErrorKind::InvalidInput,
-                                    "authority must be valid UTF-8",
-                                )
-                            })?
-                            .into(),
-                    ))
+                    Address::Unix(UnixSocketAddr::from_pathname(
+                        String::from_utf8(bytes).map_err(|_| {
+                            io::Error::new(
+                                io::ErrorKind::InvalidInput,
+                                "authority must be valid UTF-8",
+                            )
+                        })?,
+                    )?)
                 }
                 _ => unimplemented!(),
             };

--- a/volo/src/net/conn.rs
+++ b/volo/src/net/conn.rs
@@ -327,7 +327,7 @@ impl ConnStream {
         match self {
             Self::Tcp(s) => s.peer_addr().map(Address::from).ok(),
             #[cfg(target_family = "unix")]
-            Self::Unix(s) => s.peer_addr().ok().and_then(|s| Address::try_from(s).ok()),
+            Self::Unix(s) => s.peer_addr().map(Address::from).ok(),
             #[cfg(feature = "rustls")]
             Self::Rustls(s) => s.get_ref().0.peer_addr().map(Address::from).ok(),
             #[cfg(feature = "native-tls")]

--- a/volo/src/net/incoming.rs
+++ b/volo/src/net/incoming.rs
@@ -77,7 +77,15 @@ impl MakeIncoming for Address {
                 TcpListener::from_std(listener?).map(DefaultIncoming::from)
             }
             Address::Unix(addr) => {
-                let listener = unix_helper::create_unix_listener_with_max_backlog(addr).await;
+                let listener = unix_helper::create_unix_listener_with_max_backlog(
+                    addr.as_pathname().ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::AddrNotAvailable,
+                            "cannot create unnamed socket",
+                        )
+                    })?,
+                )
+                .await;
                 UnixListener::from_std(listener?).map(DefaultIncoming::from)
             }
         }


### PR DESCRIPTION
The previous `Address` used a path to a unix socket address, but it did not support unnamed socket addresses, such as the incoming address.

To support incoming unix socket addresses, we replace the path in `Address::Unix` with `std::os::unix::net::SocketAddr`.

We also noticed that `tokio` uses a self-written `SocketAddr` because it cannot create a `SocketAddr` from `std`. As a unix socket address, their `struct` is the same, so we can use `std::mem::transmute` to convert them to one another. Because `std::mem::transmute` guarantees that both types have the same size, we can convert it directly and safely.