### PR TITLE
feat: refactor error to be more clear and maintainable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,7 +70,7 @@ jobs:
         with:
           components: rustfmt
           toolchain: ${{matrix.rust}}
-      - uses: Swatinem/rust-cache@v1
+      # - uses: Swatinem/rust-cache@v1
       - name: Run tests
         run: |
           cargo check --features multiplex
@@ -89,7 +89,7 @@ jobs:
         with:
           components: rustfmt
           toolchain: ${{matrix.rust}}
-      - uses: Swatinem/rust-cache@v1
+      # - uses: Swatinem/rust-cache@v1
       - name: Run tests
         run: |
           cargo check --features multiplex

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -71,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
@@ -135,7 +135,7 @@ checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -157,7 +157,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -168,7 +168,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -212,15 +212,9 @@ checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "d32a994c2b3ca201d9b263612a374263f05e7adde37c4707f693dcd375076d1f"
 
 [[package]]
 name = "bytes"
@@ -249,9 +243,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -261,9 +255,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -271,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
 dependencies = [
  "anstream",
  "anstyle",
@@ -284,21 +278,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "colorchoice"
@@ -354,9 +348,9 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
@@ -457,9 +451,9 @@ checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "encoding_rs"
@@ -536,7 +530,7 @@ dependencies = [
  "motore",
  "pilota",
  "rustls 0.22.2",
- "rustls-pemfile 2.0.0",
+ "rustls-pemfile 2.1.0",
  "rustls-pki-types",
  "serde",
  "tokio",
@@ -680,7 +674,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -714,15 +708,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,9 +726,9 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "git2"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf97ba92db08df386e10c8ede66a2a0369bd277090afd8710e19e38de9ec0cd"
+checksum = "1b3ba52851e73b46a4c3df1d89343741112003f0f6f13beb0dfac9e457c3fdcd"
 dependencies = [
  "bitflags 2.4.2",
  "libc",
@@ -764,7 +749,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.11",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -783,7 +768,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 1.0.0",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -819,9 +804,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
+checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
 
 [[package]]
 name = "hex"
@@ -1005,9 +990,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.59"
+version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1048,9 +1033,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -1083,12 +1068,12 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
  "hermit-abi",
- "rustix",
+ "libc",
  "windows-sys 0.52.0",
 ]
 
@@ -1109,18 +1094,18 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
+checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1139,9 +1124,9 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.16.1+1.7.1"
+version = "0.16.2+1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a2bb3680b094add03bb3732ec520ece34da31a8cd2d633d1389d0f0fb60d0c"
+checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
 dependencies = [
  "cc",
  "libc",
@@ -1268,9 +1253,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
@@ -1383,9 +1368,9 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
 ]
@@ -1418,7 +1403,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -1465,7 +1450,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -1476,9 +1461,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.2.2+3.2.1"
+version = "300.2.3+3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bbfad0063610ac26ee79f7484739e2b07555a75c42453b89263830b5c8103bc"
+checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
 dependencies = [
  "cc",
 ]
@@ -1597,7 +1582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
 ]
 
 [[package]]
@@ -1630,7 +1615,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -1644,9 +1629,8 @@ dependencies = [
 
 [[package]]
 name = "pilota"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9c5ca077f7e8a8a92c770871f3904fd6b6db3d1dac76fc7f40169b28571ec7"
+version = "0.11.0"
+source = "git+https://github.com/PureWhiteWu/pilota?branch=refactor/error#bb3f707db758be0c7ed5b82c1090937f25479e59"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1666,14 +1650,13 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed60c849bbcb729248832e683486092305bdea3c859e926cb50baaaa25cbcb6b"
+version = "0.11.0"
+source = "git+https://github.com/PureWhiteWu/pilota?branch=refactor/error#bb3f707db758be0c7ed5b82c1090937f25479e59"
 dependencies = [
+ "ahash",
  "anyhow",
  "dashmap",
  "faststr",
- "fxhash",
  "heck 0.4.1",
  "itertools",
  "lazy_static",
@@ -1687,11 +1670,12 @@ dependencies = [
  "protobuf2",
  "quote",
  "rayon",
+ "rustc-hash",
  "salsa",
  "scoped-tls",
  "serde",
  "serde_yaml",
- "syn 2.0.48",
+ "syn 2.0.49",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -1699,9 +1683,8 @@ dependencies = [
 
 [[package]]
 name = "pilota-thrift-parser"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a51f9d564726ae206679be846cb0277d109d5183815276283b71eed12231b164"
+version = "0.11.0"
+source = "git+https://github.com/PureWhiteWu/pilota?branch=refactor/error#bb3f707db758be0c7ed5b82c1090937f25479e59"
 dependencies = [
  "nom",
 ]
@@ -1723,7 +1706,7 @@ checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -1740,9 +1723,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "powerfmt"
@@ -1772,7 +1755,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.21.1",
 ]
 
 [[package]]
@@ -1989,7 +1972,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -2030,9 +2013,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.30"
+version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
  "bitflags 2.4.2",
  "errno",
@@ -2062,7 +2045,7 @@ dependencies = [
  "log",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.1",
+ "rustls-webpki 0.102.2",
  "subtle",
  "zeroize",
 ]
@@ -2078,9 +2061,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
+checksum = "3c333bb734fcdedcea57de1602543590f545f127dc8b533324318fd492c5c70b"
 dependencies = [
  "base64",
  "rustls-pki-types",
@@ -2088,9 +2071,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9d979b3ce68192e42760c7810125eb6cf2ea10efae545a156063e61f314e2a"
+checksum = "048a63e5b3ac996d78d402940b5fa47973d2d080c6c6fffa1d0f19c4445310b7"
 
 [[package]]
 name = "rustls-webpki"
@@ -2104,9 +2087,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.1"
+version = "0.102.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4ca26037c909dedb327b48c3327d0ba91d3dd3c4e05dad328f210ffb68e95b"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2234,7 +2217,7 @@ checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -2244,7 +2227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20e1066e1cfa6692a722cf40386a2caec36da5ddc4a2c16df592f0f609677e8c"
 dependencies = [
  "form_urlencoded",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "itoa",
  "ryu",
  "serde",
@@ -2288,7 +2271,7 @@ version = "0.9.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adf8a49373e98a4c5f0ceb5d05aa7c648d75f63774981ed95b7c7443bbd50c6e"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "itoa",
  "ryu",
  "serde",
@@ -2379,9 +2362,9 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "subtle"
@@ -2402,9 +2385,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "915aea9e586f80826ee59f8453c1101f9d1c4b3964cd2460185ee8e299ada496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2440,13 +2423,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.9.0"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall 0.4.1",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -2472,22 +2454,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -2502,9 +2484,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe80ced77cbfb4cb91a94bf72b378b4b6791a0d9b7f09d0be747d1bdff4e68bd"
+checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
 dependencies = [
  "deranged",
  "itoa",
@@ -2548,9 +2530,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.35.1"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2573,7 +2555,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -2635,14 +2617,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6a4b9e8023eb94392d3dca65d717c53abc5dad49c07cb65bb8fcd87115fa325"
+checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.22.6",
 ]
 
 [[package]]
@@ -2660,11 +2642,22 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
+ "toml_datetime",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
+dependencies = [
+ "indexmap 2.2.3",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.6.1",
 ]
 
 [[package]]
@@ -2719,7 +2712,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -2790,9 +2783,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -2822,20 +2815,21 @@ dependencies = [
 
 [[package]]
 name = "ureq"
-version = "2.9.1"
+version = "2.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cdd25c339e200129fe4de81451814e5228c9b771d57378817d6117cc2b3f97"
+checksum = "11f214ce18d8b2cbe84ed3aa6486ed3f5b285cf8d8fbdbce9f3f767a724adc35"
 dependencies = [
  "base64",
  "flate2",
  "log",
  "once_cell",
- "rustls 0.21.10",
- "rustls-webpki 0.101.7",
+ "rustls 0.22.2",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
  "serde",
  "serde_json",
  "url",
- "webpki-roots",
+ "webpki-roots 0.26.1",
 ]
 
 [[package]]
@@ -2927,7 +2921,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_yaml",
- "syn 2.0.48",
+ "syn 2.0.49",
  "tempfile",
  "url_path",
  "volo",
@@ -3102,9 +3096,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
+checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3112,24 +3106,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
+checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
+checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3139,9 +3133,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
+checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3149,28 +3143,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
+checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
+checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
 name = "web-sys"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
+checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3178,9 +3172,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.3"
+version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "which"
@@ -3368,9 +3371,18 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.36"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818ce546a11a9986bc24f93d0cdf38a8a1a400f1473ea8c82e59f6e0ffab9249"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d90f4e0f530c4c69f62b80d839e9ef3855edc9cba471a160c4d692deed62b401"
 dependencies = [
  "memchr",
 ]
@@ -3402,7 +3414,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,7 +1630,7 @@ dependencies = [
 [[package]]
 name = "pilota"
 version = "0.11.0"
-source = "git+https://github.com/PureWhiteWu/pilota?branch=refactor/error#bb3f707db758be0c7ed5b82c1090937f25479e59"
+source = "git+https://github.com/cloudwego/pilota?branch=main#9bc9ae3731b97881533bb563daa02cd5c615f08e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1651,7 +1651,7 @@ dependencies = [
 [[package]]
 name = "pilota-build"
 version = "0.11.0"
-source = "git+https://github.com/PureWhiteWu/pilota?branch=refactor/error#bb3f707db758be0c7ed5b82c1090937f25479e59"
+source = "git+https://github.com/cloudwego/pilota?branch=main#9bc9ae3731b97881533bb563daa02cd5c615f08e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1684,7 +1684,7 @@ dependencies = [
 [[package]]
 name = "pilota-thrift-parser"
 version = "0.11.0"
-source = "git+https://github.com/PureWhiteWu/pilota?branch=refactor/error#bb3f707db758be0c7ed5b82c1090937f25479e59"
+source = "git+https://github.com/cloudwego/pilota?branch=main#9bc9ae3731b97881533bb563daa02cd5c615f08e"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,12 @@ repository = "https://github.com/cloudwego/volo"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
-pilota = "0.10"
-pilota-build = "0.10"
-pilota-thrift-parser = "0.10"
-# pilota = { git = "https://github.com/cloudwego/pilota", branch = "main" }
-# pilota-build = { git = "https://github.com/cloudwego/pilota", branch = "main" }
-# pilota-thrift-parser = { git = "https://github.com/cloudwego/pilota", branch = "main" }
+# pilota = "0.10"
+# pilota-build = "0.10"
+# pilota-thrift-parser = "0.10"
+pilota = { git = "https://github.com/PureWhiteWu/pilota", branch = "refactor/error" }
+pilota-build = { git = "https://github.com/PureWhiteWu/pilota", branch = "refactor/error" }
+pilota-thrift-parser = { git = "https://github.com/PureWhiteWu/pilota", branch = "refactor/error" }
 
 motore = "0.4"
 # motore = { git = "https://github.com/cloudwego/motore", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ license = "MIT OR Apache-2.0"
 # pilota = "0.10"
 # pilota-build = "0.10"
 # pilota-thrift-parser = "0.10"
-pilota = { git = "https://github.com/PureWhiteWu/pilota", branch = "refactor/error" }
-pilota-build = { git = "https://github.com/PureWhiteWu/pilota", branch = "refactor/error" }
-pilota-thrift-parser = { git = "https://github.com/PureWhiteWu/pilota", branch = "refactor/error" }
+pilota = { git = "https://github.com/cloudwego/pilota", branch = "main" }
+pilota-build = { git = "https://github.com/cloudwego/pilota", branch = "main" }
+pilota-thrift-parser = { git = "https://github.com/cloudwego/pilota", branch = "main" }
 
 motore = "0.4"
 # motore = { git = "https://github.com/cloudwego/motore", branch = "main" }

--- a/examples/src/hello/thrift_server.rs
+++ b/examples/src/hello/thrift_server.rs
@@ -6,7 +6,7 @@ impl volo_gen::thrift_gen::hello::HelloService for S {
     async fn hello(
         &self,
         req: volo_gen::thrift_gen::hello::HelloRequest,
-    ) -> Result<volo_gen::thrift_gen::hello::HelloResponse, volo_thrift::AnyhowError> {
+    ) -> Result<volo_gen::thrift_gen::hello::HelloResponse, volo_thrift::ServerError> {
         let resp = volo_gen::thrift_gen::hello::HelloResponse {
             message: format!("Hello, {}!", req.name).into(),
         };

--- a/examples/src/multiplex/thrift_server.rs
+++ b/examples/src/multiplex/thrift_server.rs
@@ -6,7 +6,7 @@ impl volo_gen::thrift_gen::hello::HelloService for S {
     async fn hello(
         &self,
         req: volo_gen::thrift_gen::hello::HelloRequest,
-    ) -> Result<volo_gen::thrift_gen::hello::HelloResponse, volo_thrift::AnyhowError> {
+    ) -> Result<volo_gen::thrift_gen::hello::HelloResponse, volo_thrift::ServerError> {
         let resp = volo_gen::thrift_gen::hello::HelloResponse {
             message: format!("Hello, {}!", req.name).into(),
         };

--- a/examples/src/unknown/thrift_server.rs
+++ b/examples/src/unknown/thrift_server.rs
@@ -6,7 +6,7 @@ impl volo_gen::thrift_gen::echo_unknown::EchoService for S {
     async fn hello(
         &self,
         req: volo_gen::thrift_gen::echo_unknown::EchoRequest,
-    ) -> Result<volo_gen::thrift_gen::echo_unknown::EchoResponse, volo_thrift::AnyhowError> {
+    ) -> Result<volo_gen::thrift_gen::echo_unknown::EchoResponse, volo_thrift::ServerError> {
         let resp = volo_gen::thrift_gen::echo_unknown::EchoResponse {
             name: format!("{}", req.name).into(),
             echo_union: req.echo_union,

--- a/volo-build/src/thrift_backend.rs
+++ b/volo-build/src/thrift_backend.rs
@@ -409,8 +409,10 @@ impl pilota_build::CodegenBackend for VoloThriftBackend {
             }).join("");
 
             let mut resp_type_str = format!("{resp_type}");
+            let mut resp_str = "Ok(resp)";
             if !convert_exceptions.is_empty() {
                 resp_type_str = format!("::volo_thrift::MaybeException<{resp_type_str}, {exception}>");
+                resp_str = "Ok(::volo_thrift::MaybeException::Ok(resp))";
             }
             client_methods.push(format! {
                 r#"pub async fn {name}(&self {req_fields}) -> ::std::result::Result<{resp_type_str}, ::volo_thrift::ClientError> {{
@@ -420,7 +422,7 @@ impl pilota_build::CodegenBackend for VoloThriftBackend {
                     let mut cx = self.0.make_cx("{method_name_str}", {oneway});
                     #[allow(unreachable_patterns)]
                     let resp = match ::volo::service::Service::call(&self.0, &mut cx, req).await? {{
-                        Some({res_recv_name}::{enum_variant}({result_path}::Ok(resp))) => Ok(resp),{convert_exceptions}
+                        Some({res_recv_name}::{enum_variant}({result_path}::Ok(resp))) => {resp_str},{convert_exceptions}
                         {none},
                         _ => unreachable!()
                     }};
@@ -442,7 +444,7 @@ impl pilota_build::CodegenBackend for VoloThriftBackend {
                     let mut cx = self.0.make_cx("{method_name_str}", {oneway});
                     #[allow(unreachable_patterns)]
                     let resp = match ::volo::client::OneShotService::call(self.0, &mut cx, req).await? {{
-                        Some({res_recv_name}::{enum_variant}({result_path}::Ok(resp))) => Ok(resp),{convert_exceptions}
+                        Some({res_recv_name}::{enum_variant}({result_path}::Ok(resp))) => {resp_str},{convert_exceptions}
                         {none},
                         _ => unreachable!()
                     }};

--- a/volo-build/src/thrift_backend.rs
+++ b/volo-build/src/thrift_backend.rs
@@ -72,7 +72,7 @@ impl VoloThriftBackend {
                     r#"Ok(match &*msg_ident.name {{
                         {match_methods}
                         _ => {{
-                            return Err(::pilota::thrift::DecodeError::new(::pilota::thrift::DecodeErrorKind::UnknownMethod,  format!("unknown method {{}}", msg_ident.name)));
+                            return Err(::pilota::thrift::new_application_exception(::pilota::thrift::ApplicationExceptionKind::UNKNOWN_METHOD,  format!("unknown method {{}}", msg_ident.name)));
                         }},
                     }})"#
                 }
@@ -93,20 +93,20 @@ impl VoloThriftBackend {
 
             format! {
                 r#"impl ::volo_thrift::EntryMessage for {req_recv_name} {{
-                    fn encode<T: ::pilota::thrift::TOutputProtocol>(&self, protocol: &mut T) -> ::core::result::Result<(), ::pilota::thrift::EncodeError> {{
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(&self, protocol: &mut T) -> ::core::result::Result<(), ::pilota::thrift::ThriftException> {{
                         match self {{
                             {match_encode}
                         }}
                     }}
 
-                    fn decode<T: ::pilota::thrift::TInputProtocol>(protocol: &mut T, msg_ident: &::pilota::thrift::TMessageIdentifier) -> ::core::result::Result<Self, ::pilota::thrift::DecodeError> {{
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(protocol: &mut T, msg_ident: &::pilota::thrift::TMessageIdentifier) -> ::core::result::Result<Self, ::pilota::thrift::ThriftException> {{
                        {recv_decode}
                     }}
 
                     async fn decode_async<T: ::pilota::thrift::TAsyncInputProtocol>(
                         protocol: &mut T,
                         msg_ident: &::pilota::thrift::TMessageIdentifier
-                    ) -> ::core::result::Result<Self, ::pilota::thrift::DecodeError>
+                    ) -> ::core::result::Result<Self, ::pilota::thrift::ThriftException>
                         {{
                             {recv_decode_async}
                         }}
@@ -119,20 +119,20 @@ impl VoloThriftBackend {
                 }}
 
                 impl ::volo_thrift::EntryMessage for {req_send_name} {{
-                    fn encode<T: ::pilota::thrift::TOutputProtocol>(&self, protocol: &mut T) -> ::core::result::Result<(), ::pilota::thrift::EncodeError> {{
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(&self, protocol: &mut T) -> ::core::result::Result<(), ::pilota::thrift::ThriftException> {{
                         match self {{
                             {match_encode}
                         }}
                     }}
 
-                    fn decode<T: ::pilota::thrift::TInputProtocol>(protocol: &mut T, msg_ident: &::pilota::thrift::TMessageIdentifier) -> ::core::result::Result<Self, ::pilota::thrift::DecodeError> {{
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(protocol: &mut T, msg_ident: &::pilota::thrift::TMessageIdentifier) -> ::core::result::Result<Self, ::pilota::thrift::ThriftException> {{
                        {send_decode}
                     }}
 
                     async fn decode_async<T: ::pilota::thrift::TAsyncInputProtocol>(
                         protocol: &mut T,
                         msg_ident: &::pilota::thrift::TMessageIdentifier
-                    ) -> ::core::result::Result<Self, ::pilota::thrift::DecodeError>
+                    ) -> ::core::result::Result<Self, ::pilota::thrift::ThriftException>
                         {{
                             {send_decode_async}
                         }}
@@ -174,7 +174,7 @@ impl VoloThriftBackend {
                     r#"Ok(match &*msg_ident.name {{
                         {match_methods}
                         _ => {{
-                            return Err(::pilota::thrift::DecodeError::new(::pilota::thrift::DecodeErrorKind::UnknownMethod,  format!("unknown method {{}}", msg_ident.name)));
+                            return Err(::pilota::thrift::new_application_exception(::pilota::thrift::ApplicationExceptionKind::UNKNOWN_METHOD,  format!("unknown method {{}}", msg_ident.name)));
                         }},
                     }})"#
                 )
@@ -194,20 +194,20 @@ impl VoloThriftBackend {
             let recv_decode_async = mk_decode(true, false);
             format! {
                 r#"impl ::volo_thrift::EntryMessage for {res_recv_name} {{
-                    fn encode<T: ::pilota::thrift::TOutputProtocol>(&self, protocol: &mut T) -> ::core::result::Result<(), ::pilota::thrift::EncodeError> {{
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(&self, protocol: &mut T) -> ::core::result::Result<(), ::pilota::thrift::ThriftException> {{
                         match self {{
                             {match_encode}
                         }}
                     }}
 
-                    fn decode<T: ::pilota::thrift::TInputProtocol>(protocol: &mut T, msg_ident: &::pilota::thrift::TMessageIdentifier) -> ::core::result::Result<Self, ::pilota::thrift::DecodeError> {{
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(protocol: &mut T, msg_ident: &::pilota::thrift::TMessageIdentifier) -> ::core::result::Result<Self, ::pilota::thrift::ThriftException> {{
                        {recv_decode}
                     }}
 
                     async fn decode_async<T: ::pilota::thrift::TAsyncInputProtocol>(
                         protocol: &mut T,
                         msg_ident: &::pilota::thrift::TMessageIdentifier,
-                    ) -> ::core::result::Result<Self, ::pilota::thrift::DecodeError>
+                    ) -> ::core::result::Result<Self, ::pilota::thrift::ThriftException>
                         {{
                             {recv_decode_async}
                         }}
@@ -220,20 +220,20 @@ impl VoloThriftBackend {
                 }}
 
                 impl ::volo_thrift::EntryMessage for {res_send_name} {{
-                    fn encode<T: ::pilota::thrift::TOutputProtocol>(&self, protocol: &mut T) -> ::core::result::Result<(), ::pilota::thrift::EncodeError> {{
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(&self, protocol: &mut T) -> ::core::result::Result<(), ::pilota::thrift::ThriftException> {{
                         match self {{
                             {match_encode}
                         }}
                     }}
 
-                    fn decode<T: ::pilota::thrift::TInputProtocol>(protocol: &mut T, msg_ident: &::pilota::thrift::TMessageIdentifier) -> ::core::result::Result<Self, ::pilota::thrift::DecodeError> {{
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(protocol: &mut T, msg_ident: &::pilota::thrift::TMessageIdentifier) -> ::core::result::Result<Self, ::pilota::thrift::ThriftException> {{
                        {send_decode}
                     }}
 
                     async fn decode_async<T: ::pilota::thrift::TAsyncInputProtocol>(
                         protocol: &mut T,
                         msg_ident: &::pilota::thrift::TMessageIdentifier,
-                    ) -> ::core::result::Result<Self, ::pilota::thrift::DecodeError>
+                    ) -> ::core::result::Result<Self, ::pilota::thrift::ThriftException>
                         {{
                             {send_decode_async}
                         }}
@@ -392,6 +392,7 @@ impl pilota_build::CodegenBackend for VoloThriftBackend {
             let exception = if let Some(p) = &m.exceptions {
                 self.cx().cur_related_item_path(p.did)
             } else {
+                // only placeholder, should never be used
                 "std::convert::Infallible".into()
             };
 
@@ -401,14 +402,18 @@ impl pilota_build::CodegenBackend for VoloThriftBackend {
                 match &*e {
                     rir::Item::Enum(e) => e.variants.iter().map(|v| {
                         let name = self.cx().rust_name(v.did);
-                        format!("Some({res_recv_name}::{enum_variant}({result_path}::{name}(err))) => Err(::volo_thrift::error::ResponseError::UserException({exception}::{name}(err))),")
+                        format!("Some({res_recv_name}::{enum_variant}({result_path}::{name}(ex))) => Err(::volo_thrift::MaybeException::Exception({exception}::{name}(ex))),")
                     }).collect::<Vec<_>>(),
                     _ => panic!()
                 }
             }).join("");
 
+            let mut resp_type_str = format!("{resp_type}");
+            if !convert_exceptions.is_empty() {
+                resp_type_str = format!("::volo_thrift::MaybeException<{resp_type_str}, {exception}>");
+            }
             client_methods.push(format! {
-                r#"pub async fn {name}(&self {req_fields}) -> ::std::result::Result<{resp_type}, ::volo_thrift::error::ResponseError<{exception}>> {{
+                r#"pub async fn {name}(&self {req_fields}) -> ::std::result::Result<{resp_type_str}, ::volo_thrift::ClientError> {{
                     let req = {req_send_name}::{enum_variant}({anonymous_args_send_name} {{
                         {req_field_names}
                     }});
@@ -430,7 +435,7 @@ impl pilota_build::CodegenBackend for VoloThriftBackend {
             });
 
             oneshot_client_methods.push(format! {
-                r#"pub async fn {name}(self {req_fields}) -> ::std::result::Result<{resp_type}, ::volo_thrift::error::ResponseError<{exception}>> {{
+                r#"pub async fn {name}(self {req_fields}) -> ::std::result::Result<{resp_type_str}, ::volo_thrift::ClientError> {{
                     let req = {req_send_name}::{enum_variant}({anonymous_args_send_name} {{
                         {req_field_names}
                     }});
@@ -470,12 +475,6 @@ impl pilota_build::CodegenBackend for VoloThriftBackend {
                 let has_exception = m.exceptions.is_some();
                 let method_result_path = self.method_result_path(&service_name, m, false);
 
-                let exception: FastStr = if let Some(p) = &m.exceptions {
-                    self.cx().cur_related_item_path(p.did)
-                } else {
-                    "::volo_thrift::error::DummyError".into()
-                };
-
                 let convert_exceptions = m
                     .exceptions
                     .iter()
@@ -486,8 +485,9 @@ impl pilota_build::CodegenBackend for VoloThriftBackend {
                             .iter()
                             .map(|v| {
                                 let name = self.cx().rust_name(v.did);
+                                let exception = self.cx().cur_related_item_path(m.exceptions.as_ref().expect("must be exception here").did);
                                 format!(
-                                "Err(::volo_thrift::error::UserError::UserException({exception}::{name}(err))) => {method_result_path}::{name}(err),"
+                                "Ok(::volo_thrift::MaybeException::Exception({exception}::{name}(ex))) => {method_result_path}::{name}(ex),"
                             )
                             })
                             .collect::<Vec<_>>(),
@@ -498,16 +498,16 @@ impl pilota_build::CodegenBackend for VoloThriftBackend {
                 if has_exception {
                     format! {
                         r#"match self.inner.{name}({args}).await {{
-                        Ok(resp) => {method_result_path}::Ok(resp),
+                        Ok(::volo_thrift::MaybeException::Ok(resp)) => {method_result_path}::Ok(resp),
                         {convert_exceptions}
-                        Err(::volo_thrift::error::UserError::Other(err)) => return Err(::volo_thrift::Error::Application(::volo_thrift::error::ApplicationError::new(::volo_thrift::error::ApplicationErrorKind::INTERNAL_ERROR, err.to_string()))),
+                        Err(err) => return Err(err),
                     }}"#
                     }
                 } else {
                     format! {
                         r#"match self.inner.{name}({args}).await {{
                         Ok(resp) => {method_result_path}::Ok(resp),
-                        Err(err) => return Err(::volo_thrift::Error::Anyhow(err)),
+                        Err(err) => return Err(err),
                     }}"#
                     }
                 }
@@ -530,7 +530,7 @@ impl pilota_build::CodegenBackend for VoloThriftBackend {
 
             pub struct {mk_client_name};
 
-            pub type {client_name} = {generic_client_name}<::volo::service::BoxCloneService<::volo_thrift::context::ClientContext, {req_send_name}, ::std::option::Option<{res_recv_name}>, ::volo_thrift::Error>>;
+            pub type {client_name} = {generic_client_name}<::volo::service::BoxCloneService<::volo_thrift::context::ClientContext, {req_send_name}, ::std::option::Option<{res_recv_name}>, ::volo_thrift::ClientError>>;
 
             impl<S> ::volo::client::MkClient<::volo_thrift::Client<S>> for {mk_client_name} {{
                 type Target = {generic_client_name}<S>;
@@ -544,7 +544,7 @@ impl pilota_build::CodegenBackend for VoloThriftBackend {
 
             pub struct {oneshot_client_name}<S>(pub ::volo_thrift::Client<S>);
 
-            impl<S: ::volo::service::Service<::volo_thrift::context::ClientContext, {req_send_name}, Response = ::std::option::Option<{res_recv_name}>, Error = ::volo_thrift::Error> + Send + Sync + 'static> {generic_client_name}<S> {{
+            impl<S: ::volo::service::Service<::volo_thrift::context::ClientContext, {req_send_name}, Response = ::std::option::Option<{res_recv_name}>, Error = ::volo_thrift::ClientError> + Send + Sync + 'static> {generic_client_name}<S> {{
                 pub fn with_callopt<Opt: ::volo::client::Apply<::volo_thrift::context::ClientContext>>(self, opt: Opt) -> {oneshot_client_name}<::volo::client::WithOptService<S, Opt>> {{
                     {oneshot_client_name}(self.0.with_opt(opt))
                 }}
@@ -552,7 +552,7 @@ impl pilota_build::CodegenBackend for VoloThriftBackend {
                 {client_methods}
             }}
 
-            impl<S: ::volo::client::OneShotService<::volo_thrift::context::ClientContext, {req_send_name}, Response = ::std::option::Option<{res_recv_name}>, Error = ::volo_thrift::Error> + Send + Sync + 'static> {oneshot_client_name}<S> {{
+            impl<S: ::volo::client::OneShotService<::volo_thrift::context::ClientContext, {req_send_name}, Response = ::std::option::Option<{res_recv_name}>, Error = ::volo_thrift::ClientError> + Send + Sync + 'static> {oneshot_client_name}<S> {{
                 {oneshot_client_methods}
             }}
 
@@ -586,7 +586,7 @@ impl pilota_build::CodegenBackend for VoloThriftBackend {
 
             impl<T> ::volo::service::Service<::volo_thrift::context::ServerContext, {req_recv_name}> for {server_name}<T> where T: {service_name} + Send + Sync + 'static {{
                 type Response = {res_send_name};
-                type Error = ::volo_thrift::Error;
+                type Error = ::volo_thrift::ServerError;
 
                 async fn call<'s, 'cx>(&'s self, _cx: &'cx mut ::volo_thrift::context::ServerContext, req: {req_recv_name}) -> ::std::result::Result<Self::Response, Self::Error> {{
                     match req {{
@@ -620,16 +620,14 @@ impl pilota_build::CodegenBackend for VoloThriftBackend {
             })
             .join(",");
 
-        let exception: FastStr = if let Some(p) = &method.exceptions {
+        if let Some(p) = &method.exceptions {
             let exception = self.inner.cur_related_item_path(p.did);
-            format! {"::volo_thrift::error::UserError<{exception}>" }.into()
-        } else {
-            "::volo_thrift::AnyhowError".into()
-        };
+            ret_ty = format!("::volo_thrift::MaybeException<{ret_ty}, {exception}>");
+        }
 
         format!(
             "fn {name}(&self, {args}) -> impl ::std::future::Future<Output = \
-             ::core::result::Result<{ret_ty}, {exception}>> + Send;"
+             ::core::result::Result<{ret_ty}, ::volo_thrift::ServerError>> + Send;"
         )
     }
 
@@ -662,15 +660,13 @@ impl pilota_build::CodegenBackend for VoloThriftBackend {
             })
             .join(",");
 
-        let exception: FastStr = if let Some(p) = &method.exceptions {
-            let exception = self.inner.item_path(p.did).join("::");
-            format! {"::volo_thrift::error::UserError<volo_gen::{exception}>" }.into()
-        } else {
-            "::volo_thrift::AnyhowError".into()
-        };
+        if let Some(p) = &method.exceptions {
+            let exception = self.inner.cur_related_item_path(p.did);
+            ret_ty = format!("::volo_thrift::MaybeException<{ret_ty}, {exception}>");
+        }
 
         format!(
-            r#"async fn {name}(&self, {args}) -> ::core::result::Result<{ret_ty}, {exception}>
+            r#"async fn {name}(&self, {args}) -> ::core::result::Result<{ret_ty}, ::volo_thrift::ServerError>
             {{
                 Ok(Default::default())
             }}"#

--- a/volo-build/src/thrift_backend.rs
+++ b/volo-build/src/thrift_backend.rs
@@ -402,7 +402,7 @@ impl pilota_build::CodegenBackend for VoloThriftBackend {
                 match &*e {
                     rir::Item::Enum(e) => e.variants.iter().map(|v| {
                         let name = self.cx().rust_name(v.did);
-                        format!("Some({res_recv_name}::{enum_variant}({result_path}::{name}(ex))) => Err(::volo_thrift::MaybeException::Exception({exception}::{name}(ex))),")
+                        format!("Some({res_recv_name}::{enum_variant}({result_path}::{name}(ex))) => Ok(::volo_thrift::MaybeException::Exception({exception}::{name}(ex))),")
                     }).collect::<Vec<_>>(),
                     _ => panic!()
                 }

--- a/volo-grpc/src/lib.rs
+++ b/volo-grpc/src/lib.rs
@@ -13,7 +13,7 @@
 // Ref:
 // - https://github.com/rust-lang/rust-clippy/issues/12154
 // - https://github.com/rust-lang/rust-clippy/pull/12177
-#![allow(clippy::unconditional_recursion)]
+#![allow(unconditional_recursion)]
 
 #[macro_use]
 mod cfg;

--- a/volo-thrift/src/client/layer/timeout.rs
+++ b/volo-thrift/src/client/layer/timeout.rs
@@ -14,12 +14,11 @@ pub struct Timeout<S> {
 impl<Req, S> Service<ClientContext, Req> for Timeout<S>
 where
     Req: 'static + Send,
-    S: Service<ClientContext, Req> + 'static + Send + Sync,
-    S::Error: Send + Sync + Into<crate::Error>,
+    S: Service<ClientContext, Req, Error = crate::ClientError> + 'static + Send + Sync,
 {
     type Response = S::Response;
 
-    type Error = crate::Error;
+    type Error = S::Error;
 
     async fn call<'s, 'cx>(
         &'s self,
@@ -40,7 +39,11 @@ where
                             duration
                         );
                         warn!(msg);
-                        Err(crate::BasicError::new(crate::BasicErrorKind::RpcTimeout, msg).into())
+                        Err(crate::ApplicationException::new(
+                            crate::ApplicationExceptionKind::INTERNAL_ERROR,
+                            msg,
+                        )
+                        .into())
                     }
                 }
             }

--- a/volo-thrift/src/codec/default/mod.rs
+++ b/volo-thrift/src/codec/default/mod.rs
@@ -143,7 +143,7 @@ impl<E: ZeroCopyEncoder, W: AsyncWrite + Unpin + Send + Sync + 'static> Encoder
             .map_err(|e| {
                 // record the error time
                 cx.stats_mut().record_encode_end_at();
-                ThriftException::from(e)
+                e
             });
         if write_result.is_ok() {
             cx.stats_mut().record_encode_end_at();
@@ -219,7 +219,7 @@ impl<D: ZeroCopyDecoder, R: AsyncRead + Unpin + Send + Sync + 'static> Decoder
         cx.stats_mut().record_decode_end_at();
         trace!("[VOLO] thrift codec decode message cost: {:?}", end - start);
 
-        Ok(res?)
+        res
     }
 }
 

--- a/volo-thrift/src/codec/default/ttheader.rs
+++ b/volo-thrift/src/codec/default/ttheader.rs
@@ -12,7 +12,9 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use linkedbytes::LinkedBytes;
 use metainfo::{Backward, Forward};
 use num_enum::TryFromPrimitive;
-use pilota::thrift::{new_protocol_exception, ProtocolException, ProtocolExceptionKind, ThriftException};
+use pilota::thrift::{
+    new_protocol_exception, ProtocolException, ProtocolExceptionKind, ThriftException,
+};
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt};
 use tracing::{trace, warn};
 use volo::{context::Role, util::buf_reader::BufReader, FastStr};

--- a/volo-thrift/src/codec/default/ttheader.rs
+++ b/volo-thrift/src/codec/default/ttheader.rs
@@ -4,9 +4,7 @@
 //!
 //! For more information, please visit https://www.cloudwego.io/docs/kitex/reference/transport_protocol_ttheader/
 
-use std::{
-    collections::HashMap, convert::TryFrom, default::Default, net::SocketAddr, time::Duration,
-};
+use std::{collections::HashMap, default::Default, net::SocketAddr, time::Duration};
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use linkedbytes::LinkedBytes;

--- a/volo-thrift/src/codec/mod.rs
+++ b/volo-thrift/src/codec/mod.rs
@@ -1,5 +1,6 @@
 use std::future::Future;
 
+use pilota::thrift::ThriftException;
 use tokio::io::{AsyncRead, AsyncWrite};
 
 use crate::{context::ThriftContext, EntryMessage, ThriftMessage};
@@ -18,7 +19,7 @@ pub trait Decoder: Send + 'static {
     fn decode<Msg: Send + EntryMessage, Cx: ThriftContext>(
         &mut self,
         cx: &mut Cx,
-    ) -> impl Future<Output = Result<Option<ThriftMessage<Msg>>, crate::Error>> + Send;
+    ) -> impl Future<Output = Result<Option<ThriftMessage<Msg>>, ThriftException>> + Send;
 }
 
 /// [`Encoder`] writes a [`ThriftMessage`] to an [`AsyncWrite`] and flushes the data.
@@ -29,7 +30,7 @@ pub trait Encoder: Send + 'static {
         &mut self,
         cx: &mut Cx,
         msg: ThriftMessage<Req>,
-    ) -> impl Future<Output = Result<(), crate::Error>> + Send;
+    ) -> impl Future<Output = Result<(), ThriftException>> + Send;
 }
 
 /// [`MakeCodec`] receives an [`AsyncRead`] and an [`AsyncWrite`] and returns a

--- a/volo-thrift/src/context.rs
+++ b/volo-thrift/src/context.rs
@@ -457,7 +457,7 @@ impl Reusable for Config {
 }
 
 impl ::volo::client::Apply<ClientContext> for CallOpt {
-    type Error = crate::Error;
+    type Error = crate::ClientError;
 
     #[inline]
     fn apply(self, cx: &mut ClientContext) -> Result<(), Self::Error> {

--- a/volo-thrift/src/error.rs
+++ b/volo-thrift/src/error.rs
@@ -12,8 +12,6 @@ pub use pilota::thrift::{
 };
 use volo::loadbalance::error::{LoadBalanceError, Retryable};
 
-// pub type Result<T, E = Error> = core::result::Result<T, E>;
-
 #[derive(Debug)]
 pub enum ServerError {
     // #[error("application exception: {0}")]
@@ -198,4 +196,9 @@ pub(crate) fn thrift_exception_to_application_exception(
             ApplicationException::new(ApplicationExceptionKind::PROTOCOL_ERROR, e.to_string())
         }
     }
+}
+
+pub enum MaybeException<T, E> {
+    Ok(T),
+    Exception(E),
 }

--- a/volo-thrift/src/error.rs
+++ b/volo-thrift/src/error.rs
@@ -12,11 +12,12 @@ pub use pilota::thrift::{
 };
 use volo::loadbalance::error::{LoadBalanceError, Retryable};
 
+pub type ServerResult<T> = Result<T, ServerError>;
+pub type ClientResult<T> = Result<T, ClientError>;
+
 #[derive(Debug)]
 pub enum ServerError {
-    // #[error("application exception: {0}")]
     Application(ApplicationException),
-    // #[error("biz error: {0}")]
     Biz(BizError),
 }
 

--- a/volo-thrift/src/error.rs
+++ b/volo-thrift/src/error.rs
@@ -16,9 +16,27 @@ pub type ServerResult<T> = Result<T, ServerError>;
 pub type ClientResult<T> = Result<T, ClientError>;
 
 #[derive(Debug)]
+pub struct AnyhowProxy(anyhow::Error);
+
+impl From<anyhow::Error> for AnyhowProxy {
+    fn from(e: anyhow::Error) -> Self {
+        AnyhowProxy(e)
+    }
+}
+
+#[derive(Debug)]
 pub enum ServerError {
     Application(ApplicationException),
     Biz(BizError),
+}
+
+impl From<AnyhowProxy> for ServerError {
+    fn from(e: AnyhowProxy) -> Self {
+        ServerError::Application(ApplicationException::new(
+            ApplicationExceptionKind::INTERNAL_ERROR,
+            e.0.to_string(),
+        ))
+    }
 }
 
 impl<E> From<E> for ServerError

--- a/volo-thrift/src/error.rs
+++ b/volo-thrift/src/error.rs
@@ -1,12 +1,11 @@
 use std::{fmt::Display, io};
 
-use pilota::{AHashMap, FastStr};
-
 pub use pilota::thrift::{
     new_application_exception, new_protocol_exception, ApplicationException,
     ApplicationExceptionKind, ProtocolException, ProtocolExceptionKind, ThriftException,
     TransportException,
 };
+use pilota::{AHashMap, FastStr};
 use volo::loadbalance::error::{LoadBalanceError, Retryable};
 
 pub type ServerResult<T> = Result<T, ServerError>;

--- a/volo-thrift/src/server.rs
+++ b/volo-thrift/src/server.rs
@@ -29,7 +29,7 @@ use crate::{
     },
     context::ServerContext,
     tracing::{DefaultProvider, SpanProvider},
-    EntryMessage, Result,
+    EntryMessage,
 };
 
 /// This is unstable now and may be changed in the future.
@@ -176,9 +176,9 @@ impl<S, L, Req, MkC, SP> Server<S, L, Req, MkC, SP> {
         L: Layer<S>,
         MkC: MakeCodec<OwnedReadHalf, OwnedWriteHalf>,
         L::Service: Service<ServerContext, Req, Response = S::Response> + Send + 'static + Sync,
-        <L::Service as Service<ServerContext, Req>>::Error: Into<crate::Error> + Send,
+        <L::Service as Service<ServerContext, Req>>::Error: Into<crate::ServerError> + Send,
         S: Service<ServerContext, Req> + Send + 'static,
-        S::Error: Into<crate::Error> + Send,
+        S::Error: Into<crate::ServerError> + Send,
         Req: EntryMessage + Send + 'static,
         S::Response: EntryMessage + Send + 'static + Sync,
         SP: SpanProvider,
@@ -392,7 +392,7 @@ async fn handle_conn<R, W, Req, Svc, Resp, MkC, SP>(
     W: AsyncWrite + Unpin + Send + Sync + 'static,
     Svc: Service<ServerContext, Req, Response = Resp> + Clone + Send + 'static,
     Svc::Error: Send,
-    Svc::Error: Into<crate::Error>,
+    Svc::Error: Into<crate::ServerError>,
     Req: EntryMessage + Send + 'static,
     Resp: EntryMessage + Send + 'static,
     MkC: MakeCodec<R, W>,
@@ -438,7 +438,7 @@ async fn handle_conn_multiplex<R, W, Req, Svc, Resp, MkC>(
     R: AsyncRead + Unpin + Send + Sync + 'static,
     W: AsyncWrite + Unpin + Send + Sync + 'static,
     Svc: Service<ServerContext, Req, Response = Resp> + Clone + Send + 'static + Sync,
-    Svc::Error: Into<crate::Error> + Send,
+    Svc::Error: Into<crate::ServerError> + Send,
     Req: EntryMessage + Send + 'static,
     Resp: EntryMessage + Send + 'static,
     MkC: MakeCodec<R, W>,

--- a/volo-thrift/src/transport/multiplex/thrift_transport.rs
+++ b/volo-thrift/src/transport/multiplex/thrift_transport.rs
@@ -9,7 +9,6 @@ use std::{
 use metainfo::MetaInfo;
 use pilota::thrift::{ApplicationException, ApplicationExceptionKind};
 use pin_project::pin_project;
-use rustc_hash;
 use tokio::{
     io::{AsyncRead, AsyncWrite},
     sync::{oneshot, Mutex},

--- a/volo-thrift/src/transport/multiplex/thrift_transport.rs
+++ b/volo-thrift/src/transport/multiplex/thrift_transport.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use metainfo::MetaInfo;
+use pilota::thrift::{ApplicationException, ApplicationExceptionKind};
 use pin_project::pin_project;
 use rustc_hash;
 use tokio::{
@@ -22,7 +23,7 @@ use crate::{
     codec::{Decoder, Encoder, MakeCodec},
     context::{ClientContext, ThriftContext},
     transport::pool::{Poolable, Reservation},
-    ApplicationError, ApplicationErrorKind, EntryMessage, Error, ThriftMessage,
+    ClientError, EntryMessage, ThriftMessage,
 };
 
 lazy_static::lazy_static! {
@@ -40,7 +41,7 @@ pub struct ThriftTransport<E, Resp> {
             rustc_hash::FxHashMap<
                 i32,
                 oneshot::Sender<
-                    crate::Result<Option<(MetaInfo, ClientContext, ThriftMessage<Resp>)>>,
+                    Result<Option<(MetaInfo, ClientContext, ThriftMessage<Resp>)>, ClientError>,
                 >,
             >,
         >,
@@ -96,7 +97,7 @@ where
                 rustc_hash::FxHashMap<
                     i32,
                     oneshot::Sender<
-                        crate::Result<Option<(MetaInfo, ClientContext, ThriftMessage<Resp>)>>,
+                        Result<Option<(MetaInfo, ClientContext, ThriftMessage<Resp>)>, ClientError>,
                     >,
                 >,
             >,
@@ -135,10 +136,13 @@ where
                             let mut tx_map = inner_tx_map.lock().await;
                             inner_read_error.store(true, std::sync::atomic::Ordering::Relaxed);
                             for (_, tx) in tx_map.drain() {
-                                let _ = tx.send(Err(Error::Application(ApplicationError::new(
-                                    ApplicationErrorKind::UNKNOWN,
-                                    format!("multiplex connection error: {e}, target: {target}"),
-                                ))));
+                                let _ =
+                                    tx.send(Err(ClientError::Application(ApplicationException::new(
+                                        ApplicationExceptionKind::UNKNOWN,
+                                        format!(
+                                            "multiplex connection error: {e}, target: {target}"
+                                        ),
+                                    ))));
                             }
                             return;
                         }
@@ -198,17 +202,17 @@ where
         cx: &mut ClientContext,
         msg: ThriftMessage<Req>,
         oneway: bool,
-    ) -> Result<Option<ThriftMessage<Resp>>, Error> {
+    ) -> Result<Option<ThriftMessage<Resp>>, ClientError> {
         // check error and closed
         if self.read_error.load(std::sync::atomic::Ordering::Relaxed) {
-            return Err(Error::Application(ApplicationError::new(
-                ApplicationErrorKind::UNKNOWN,
+            return Err(ClientError::Application(ApplicationException::new(
+                ApplicationExceptionKind::UNKNOWN,
                 "multiplex connection error".to_string(),
             )));
         }
         if self.read_closed.load(std::sync::atomic::Ordering::Relaxed) {
-            return Err(Error::Application(ApplicationError::new(
-                ApplicationErrorKind::UNKNOWN,
+            return Err(ClientError::Application(ApplicationException::new(
+                ApplicationExceptionKind::UNKNOWN,
                 "multiplex connection closed".to_string(),
             )));
         }
@@ -226,8 +230,8 @@ where
             // not be reused
             self.write_error
                 .store(true, std::sync::atomic::Ordering::Relaxed);
-            return Err(Error::Application(ApplicationError::new(
-                ApplicationErrorKind::UNKNOWN,
+            return Err(ClientError::Application(ApplicationException::new(
+                ApplicationExceptionKind::UNKNOWN,
                 "multiplex connection is dirty".to_string(),
             )));
         }
@@ -279,8 +283,8 @@ where
             },
             Err(e) => {
                 tracing::error!("[VOLO] multiplex connection oneshot recv error: {e}");
-                Err(Error::Application(ApplicationError::new(
-                    ApplicationErrorKind::UNKNOWN,
+                Err(ClientError::Application(ApplicationException::new(
+                    ApplicationExceptionKind::UNKNOWN,
                     format!("multiplex connection oneshot recv error: {e}"),
                 )))
             }
@@ -301,7 +305,7 @@ where
         &mut self,
         cx: &mut ClientContext,
         target: Address,
-    ) -> Result<Option<ThriftMessage<T>>, Error> {
+    ) -> Result<Option<ThriftMessage<T>>, ClientError> {
         let thrift_msg = self.decoder.decode(cx).await.map_err(|e| {
             tracing::error!(
                 "[VOLO] transport[{}] decode error: {}, target: {}",
@@ -344,7 +348,7 @@ where
         &mut self,
         cx: &mut impl ThriftContext,
         msg: ThriftMessage<T>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), ClientError> {
         self.encoder.encode(cx, msg).await.map_err(|mut e| {
             e.append_msg(&format!(", rpcinfo: {:?}", cx.rpc_info()));
             tracing::error!("[VOLO] transport[{}] encode error: {:?}", self.id, e);

--- a/volo-thrift/src/transport/multiplex/thrift_transport.rs
+++ b/volo-thrift/src/transport/multiplex/thrift_transport.rs
@@ -136,13 +136,14 @@ where
                             let mut tx_map = inner_tx_map.lock().await;
                             inner_read_error.store(true, std::sync::atomic::Ordering::Relaxed);
                             for (_, tx) in tx_map.drain() {
-                                let _ =
-                                    tx.send(Err(ClientError::Application(ApplicationException::new(
+                                let _ = tx.send(Err(ClientError::Application(
+                                    ApplicationException::new(
                                         ApplicationExceptionKind::UNKNOWN,
                                         format!(
                                             "multiplex connection error: {e}, target: {target}"
                                         ),
-                                    ))));
+                                    ),
+                                )));
                             }
                             return;
                         }

--- a/volo-thrift/src/transport/pool/make_transport.rs
+++ b/volo-thrift/src/transport/pool/make_transport.rs
@@ -46,11 +46,11 @@ impl<MT, K: Key> UnaryService<(K, Ver)> for PooledMakeTransport<MT, K>
 where
     MT: UnaryService<K> + Send + Clone + 'static + Sync,
     MT::Response: Poolable + Send,
-    MT::Error: Into<crate::Error> + Send,
+    MT::Error: Into<crate::ClientError> + Send,
 {
     type Response = Pooled<K, MT::Response>;
 
-    type Error = crate::Error;
+    type Error = crate::ClientError;
 
     async fn call(&self, kv: (K, Ver)) -> Result<Self::Response, Self::Error> {
         let mt = self.inner.clone();


### PR DESCRIPTION
## Motivation

目前的实现具有以下问题：

1. 错误无法类型化，失去了 Rust 类型系统的优势：所有的错误类型都转为了 anyhow::Error，虽然可以 downcast，但是无法在编译期保证类型安全
2. 无法表达所有的语义：比如无法通过目前的类型返回 Thrift 标准定义的 ApplicationError
3. 可扩展性、可维护性差：如新增的 BizError 只能让用户通过 anyhow::Error 返回，再在中间件中 downcast 判断，如果后续还需要新增错误类型，会极大影响可维护性
4. 用户接口不清晰：如需要用户返回 BizError，但用户需要转换成 anyhow::Error 返回
5. 错误语义不清晰：UserError 在 Rust 中被认为是 Result 的 Err，但是在 Thrift RPC 框架来看，被认为是成功的，也即 Result 的 Ok
6. 不是所有错误都同时适用于 Server/Client：比如 Server 侧不应当出现 Transport 和 Protocol 错误
7. 不明确的语义：比如 AnyhowError，并没有明确的语义，在传输过程中会被转换为 ApplicationError，但是在 Service 处理过程中无法提供有价值的信息

## Solution

这个 PR 完成了以下更改：

1. 将所有错误强类型化，通过 Rust 类型系统保证正确性、可扩展性、可维护性，防止误用，去除 anyhow::Error
2. 明确所有错误语义，框架返回的所有错误都是应当可枚举可解释的
3. 消除不必要存在的 variant，以最小所需集分别定义不同阶段的错误
4. 修正用户自定义 Exception 语义为 Ok/Success，不再在 Error 中体现

具体来看，在 Server 端，无论是 Handler 还是 Service 中，错误类型为：

```rust
pub enum ServerError {
    Application(ApplicationException),
    Biz(BizError),
}
```

在 Client 端，错误类型为：

```rust
pub enum ClientError {
    Application(ApplicationException),
    Transport(TransportException),
    Protocol(ProtocolException),
    Biz(BizError),
}
```