### PR TITLE
chore(volo-http): support `Body::from_body` with any error

### DIFF
--- a/volo-http/src/body.rs
+++ b/volo-http/src/body.rs
@@ -41,9 +41,10 @@ impl Body {
 
     pub fn from_body<B>(body: B) -> Self
     where
-        B: http_body::Body<Data = Bytes, Error = BoxError> + Send + Sync + 'static,
+        B: http_body::Body<Data = Bytes> + Send + Sync + 'static,
+        B::Error: Into<BoxError>,
     {
-        Self::Body(BoxBody::new(body))
+        Self::Body(BoxBody::new(body.map_err(Into::into)))
     }
 }
 

--- a/volo-http/src/error/client.rs
+++ b/volo-http/src/error/client.rs
@@ -13,11 +13,11 @@ pub struct ClientError {
 }
 
 impl ClientError {
-    pub(crate) fn new(kind: Kind, error: ClientErrorInner) -> Self {
+    pub fn new(kind: Kind, error: ClientErrorInner) -> Self {
         Self { kind, error }
     }
 
-    pub(crate) fn new_other<E>(kind: Kind, error: E) -> Self
+    pub fn new_other<E>(kind: Kind, error: E) -> Self
     where
         E: Into<BoxError>,
     {


### PR DESCRIPTION
## Motivation

The previous `Body::from_body` can only accept `Body::Error = BoxError`, which is not flexible.

## Solution

Use `http_body_util::combinators::MapErr` for converting error to `BoxError`.