### PR TITLE
chore(volo-http): only make `Route<Infallible>` as Service

### DIFF
--- a/volo-http/src/server/route.rs
+++ b/volo-http/src/server/route.rs
@@ -142,10 +142,7 @@ impl<E> Router<E> {
     }
 }
 
-impl<E> Service<ServerContext, ServerRequest> for Router<E>
-where
-    E: IntoResponse,
-{
+impl Service<ServerContext, ServerRequest> for Router {
     type Response = ServerResponse;
     type Error = Infallible;
 


### PR DESCRIPTION
## Motivation

The `Router` should handle all errors, so it should only be with `Infallible`.

In addition, without this limit, compiler cannot judge what `E` does the `Router` use.

## Solution

Change `impl<E> Service for Router<E>` to `impl Service for Router`