### PR TITLE
chore(volo-http): refactor context and service for server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3008,7 +3008,7 @@ dependencies = [
 
 [[package]]
 name = "volo-http"
-version = "0.1.18"
+version = "0.2.0-rc.1"
 dependencies = [
  "ahash",
  "bytes",

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-http"
-version = "0.1.18"
+version = "0.2.0-rc.1"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -30,7 +30,7 @@ futures-util.workspace = true
 http.workspace = true
 http-body.workspace = true
 http-body-util.workspace = true
-hyper = { workspace = true, features = ["server", "http1", "http2"] }
+hyper = { workspace = true, features = ["client", "server", "http1"] }
 hyper-util = { workspace = true, features = ["tokio"] }
 matchit.workspace = true
 metainfo.workspace = true

--- a/volo-http/src/body.rs
+++ b/volo-http/src/body.rs
@@ -11,8 +11,10 @@ use faststr::FastStr;
 use futures_util::{ready, Stream};
 use http_body::{Frame, SizeHint};
 use http_body_util::{combinators::BoxBody, BodyExt, Full, StreamBody};
+pub use hyper::body::Incoming;
 use motore::BoxError;
 use pin_project::pin_project;
+#[cfg(any(feature = "serde_json", feature = "sonic_json"))]
 use serde::de::DeserializeOwned;
 
 // The `futures_util::stream::BoxStream` does not have `Sync`

--- a/volo-http/src/cookie.rs
+++ b/volo-http/src/cookie.rs
@@ -1,7 +1,7 @@
 use std::{convert::Infallible, ops::Deref};
 
 pub use cookie::{time::Duration, Cookie};
-use http::{header, HeaderMap};
+use http::{header, request::Parts, HeaderMap};
 
 use crate::{context::ServerContext, extract::FromContext};
 
@@ -34,10 +34,13 @@ impl Deref for CookieJar {
     }
 }
 
-impl<S: Sync> FromContext<S> for CookieJar {
+impl FromContext for CookieJar {
     type Rejection = Infallible;
 
-    async fn from_context(cx: &mut ServerContext, _state: &S) -> Result<Self, Self::Rejection> {
-        Ok(Self::from_header(cx.headers()))
+    async fn from_context(
+        _cx: &mut ServerContext,
+        parts: &mut Parts,
+    ) -> Result<Self, Self::Rejection> {
+        Ok(Self::from_header(&parts.headers))
     }
 }

--- a/volo-http/src/lib.rs
+++ b/volo-http/src/lib.rs
@@ -24,32 +24,15 @@ mod macros;
 #[doc(hidden)]
 pub mod prelude {
     pub use bytes::Bytes;
-    pub use http::{self, HeaderMap, HeaderName, HeaderValue, Method, StatusCode, Uri, Version};
-    pub use hyper::{self, body::Incoming};
+    pub use http;
+    pub use hyper;
     pub use volo::net::Address;
 
     #[cfg(feature = "cookie")]
     pub use crate::cookie::CookieJar;
     #[cfg(any(feature = "serde_json", feature = "sonic_json"))]
     pub use crate::json::Json;
-    pub use crate::{
-        context::{ConnectionInfo, HttpContext, ServerContext},
-        extension::Extension,
-        extract::{Form, MaybeInvalid, Query},
-        param::Params,
-        request::Request,
-        response::Response,
-        route::Router,
-        server::Server,
-    };
-
-    pub type BodyIncoming = Incoming;
-    pub type DynService = motore::service::BoxCloneService<
-        ServerContext,
-        Incoming,
-        Response,
-        std::convert::Infallible,
-    >;
+    pub use crate::{extension::Extension, param::Params, route::Router, server::Server};
 }
 
-pub use prelude::*;
+pub use self::prelude::*;

--- a/volo-http/src/request.rs
+++ b/volo-http/src/request.rs
@@ -2,7 +2,5 @@ use hyper::body::Incoming;
 
 use crate::body::Body;
 
-pub type Request<B = Incoming> = http::Request<B>;
-
 pub type ClientRequest<B = Body> = http::Request<B>;
 pub type ServerRequest<B = Incoming> = http::Request<B>;

--- a/volo-http/src/response/mod.rs
+++ b/volo-http/src/response/mod.rs
@@ -5,7 +5,5 @@ use hyper::body::Incoming;
 pub use self::into_response::IntoResponse;
 use crate::body::Body;
 
-pub type Response<B = Body> = http::Response<B>;
-
 pub type ServerResponse<B = Body> = http::Response<B>;
 pub type ClientResponse<B = Incoming> = http::Response<B>;


### PR DESCRIPTION
This PR is for server side.

1. Remove `state` fully. `FromContext` and `FromRequest` do not need generic type `S` now
2. Remove `Parts` from `ServerContext`
3. Update args of `from_context` from `(&mut ServerContext, &State)` to `(&mut ServerContext, &mut Parts)`
4. Update args of `from_context` from `(&mut ServerContext, ServerRequest, State)` to `(&mut ServerContext, Parts, Incoming)`
5. Update all service from `Service<ServerContext, Incoming>` to `Service<ServerContext, ServerRequest>`
6. Rename `DynService` to `Route`

This PR also updates `volo-http` to `0.2.0-rc1`