### PR TITLE
chore(volo-http): adjust stats of client and server

### DIFF
--- a/examples/src/http/example-http-server.rs
+++ b/examples/src/http/example-http-server.rs
@@ -418,8 +418,8 @@ async fn headers_map_response(response: ServerResponse) -> impl IntoResponse {
 fn tracer(cx: &ServerContext) {
     tracing::info!(
         "process start at {:?}, end at {:?}, req size: {:?}, resp size: {:?}, resp status: {:?}",
-        cx.stats.process_start_at().unwrap(),
-        cx.stats.process_end_at().unwrap(),
+        cx.common_stats.process_start_at().unwrap(),
+        cx.common_stats.process_end_at().unwrap(),
         cx.common_stats.req_size().unwrap_or(&0),
         cx.common_stats.resp_size().unwrap_or(&0),
         cx.common_stats.status_code().unwrap(),

--- a/volo-http/src/client/meta.rs
+++ b/volo-http/src/client/meta.rs
@@ -64,7 +64,7 @@ where
 
         if stat_enabled {
             if let Ok(response) = res.as_ref() {
-                cx.stats.set_status_code(response.status());
+                cx.common_stats.set_status_code(response.status());
                 if let Some(resp_size) = response.size_hint().exact() {
                     cx.common_stats.set_resp_size(resp_size);
                 }

--- a/volo-http/src/client/mod.rs
+++ b/volo-http/src/client/mod.rs
@@ -567,13 +567,13 @@ where
 
         let mk_call = async {
             if stat_enabled {
-                cx.stats.record_process_start_at();
+                cx.common_stats.record_process_start_at();
             }
 
             let res = self.service.call(cx, req).await;
 
             if stat_enabled {
-                cx.stats.record_process_end_at();
+                cx.common_stats.record_process_end_at();
             }
             res
         };

--- a/volo-http/src/client/mod.rs
+++ b/volo-http/src/client/mod.rs
@@ -377,7 +377,7 @@ impl<L, MkC> ClientBuilder<L, MkC> {
             config: self.config,
         };
         let client = Client {
-            transport: service,
+            service,
             inner: Arc::new(client_inner),
         };
         self.mk_client.mk_client(client)
@@ -393,7 +393,7 @@ struct ClientInner {
 
 #[derive(Clone)]
 pub struct Client<S> {
-    transport: S,
+    service: S,
     inner: Arc<ClientInner>,
 }
 
@@ -563,7 +563,20 @@ where
         req.headers_mut().extend(self.inner.headers.clone());
 
         let has_metainfo = METAINFO.try_with(|_| {}).is_ok();
-        let mk_call = self.transport.call(cx, req);
+        let stat_enabled = cx.stat_enabled();
+
+        let mk_call = async {
+            if stat_enabled {
+                cx.stats.record_process_start_at();
+            }
+
+            let res = self.service.call(cx, req).await;
+
+            if stat_enabled {
+                cx.stats.record_process_end_at();
+            }
+            res
+        };
 
         if has_metainfo {
             mk_call.await

--- a/volo-http/src/context/client.rs
+++ b/volo-http/src/context/client.rs
@@ -63,6 +63,8 @@ impl ClientCxInner {
 /// This is unstable now and may be changed in the future.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct ClientStats {
+    process_start_at: Option<DateTime<Local>>,
+    process_end_at: Option<DateTime<Local>>,
     transport_start_at: Option<DateTime<Local>>,
     transport_end_at: Option<DateTime<Local>>,
 
@@ -70,6 +72,8 @@ pub struct ClientStats {
 }
 
 impl ClientStats {
+    stat_impl!(process_start_at);
+    stat_impl!(process_end_at);
     stat_impl!(transport_start_at);
     stat_impl!(transport_end_at);
     stat_impl_getter_and_setter!(status_code, StatusCode);

--- a/volo-http/src/context/client.rs
+++ b/volo-http/src/context/client.rs
@@ -1,6 +1,5 @@
 use chrono::{DateTime, Local};
 use faststr::FastStr;
-use http::StatusCode;
 use paste::paste;
 use volo::{
     context::{Context, Reusable, Role, RpcCx, RpcInfo},
@@ -61,22 +60,15 @@ impl ClientCxInner {
 }
 
 /// This is unstable now and may be changed in the future.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone)]
 pub struct ClientStats {
-    process_start_at: Option<DateTime<Local>>,
-    process_end_at: Option<DateTime<Local>>,
     transport_start_at: Option<DateTime<Local>>,
     transport_end_at: Option<DateTime<Local>>,
-
-    status_code: Option<StatusCode>,
 }
 
 impl ClientStats {
-    stat_impl!(process_start_at);
-    stat_impl!(process_end_at);
     stat_impl!(transport_start_at);
     stat_impl!(transport_end_at);
-    stat_impl_getter_and_setter!(status_code, StatusCode);
 }
 
 #[derive(Clone, Debug)]

--- a/volo-http/src/context/mod.rs
+++ b/volo-http/src/context/mod.rs
@@ -1,4 +1,5 @@
-use http::StatusCode;
+use chrono::{DateTime, Local};
+use http::{Method, StatusCode, Uri};
 use paste::paste;
 
 // This macro is unused only when both `client` and `server` features are not enabled.
@@ -58,17 +59,29 @@ pub mod server;
 pub use self::server::{RequestPartsExt, ServerContext};
 
 /// This is unstable now and may be changed in the future.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone)]
 pub struct CommonStats {
+    process_start_at: Option<DateTime<Local>>,
+    process_end_at: Option<DateTime<Local>>,
+
+    method: Option<Method>,
+    uri: Option<Uri>,
+    status_code: Option<StatusCode>,
+
     req_size: Option<u64>,
     resp_size: Option<u64>,
-    status_code: Option<StatusCode>,
 }
 
 impl CommonStats {
+    stat_impl!(process_start_at);
+    stat_impl!(process_end_at);
+
+    stat_impl_getter_and_setter!(method, Method);
+    stat_impl_getter_and_setter!(uri, Uri);
+    stat_impl_getter_and_setter!(status_code, StatusCode);
+
     stat_impl_getter_and_setter!(req_size, u64);
     stat_impl_getter_and_setter!(resp_size, u64);
-    stat_impl_getter_and_setter!(status_code, StatusCode);
 
     #[inline]
     pub fn reset(&mut self) {

--- a/volo-http/src/context/server.rs
+++ b/volo-http/src/context/server.rs
@@ -1,10 +1,8 @@
-use chrono::{DateTime, Local};
 use http::{
     header,
     header::{HeaderMap, HeaderValue},
     request::Parts,
     uri::{Authority, PathAndQuery, Scheme, Uri},
-    Method,
 };
 use paste::paste;
 use volo::{
@@ -68,22 +66,11 @@ impl ServerCxInner {
 
 /// This is unstable now and may be changed in the future.
 #[derive(Debug, Default, Clone)]
-pub struct ServerStats {
-    process_start_at: Option<DateTime<Local>>,
-    process_end_at: Option<DateTime<Local>>,
+pub struct ServerStats {}
 
-    method: Option<Method>,
-    uri: Option<Uri>,
-}
+impl ServerStats {}
 
-impl ServerStats {
-    stat_impl!(process_start_at);
-    stat_impl!(process_end_at);
-    stat_impl_getter_and_setter!(method, Method);
-    stat_impl_getter_and_setter!(uri, Uri);
-}
-
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct Config {
     pub(crate) stat_enable: bool,
 }

--- a/volo-http/src/server/mod.rs
+++ b/volo-http/src/server/mod.rs
@@ -309,7 +309,7 @@ impl<S, L> Server<S, L> {
                 tokio::task::spawn(handle_conn(
                     conn,
                     service.clone(),
-                    self.config,
+                    self.config.clone(),
                     stat_tracer.clone(),
                     exit_notify_inner.clone(),
                     conn_cnt.clone(),
@@ -430,7 +430,7 @@ async fn handle_conn<S>(
             serve(
                 service.clone(),
                 peer.clone(),
-                config,
+                config.clone(),
                 stat_tracer.clone(),
                 req,
             )
@@ -478,18 +478,18 @@ where
             let stat_enabled = cx.stat_enabled();
 
             if stat_enabled {
-                cx.stats.set_uri(request.uri().to_owned());
-                cx.stats.set_method(request.method().to_owned());
+                cx.common_stats.set_uri(request.uri().to_owned());
+                cx.common_stats.set_method(request.method().to_owned());
                 if let Some(req_size) = request.size_hint().exact() {
                     cx.common_stats.set_req_size(req_size);
                 }
-                cx.stats.record_process_start_at();
+                cx.common_stats.record_process_start_at();
             }
 
             let resp = service.call(&mut cx, request).await.into_response();
 
             if stat_enabled {
-                cx.stats.record_process_end_at();
+                cx.common_stats.record_process_end_at();
                 cx.common_stats.set_status_code(resp.status());
                 if let Some(resp_size) = resp.size_hint().exact() {
                     cx.common_stats.set_resp_size(resp_size);


### PR DESCRIPTION
## Motivation

We note that `process_start`, `process_end` and `method`, `uri`, `status_code` are common information, it is best to put them in `CommonStats`. And only the client needs to log transport times, so this can be put in `ClientStats`.

## Solution

```diff
 pub struct CommonStats {
+    process_start_at: Option<DateTime<Local>>,
+    process_end_at: Option<DateTime<Local>>,
+
+    method: Option<Method>,
+    uri: Option<Uri>,
+    status_code: Option<StatusCode>,
+
     req_size: Option<u64>,
     resp_size: Option<u64>,
-    status_code: Option<StatusCode>,
 }

+pub struct ServerStats {}
-pub struct ServerStats {
-    process_start_at: Option<DateTime<Local>>,
-    process_end_at: Option<DateTime<Local>>,
-
-    method: Option<Method>,
-    uri: Option<Uri>,
-}

 pub struct ClientStats {
     transport_start_at: Option<DateTime<Local>>,
     transport_end_at: Option<DateTime<Local>>,
-
-    status_code: Option<StatusCode>,
 }
```