### PR TITLE
feat(volo-build, volo-cli): add more hint for build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3003,7 +3003,7 @@ dependencies = [
 
 [[package]]
 name = "volo-build"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "volo-cli"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/examples/volo-gen/volo.yml
+++ b/examples/volo-gen/volo.yml
@@ -1,3 +1,4 @@
+# Please refer to https://www.cloudwego.io/docs/volo/guide/config/ for the configuration file format.
 entries:
   proto:
     filename: proto_gen.rs
@@ -6,29 +7,29 @@ entries:
       protobuf:
         url: https://github.com/protocolbuffers/protobuf.git
         ref: HEAD
-        lock: 704d0454ddc58da683e8cec22896ff3498089549
+        lock: cb93f9aa6e81329e368f09ded42d17c3f26442f2
     services:
-      - idl:
-          source: local
-          path: ../proto/echo.proto
-          includes:
-            - ../proto
-      - idl:
-          source: local
-          path: ../proto/streaming.proto
-          includes:
-            - ../proto
-      - idl:
-          source: local
-          path: ../proto/hello.proto
-          includes:
-            - ../proto
-      - idl:
-          source: git
-          repo: protobuf
-          path: examples/addressbook.proto
-          includes:
-            - examples
+    - idl:
+        source: local
+        path: ../proto/echo.proto
+        includes:
+        - ../proto
+    - idl:
+        source: local
+        path: ../proto/streaming.proto
+        includes:
+        - ../proto
+    - idl:
+        source: local
+        path: ../proto/hello.proto
+        includes:
+        - ../proto
+    - idl:
+        source: git
+        repo: protobuf
+        path: examples/addressbook.proto
+        includes:
+        - examples
   thrift:
     filename: thrift_gen.rs
     protocol: thrift
@@ -38,18 +39,18 @@ entries:
         ref: HEAD
         lock: 9bd1f1bee7bf59080492bbd3213ca1fed57ab4d6
     services:
-      - idl:
-          source: local
-          path: ../thrift_idl/hello.thrift
-      - idl:
-          source: local
-          path: ../thrift_idl/echo.thrift
-      - idl:
-          source: local
-          path: ../thrift_idl/echo_unknown.thrift
-        codegen_option:
-          keep_unknown_fields: true
-      - idl:
-          source: git
-          repo: thrift
-          path: test/Service.thrift
+    - idl:
+        source: local
+        path: ../thrift_idl/hello.thrift
+    - idl:
+        source: local
+        path: ../thrift_idl/echo.thrift
+    - idl:
+        source: local
+        path: ../thrift_idl/echo_unknown.thrift
+      codegen_option:
+        keep_unknown_fields: true
+    - idl:
+        source: git
+        repo: thrift
+        path: test/Service.thrift

--- a/volo-build/Cargo.toml
+++ b/volo-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-build"
-version = "0.10.0"
+version = "0.10.1"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-build/src/config_builder.rs
+++ b/volo-build/src/config_builder.rs
@@ -156,8 +156,8 @@ impl ConfigBuilder {
 
     pub fn write(self) -> anyhow::Result<()> {
         println!("cargo:rerun-if-changed={}", self.filename.display());
-        let f = open_config_file(self.filename.clone())?;
-        let config = read_config_from_file(&f)?;
+        let mut f = open_config_file(self.filename.clone())?;
+        let config = read_config_from_file(&mut f)?;
         config
             .entries
             .into_iter()

--- a/volo-build/src/util.rs
+++ b/volo-build/src/util.rs
@@ -38,7 +38,7 @@ pub fn read_config_from_file(f: &mut File) -> Result<SingleConfig, serde_yaml::E
             if metadata.len() == 0 {
                 Ok(SingleConfig::new())
             } else {
-                let mut s = String::with_capacity(4096); // should be enough for most cases
+                let mut s = String::with_capacity(metadata.len() as usize);
                 f.read_to_string(&mut s).map_err(|e| {
                     serde_yaml::Error::custom(format!("failed to read config file, err: {}", e))
                 })?;

--- a/volo-cli/Cargo.toml
+++ b/volo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-cli"
-version = "0.10.0"
+version = "0.10.1"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Motivation

1. Add more hint for `volo-build` of the config file migration
2. Add docs link to the front of config file
3. Make `volo-cli` update detect before executing, and add an env to opt-out the behaviour
