### PR TITLE
feat(volo-thrift): eliminate service type for server run

### DIFF
--- a/volo-thrift/src/codec/default/ttheader.rs
+++ b/volo-thrift/src/codec/default/ttheader.rs
@@ -321,6 +321,7 @@ pub(crate) fn encode<Cx: ThriftContext>(
             Role::Server => {
                 metainfo.get_all_backward_transients().is_some()
                     || cx.encode_conn_reset().unwrap_or(false)
+                    || cx.stats().biz_error().is_some()
             }
         };
 


### PR DESCRIPTION
This PR eliminates the type for server::run. If we intend to add more service before actual running in the future, it will not be a break change anymore.