### PR TITLE
feat(volo-http): support disabling stats

### DIFF
--- a/examples/src/http/example-http-server.rs
+++ b/examples/src/http/example-http-server.rs
@@ -391,9 +391,9 @@ fn tracer(cx: &ServerContext) {
         "process start at {:?}, end at {:?}, req size: {:?}, resp size: {:?}, resp status: {:?}",
         cx.stats.process_start_at().unwrap(),
         cx.stats.process_end_at().unwrap(),
-        cx.common_stats.req_size().unwrap_or(0),
-        cx.common_stats.resp_size().unwrap_or(0),
-        cx.stats.status_code().unwrap(),
+        cx.common_stats.req_size().unwrap_or(&0),
+        cx.common_stats.resp_size().unwrap_or(&0),
+        cx.common_stats.status_code().unwrap(),
     );
 }
 

--- a/volo-http/src/context/client.rs
+++ b/volo-http/src/context/client.rs
@@ -14,15 +14,16 @@ use crate::utils::macros::impl_deref_and_deref_mut;
 pub struct ClientContext(pub(crate) RpcCx<ClientCxInner, Config>);
 
 impl ClientContext {
-    pub(crate) fn new(target: Address) -> Self {
+    pub fn new(target: Address, stat_enable: bool) -> Self {
         let mut cx = RpcCx::new(
-            RpcInfo::with_role(Role::Client),
+            RpcInfo::<Config>::with_role(Role::Client),
             ClientCxInner {
                 stats: ClientStats::default(),
                 common_stats: CommonStats::default(),
             },
         );
         cx.rpc_info_mut().callee_mut().set_address(target);
+        cx.rpc_info_mut().config_mut().stat_enable = stat_enable;
         Self(cx)
     }
 }
@@ -54,9 +55,19 @@ impl ClientStats {
     stat_impl_getter_and_setter!(status_code, StatusCode);
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct Config {
-    pub(crate) host: Host,
+    pub host: Host,
+    pub stat_enable: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            host: Host::default(),
+            stat_enable: true,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default)]

--- a/volo-http/src/context/mod.rs
+++ b/volo-http/src/context/mod.rs
@@ -1,3 +1,6 @@
+use http::StatusCode;
+use paste::paste;
+
 macro_rules! stat_impl {
     ($t: ident) => {
         paste! {
@@ -41,6 +44,7 @@ macro_rules! stat_impl_getter_and_setter {
 
 #[cfg(feature = "client")]
 pub mod client;
+
 #[cfg(feature = "client")]
 pub use self::client::ClientContext;
 
@@ -54,28 +58,13 @@ pub use self::server::{ConnectionInfo, ServerContext};
 pub struct CommonStats {
     req_size: Option<u64>,
     resp_size: Option<u64>,
+    status_code: Option<StatusCode>,
 }
 
 impl CommonStats {
-    #[inline]
-    pub fn req_size(&self) -> Option<u64> {
-        self.req_size
-    }
-
-    #[inline]
-    pub fn set_req_size(&mut self, size: u64) {
-        self.req_size = Some(size)
-    }
-
-    #[inline]
-    pub fn resp_size(&self) -> Option<u64> {
-        self.resp_size
-    }
-
-    #[inline]
-    pub fn set_resp_size(&mut self, size: u64) {
-        self.resp_size = Some(size)
-    }
+    stat_impl_getter_and_setter!(req_size, u64);
+    stat_impl_getter_and_setter!(resp_size, u64);
+    stat_impl_getter_and_setter!(status_code, StatusCode);
 
     #[inline]
     pub fn reset(&mut self) {


### PR DESCRIPTION
## Motivation

Sometimes `stats` needs a switch to control it for optimal performance, this PR adds it to the config to enable or disable it.

## Solution

Add `enable_stats` in `Config`.

For server, we can disable it by:

```rust
let mut server = Server::new(app);
server.config_mut().stat_enable = false;
server.run(addr).await.unwrap();
```

For client, we can disable it by:

```rust
let client = ClientBuilder::new()
    .caller_name("example.http.client")
    .callee_name("example.http.server")
    .enable_stat(false)
    .header("Test", "Test")?
    .build();
```

Or:

```rust
let mut builder = ClientBuilder::new()
    .caller_name("example.http.client")
    .callee_name("example.http.server")
    .header("Test", "Test")?;
builder.config_mut().stat_enable = false;
let client = builder.build();
```