### PR TITLE
feat(volo-http): support request with any body

### DIFF
--- a/examples/src/http/example-http-client.rs
+++ b/examples/src/http/example-http-client.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<(), BoxError> {
         "{:?}",
         client
             .post("http://127.0.0.1:8080/user/json_post")?
-            .body(Json(Person {
+            .data(Json(Person {
                 name: "Foo".to_string(),
                 age: 25,
                 phones: vec!["114514".to_string()],

--- a/volo-http/src/client/meta.rs
+++ b/volo-http/src/client/meta.rs
@@ -20,12 +20,13 @@ impl<S> MetaService<S> {
     }
 }
 
-impl<S> Service<ClientContext, ClientRequest> for MetaService<S>
+impl<S, B> Service<ClientContext, ClientRequest<B>> for MetaService<S>
 where
-    S: Service<ClientContext, ClientRequest, Response = ClientResponse, Error = ClientError>
+    S: Service<ClientContext, ClientRequest<B>, Response = ClientResponse, Error = ClientError>
         + Send
         + Sync
         + 'static,
+    B: Send + 'static,
 {
     type Response = S::Response;
     type Error = S::Error;
@@ -33,7 +34,7 @@ where
     async fn call(
         &self,
         cx: &mut ClientContext,
-        mut req: ClientRequest,
+        mut req: ClientRequest<B>,
     ) -> Result<Self::Response, Self::Error> {
         let config = cx.rpc_info().config();
         let host = match config.host {


### PR DESCRIPTION
## Motivation

Previous client only support `ClientRequest`, which is `http::Request<volo_http::Body>`.  It is not flexible.

## Solution

This PR supports any type with `http_body::Body` as `B` of `ClientRequest<B>`.