### PR TITLE
feat(volo-http): record uri and method in server stats

### DIFF
--- a/volo-http/src/context/client.rs
+++ b/volo-http/src/context/client.rs
@@ -51,16 +51,7 @@ pub struct ClientStats {
 impl ClientStats {
     stat_impl!(transport_start_at);
     stat_impl!(transport_end_at);
-
-    #[inline]
-    pub fn status_code(&self) -> Option<StatusCode> {
-        self.status_code
-    }
-
-    #[inline]
-    pub fn set_status_code(&mut self, status: StatusCode) {
-        self.status_code = Some(status);
-    }
+    stat_impl_getter_and_setter!(status_code, StatusCode);
 }
 
 #[derive(Clone, Debug, Default)]

--- a/volo-http/src/context/mod.rs
+++ b/volo-http/src/context/mod.rs
@@ -23,6 +23,22 @@ macro_rules! stat_impl {
     };
 }
 
+macro_rules! stat_impl_getter_and_setter {
+    ($name: ident, $type: ty) => {
+        paste! {
+            #[inline]
+            pub fn $name(&self) -> Option<&$type> {
+                self.$name.as_ref()
+            }
+
+            #[inline]
+            pub fn [<set_ $name>](&mut self, t: $type) {
+                self.$name = Some(t)
+            }
+        }
+    };
+}
+
 #[cfg(feature = "client")]
 pub mod client;
 #[cfg(feature = "client")]

--- a/volo-http/src/context/server.rs
+++ b/volo-http/src/context/server.rs
@@ -3,7 +3,7 @@ use http::{
     header,
     request::Parts,
     uri::{Authority, Scheme},
-    HeaderMap, HeaderName, StatusCode,
+    HeaderMap, HeaderName, Method, StatusCode, Uri,
 };
 use hyper::header::HeaderValue;
 use paste::paste;
@@ -60,27 +60,22 @@ impl ServerCxInner {
 }
 
 /// This is unstable now and may be changed in the future.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone)]
 pub struct ServerStats {
     process_start_at: Option<DateTime<Local>>,
     process_end_at: Option<DateTime<Local>>,
 
+    method: Option<Method>,
+    uri: Option<Uri>,
     status_code: Option<StatusCode>,
 }
 
 impl ServerStats {
     stat_impl!(process_start_at);
     stat_impl!(process_end_at);
-
-    #[inline]
-    pub fn status_code(&self) -> Option<StatusCode> {
-        self.status_code
-    }
-
-    #[inline]
-    pub fn set_status_code(&mut self, status: StatusCode) {
-        self.status_code = Some(status);
-    }
+    stat_impl_getter_and_setter!(method, Method);
+    stat_impl_getter_and_setter!(uri, Uri);
+    stat_impl_getter_and_setter!(status_code, StatusCode);
 }
 
 #[derive(Debug, Default, Clone, Copy)]

--- a/volo-http/src/server/mod.rs
+++ b/volo-http/src/server/mod.rs
@@ -321,6 +321,8 @@ where
             let peer = peer.clone();
             let mut cx = ServerContext::new(peer);
 
+            cx.stats.set_uri(request.uri().to_owned());
+            cx.stats.set_method(request.method().to_owned());
             if let Some(req_size) = request.size_hint().exact() {
                 cx.common_stats.set_req_size(req_size);
             }

--- a/volo-http/src/utils/macros.rs
+++ b/volo-http/src/utils/macros.rs
@@ -76,17 +76,7 @@ macro_rules! impl_getter {
         }
     };
     ($name: ident, $type: ty) => {
-        paste! {
-            #[inline]
-            pub fn $name(&self) -> &$type {
-                &self.$name
-            }
-
-            #[inline]
-            pub fn [<$name _mut>](&mut self) -> &mut $type {
-                &mut self.$name
-            }
-        }
+        impl_getter!($name, $type, $name);
     };
 }
 


### PR DESCRIPTION
## Motivation

There is no `uri` and `method` in server stats, this PR adds it.

## Solution

Record `uri` and `method` when receiving request.