### PR TITLE
feat(volo-http): use generic types for resp and err

### DIFF
--- a/volo-http/src/extension.rs
+++ b/volo-http/src/extension.rs
@@ -1,5 +1,3 @@
-use std::convert::Infallible;
-
 use http::{request::Parts, StatusCode};
 use motore::{layer::Layer, service::Service};
 use volo::context::Context;
@@ -16,7 +14,9 @@ pub struct Extension<T>(pub T);
 
 impl<S, T> Layer<S> for Extension<T>
 where
-    S: Service<ServerContext, ServerRequest, Response = ServerResponse> + Send + Sync + 'static,
+    S: Service<ServerContext, ServerRequest> + Send + Sync + 'static,
+    S::Response: IntoResponse,
+    S::Error: IntoResponse,
     T: Sync,
 {
     type Service = ExtensionService<S, T>;
@@ -34,10 +34,9 @@ pub struct ExtensionService<I, T> {
 
 impl<S, T> Service<ServerContext, ServerRequest> for ExtensionService<S, T>
 where
-    S: Service<ServerContext, ServerRequest, Response = ServerResponse, Error = Infallible>
-        + Send
-        + Sync
-        + 'static,
+    S: Service<ServerContext, ServerRequest> + Send + Sync + 'static,
+    S::Response: IntoResponse,
+    S::Error: IntoResponse,
     T: Clone + Send + Sync + 'static,
 {
     type Response = S::Response;


### PR DESCRIPTION
## Motivation

The previous code uses a fixed Service with `Response = ServerResponse` and `Error = Infallible`, which is not flexible enough.

## Solution

This PR updates `Service`s for server. Its `Response` can be of any type with `IntoResponse`, and `Error` can be any type without `trait`. The only restriction is that the `Error` must be converted to `ServerResponse` (with `Error = Infallible`) before it is given to the client.

In other words, you can define your own error code in the business code, but you must handle it before sending it to client.

An example is also updated where you can create a service with an error code (`usize` in the example, which doesn't implement `IntoResponse`) and wrap it with a layer to convert it.
