### PR TITLE
chore(volo-http): refactor config of context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3006,7 +3006,7 @@ dependencies = [
 
 [[package]]
 name = "volo-http"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 dependencies = [
  "ahash",
  "bytes",

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-http"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-http/src/client/meta.rs
+++ b/volo-http/src/client/meta.rs
@@ -3,7 +3,6 @@ use std::error::Error;
 use http::header;
 use http_body::Body;
 use motore::service::Service;
-use volo::context::Context;
 
 use crate::{
     context::ClientContext, error::client::ClientError, request::ClientRequest,
@@ -47,9 +46,9 @@ where
             }
         }
 
-        let stat_enable = cx.rpc_info().config().stat_enable;
+        let stat_enabled = cx.stat_enabled();
 
-        if stat_enable {
+        if stat_enabled {
             if let Some(req_size) = exact_len {
                 cx.common_stats.set_req_size(req_size);
             }
@@ -60,7 +59,7 @@ where
 
         let res = self.inner.call(cx, req).await;
 
-        if stat_enable {
+        if stat_enabled {
             if let Ok(response) = res.as_ref() {
                 cx.stats.set_status_code(response.status());
                 if let Some(resp_size) = response.size_hint().exact() {

--- a/volo-http/src/client/mod.rs
+++ b/volo-http/src/client/mod.rs
@@ -522,17 +522,15 @@ impl<S> Client<S> {
             }
         }
 
-        let mut cx = ClientContext::new(target, true);
+        let mut cx = ClientContext::new(
+            target,
+            #[cfg(feature = "__tls")]
+            uri.scheme()
+                .is_some_and(|scheme| scheme == &http::uri::Scheme::HTTPS),
+        );
         cx.rpc_info_mut().caller_mut().set_service_name(caller_name);
         cx.rpc_info_mut().callee_mut().set_service_name(callee_name);
         cx.rpc_info_mut().set_config(self.inner.config.clone());
-        #[cfg(feature = "__tls")]
-        {
-            cx.rpc_info_mut().config_mut().is_tls = match uri.scheme() {
-                Some(scheme) => scheme == &http::uri::Scheme::HTTPS,
-                None => false,
-            };
-        }
 
         self.call(&mut cx, request).await
     }

--- a/volo-http/src/context/server.rs
+++ b/volo-http/src/context/server.rs
@@ -26,7 +26,7 @@ use crate::{
 pub struct ServerContext(pub(crate) RpcCx<ServerCxInner, Config>);
 
 impl ServerContext {
-    pub fn new(peer: Address, stat_enable: bool) -> Self {
+    pub fn new(peer: Address) -> Self {
         let mut cx = RpcCx::new(
             RpcInfo::<Config>::with_role(Role::Server),
             ServerCxInner {
@@ -36,8 +36,15 @@ impl ServerContext {
             },
         );
         cx.rpc_info_mut().caller_mut().set_address(peer);
-        cx.rpc_info_mut().config_mut().stat_enable = stat_enable;
         Self(cx)
+    }
+
+    pub fn enable_stat(&mut self, enable: bool) {
+        self.rpc_info_mut().config_mut().stat_enable = enable;
+    }
+
+    pub(crate) fn stat_enabled(&self) -> bool {
+        self.rpc_info().config().stat_enable
     }
 }
 
@@ -78,7 +85,7 @@ impl ServerStats {
 
 #[derive(Debug, Clone, Copy)]
 pub struct Config {
-    pub stat_enable: bool,
+    pub(crate) stat_enable: bool,
 }
 
 impl Default for Config {


### PR DESCRIPTION
## Motivation

The previous context has an argument `stat_enable` in its `new` function, but it can be set in other ways and setting it in `new` is not a good design.  However, `tls`, in other words, whether tls is enabled should not be changed during processing request, so it is better to set it in `ClientContext::new`.

In addition, in previous codes, we should import `volo::context::Context` for getting `tls` and `stat_enable`, and it is not a good design, too.  It requires a getter or setter function.

## Solution

- `ServerContext::new(target: Address, stat_enable: bool)` -> `ServerContext::new(target: Address)`
- `ClientContext::new(target: Address, stat_enable: bool)` -> `ClientContext::new(target: Address, tls: bool)`
- Add `xxxContext::enable_stat`, `xxxContext::stat_enabled` and `ClientCxInner::tls`