### PR TITLE
feat(volo-http): remove connection info, add ext for parts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3027,7 +3027,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "url",
  "volo",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,6 @@ tower = "0.4"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 update-informer = "1"
-url = "2"
 url_path = "0.1"
 walkdir = "2"
 

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -51,7 +51,6 @@ tracing.workspace = true
 
 # server optional
 matchit = { workspace = true, optional = true }
-url = { workspace = true, optional = true }
 
 # cookie support
 cookie = { workspace = true, optional = true, features = ["percent-encode"] }
@@ -76,7 +75,7 @@ default_server = ["server", "query", "form", "json"]
 full = ["client", "server", "cookie", "query", "form", "json"]
 
 client = ["hyper/client"] # client core
-server = ["hyper/server", "dep:matchit", "dep:url"] # server core
+server = ["hyper/server", "dep:matchit"] # server core
 
 cookie = ["dep:cookie"]
 

--- a/volo-http/src/client/utils.rs
+++ b/volo-http/src/client/utils.rs
@@ -5,10 +5,10 @@ use http::{uri::Scheme, Uri};
 use tokio::net::lookup_host;
 use volo::net::Address;
 
-use crate::error::client::{bad_scheme, builder_error, uri_without_host, Result};
-
-const HTTP_DEFAULT_PORT: u16 = 80;
-const HTTPS_DEFAULT_PORT: u16 = 443;
+use crate::{
+    error::client::{bad_scheme, builder_error, uri_without_host, Result},
+    utils::consts::{HTTPS_DEFAULT_PORT, HTTP_DEFAULT_PORT},
+};
 
 pub trait IntoUri {
     fn into_uri(self) -> Result<Uri>;

--- a/volo-http/src/context/mod.rs
+++ b/volo-http/src/context/mod.rs
@@ -53,8 +53,9 @@ pub use self::client::ClientContext;
 
 #[cfg(feature = "server")]
 pub mod server;
+
 #[cfg(feature = "server")]
-pub use self::server::{ConnectionInfo, ServerContext};
+pub use self::server::{RequestPartsExt, ServerContext};
 
 /// This is unstable now and may be changed in the future.
 #[derive(Debug, Default, Clone, Copy)]

--- a/volo-http/src/context/server.rs
+++ b/volo-http/src/context/server.rs
@@ -1,13 +1,12 @@
 use chrono::{DateTime, Local};
 use http::{
     header,
+    header::{HeaderMap, HeaderValue},
     request::Parts,
-    uri::{Authority, Scheme},
-    HeaderMap, HeaderName, Method, Uri,
+    uri::{Authority, PathAndQuery, Scheme, Uri},
+    Method,
 };
-use hyper::header::HeaderValue;
 use paste::paste;
-use url::{Host, Url};
 use volo::{
     context::{Context, Reusable, Role, RpcCx, RpcInfo},
     net::Address,
@@ -17,11 +16,11 @@ use volo::{
 use super::CommonStats;
 use crate::{
     server::param::Params,
-    utils::macros::{impl_deref_and_deref_mut, impl_getter},
+    utils::{
+        consts::{HTTPS_DEFAULT_PORT, HTTP_DEFAULT_PORT},
+        macros::{impl_deref_and_deref_mut, impl_getter},
+    },
 };
-
-static X_FORWARDED_HOST: HeaderName = HeaderName::from_static("x-forwarded-host");
-static X_FORWARDED_PROTO: HeaderName = HeaderName::from_static("x-forwarded-proto");
 
 #[derive(Debug)]
 pub struct ServerContext(pub(crate) RpcCx<ServerCxInner, Config>);
@@ -94,135 +93,157 @@ impl Reusable for Config {
     }
 }
 
-#[derive(Debug)]
-pub struct ConnectionInfo {
-    scheme: Scheme,
-    host: Option<Host>,
-    port: Option<u16>,
+pub trait RequestPartsExt {
+    /// Parse `Forwarded` in headers.
+    fn forwarded(&self) -> Forwarded;
+
+    /// Get the URI in HTTP header of original request.
+    ///
+    /// For most cases, the uri is a path (and query) starting with `/`.
+    fn request_uri(&self) -> Uri;
+
+    /// Get the full URI including scheme, host, port (if any), and path.
+    fn full_uri(&self) -> Option<Uri>;
+
+    /// Get the scheme of the request URI.
+    ///
+    /// In fact, if the TLS is enabled, the scheme is always `https`, otherwise `http`.
+    fn scheme(&self) -> Scheme;
+
+    /// Get host name of the request URI from header `Host`.
+    fn host(&self) -> Option<&str>;
+
+    /// Get port of the request URI.
+    ///
+    /// If the port does not exist in host, it will be inferred from the scheme.
+    fn port(&self) -> Option<u16>;
 }
 
-impl ConnectionInfo {
-    /// Hostname and port of the request.
-    ///
-    /// Hostname is resolved through the following, in order:
-    /// - `Forwarded` header
-    /// - `X-Forwarded-Host` header
-    /// - `Host` header
-    /// - request target / URI
-    #[inline]
-    pub fn hostport(&self) -> (Option<&Host>, Option<u16>) {
-        (self.host.as_ref(), self.port)
+impl RequestPartsExt for Parts {
+    fn forwarded(&self) -> Forwarded {
+        Forwarded::from_header(&self.headers)
     }
 
-    /// Scheme of the request.
-    ///
-    /// Scheme is resolved through the following, in order:
-    /// - `Forwarded` header
-    /// - `X-Forwarded-Proto` header
-    /// - request target / URI
-    #[inline]
-    pub fn scheme(&self) -> &Scheme {
-        &self.scheme
+    fn request_uri(&self) -> Uri {
+        self.uri.clone()
+    }
+
+    fn full_uri(&self) -> Option<Uri> {
+        let scheme = self.scheme();
+        let authority = self.host()?;
+        Uri::builder()
+            .scheme(scheme)
+            .authority(authority)
+            .path_and_query(
+                self.uri
+                    .path_and_query()
+                    .map(PathAndQuery::as_str)
+                    .unwrap_or("/"),
+            )
+            .build()
+            .ok()
+    }
+
+    fn scheme(&self) -> Scheme {
+        self.uri
+            .scheme()
+            // volo-http supports http only now
+            .unwrap_or(&Scheme::HTTP)
+            .to_owned()
+    }
+
+    fn host(&self) -> Option<&str> {
+        match self.headers.get(header::HOST).map(HeaderValue::to_str) {
+            Some(Ok(host)) => Some(host),
+            _ => None,
+        }
+    }
+
+    fn port(&self) -> Option<u16> {
+        if let Some(port) = self.uri.authority().and_then(Authority::port_u16) {
+            return Some(port);
+        }
+        let scheme = self.scheme();
+        if scheme == Scheme::HTTP {
+            Some(HTTP_DEFAULT_PORT)
+        } else if scheme == Scheme::HTTPS {
+            Some(HTTPS_DEFAULT_PORT)
+        } else {
+            None
+        }
     }
 }
 
-pub(crate) fn get_connection_info(parts: &Parts) -> ConnectionInfo {
-    let mut host = None;
-    let mut scheme = None;
+#[derive(Clone, Debug)]
+pub struct Forwarded<'a> {
+    pub by: Option<&'a str>,
+    pub r#for: Vec<&'a str>,
+    pub host: Option<&'a str>,
+    pub proto: Option<&'a str>,
+}
 
-    for (name, val) in parts
-        .headers
-        .get_all(&header::FORWARDED)
-        .into_iter()
-        .filter_map(|hdr| hdr.to_str().ok())
-        // "for=1.2.3.4, for=5.6.7.8; scheme=https"
-        .flat_map(|val| val.split(';'))
-        // ["for=1.2.3.4, for=5.6.7.8", " scheme=https"]
-        .flat_map(|vals| vals.split(','))
-        // ["for=1.2.3.4", " for=5.6.7.8", " scheme=https"]
-        .flat_map(|pair| {
-            let mut items = pair.trim().splitn(2, '=');
-            Some((items.next()?, items.next()?))
-        })
-    {
-        // [(name , val      ), ...                                    ]
-        // [("for", "1.2.3.4"), ("for", "5.6.7.8"), ("scheme", "https")]
-
-        // taking the first value for each property is correct because spec states that first
-        // "for" value is client and rest are proxies; multiple values other properties have
-        // no defined semantics
-        //
-        // > In a chain of proxy servers where this is fully utilized, the first
-        // > "for" parameter will disclose the client where the request was first
-        // > made, followed by any subsequent proxy identifiers.
-        // --- https://datatracker.ietf.org/doc/html/rfc7239#section-5.2
-
-        match name.trim().to_lowercase().as_str() {
-            "host" => host.get_or_insert_with(|| unquote(val)),
-            "proto" => scheme.get_or_insert_with(|| unquote(val)),
-            "by" => {
-                // TODO: implement https://datatracker.ietf.org/doc/html/rfc7239#section-5.1
-                continue;
-            }
-            _ => continue,
+impl<'a> Forwarded<'a> {
+    fn from_header(headers: &'a HeaderMap) -> Self {
+        let mut forwarded = Forwarded {
+            by: None,
+            r#for: Vec::new(),
+            host: None,
+            proto: None,
         };
+
+        for (name, val) in headers
+            .get_all(&header::FORWARDED)
+            .into_iter()
+            .filter_map(|hdr| hdr.to_str().ok())
+            // "for=1.2.3.4, for=5.6.7.8; proto=https"
+            .flat_map(|val| val.split(';'))
+            // ["for=1.2.3.4, for=5.6.7.8", " proto=https"]
+            .flat_map(|vals| vals.split(','))
+            // ["for=1.2.3.4", " for=5.6.7.8", " proto=https"]
+            .flat_map(|pair| {
+                let mut items = pair.trim().splitn(2, '=');
+                Some((items.next()?, items.next()?))
+            })
+        {
+            // [(name , val      ), ...                                    ]
+            // [("for", "1.2.3.4"), ("for", "5.6.7.8"), ("proto", "https")]
+
+            // taking the first value for each property is correct because spec states that first
+            // "for" value is client and rest are proxies; multiple values other properties have
+            // no defined semantics
+            //
+            // > In a chain of proxy servers where this is fully utilized, the first
+            // > "for" parameter will disclose the client where the request was first
+            // > made, followed by any subsequent proxy identifiers.
+            // --- https://datatracker.ietf.org/doc/html/rfc7239#section-5.2
+
+            match name.trim().to_lowercase().as_str() {
+                "by" => {
+                    if forwarded.by.is_none() {
+                        forwarded.by = Some(unquote(val));
+                    }
+                }
+                "for" => {
+                    forwarded.r#for.push(unquote(val));
+                }
+                "host" => {
+                    if forwarded.host.is_none() {
+                        forwarded.host = Some(unquote(val));
+                    }
+                }
+                "proto" => {
+                    if forwarded.proto.is_none() {
+                        forwarded.proto = Some(unquote(val));
+                    }
+                }
+                _ => continue,
+            };
+        }
+
+        forwarded
     }
-
-    let host = match host {
-        // Forwarded
-        Some(host) => host,
-        None => {
-            if let Some(host) = first_header_value(&parts.headers, &X_FORWARDED_HOST) {
-                // X-Forwarded-Host
-                host
-            } else if let Some(Ok(host)) = parts.headers.get(&header::HOST).map(HeaderValue::to_str)
-            {
-                // Host
-                host
-            } else if let Some(host) = parts.uri.authority().map(Authority::as_str) {
-                host
-            } else {
-                ""
-            }
-        }
-    };
-    let host = host.to_owned();
-
-    let scheme = match scheme {
-        // Forwarded
-        Some(scheme) => Some(scheme),
-        None => {
-            // X-Forwarded-Host
-            first_header_value(&parts.headers, &X_FORWARDED_PROTO)
-        }
-    };
-    // map str to `Scheme`
-    let scheme = match scheme {
-        Some(scheme) => Scheme::try_from(scheme).ok(),
-        None => parts.uri.scheme().map(Scheme::to_owned),
-    };
-    // fallback
-    let scheme = match scheme {
-        Some(scheme) => scheme,
-        None => Scheme::HTTP,
-    };
-
-    let (host, port) = match Url::parse(format!("{scheme}://{host}/").as_str()) {
-        // SAFETY: calling `unwrap` is safe because the original string is a valid url
-        // constructed with the format `scheme://host/`
-        Ok(url) => (url.host().map(|s| s.to_owned()), url.port()),
-        Err(_) => (None, None),
-    };
-
-    ConnectionInfo { host, port, scheme }
 }
 
 fn unquote(val: &str) -> &str {
     val.trim().trim_start_matches('"').trim_end_matches('"')
-}
-
-fn first_header_value<'a>(headers: &'a HeaderMap, name: &'_ HeaderName) -> Option<&'a str> {
-    let hdr = headers.get(name)?.to_str().ok()?;
-    let val = hdr.split(',').next()?.trim();
-    Some(val)
 }

--- a/volo-http/src/server/extract.rs
+++ b/volo-http/src/server/extract.rs
@@ -9,11 +9,7 @@ use hyper::body::Incoming;
 use volo::{context::Context, net::Address};
 
 use super::{param::Params, IntoResponse};
-use crate::{
-    context::{server::get_connection_info, ConnectionInfo, ServerContext},
-    request::ServerRequest,
-    response::ServerResponse,
-};
+use crate::{context::ServerContext, request::ServerRequest, response::ServerResponse};
 
 mod private {
     #[derive(Debug, Clone, Copy)]
@@ -147,16 +143,6 @@ where
         let query = parts.uri.query().unwrap_or_default();
         let param = serde_urlencoded::from_str(query).map_err(RejectionError::QueryRejection)?;
         Ok(Query(param))
-    }
-}
-
-impl FromContext for ConnectionInfo {
-    type Rejection = Infallible;
-    async fn from_context(
-        _cx: &mut ServerContext,
-        parts: &mut Parts,
-    ) -> Result<Self, Self::Rejection> {
-        Ok(get_connection_info(parts))
     }
 }
 

--- a/volo-http/src/utils/consts.rs
+++ b/volo-http/src/utils/consts.rs
@@ -1,0 +1,2 @@
+pub const HTTP_DEFAULT_PORT: u16 = 80;
+pub const HTTPS_DEFAULT_PORT: u16 = 443;

--- a/volo-http/src/utils/mod.rs
+++ b/volo-http/src/utils/mod.rs
@@ -1,4 +1,5 @@
 #![allow(unused)]
+pub mod consts;
 pub mod macros;
 mod service_fn;
 


### PR DESCRIPTION
## Motivation

The previous `ConnectionInfo` is complex and not versatile enough, and some common functions are missing, e.g. getting host or getting full uri.

## Solution

This PR removed `ConnectionInfo` and add trait `RequestPartsExt` for `http::request::Parts`.  It provides `forwarded` function, which is core of `get_connection_info` without coupling to other parts.  There are also some common functions including `host`, `port`, `scheme`, `request_uri` and `full_uri`.