### PR TITLE
fix(volo-build): remove the last comma in method parameter list to ad…

### DIFF
--- a/volo-build/src/thrift_backend.rs
+++ b/volo-build/src/thrift_backend.rs
@@ -670,15 +670,10 @@ impl pilota_build::CodegenBackend for VoloThriftBackend {
         };
 
         format!(
-            r#"
-    async fn {name}(
-        &self,
-        {args},
-    ) -> ::core::result::Result<{ret_ty}, {exception}>
-    {{
-        Ok(Default::default())
-    }}
-"#
+            r#"async fn {name}(&self, {args}) -> ::core::result::Result<{ret_ty}, {exception}>
+            {{
+                Ok(Default::default())
+            }}"#
         )
     }
 


### PR DESCRIPTION
## Motivation

The generated template will be incorrect when the idl method parameter list is empty. 
```rust
impl volo_gen::namespace::XXService for S {
    async fn method1(
        &self,
        ,
    ) -> ::core::result::Result<lust_gen::namespace::XXXResponse, ::volo_thrift::AnyhowError>
    {
        Ok(Default::default())
    }
}
```

## Solution

Remove the last comma in the method template, and the generated code becomes correct like:
```rust
impl volo_gen::namespace::XXService for S {
    async fn method1(
        &self,
    ) -> ::core::result::Result<volo_gen::namespace::XXXResponse, ::volo_thrift::AnyhowError>
    {
        Ok(Default::default())
    }
}
```
