### PR TITLE
feat(volo-http): support default target for client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,6 +406,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +486,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -818,6 +836,12 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -835,12 +859,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-proto"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091a6fbccf4860009355e3efc52ff4acf37a63489aad7435372d44ceeb6fbbcf"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 0.4.0",
+ "ipnet",
+ "once_cell",
+ "rand",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b8f021164e6a984c9030023544c57789c51760065cd510572fedcfb04164e8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "rand",
+ "resolv-conf",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "home"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
 ]
 
 [[package]]
@@ -1034,6 +1114,16 @@ dependencies = [
 
 [[package]]
 name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
@@ -1079,6 +1169,18 @@ checksum = "924df4f0e24e2e7f9cdd90babb0b96f93b20f3ecfa949ea9e6613756b8c8e1bf"
 dependencies = [
  "async-trait",
  "tokio",
+]
+
+[[package]]
+name = "ipconfig"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-sys 0.48.0",
+ "winreg",
 ]
 
 [[package]]
@@ -1215,6 +1317,21 @@ name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"
@@ -1893,6 +2010,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2063,6 +2186,16 @@ dependencies = [
  "web-sys",
  "webpki-roots 0.25.4",
  "winreg",
+]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
+dependencies = [
+ "hostname",
+ "quick-error",
 ]
 
 [[package]]
@@ -2935,7 +3068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.5.0",
  "percent-encoding",
 ]
 
@@ -3118,11 +3251,13 @@ dependencies = [
  "faststr",
  "futures",
  "futures-util",
+ "hickory-resolver",
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
  "hyper 1.2.0",
  "hyper-util",
+ "lazy_static",
  "matchit",
  "metainfo",
  "mime",
@@ -3305,6 +3440,12 @@ dependencies = [
  "once_cell",
  "rustix",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ git2 = { version = "0.18", default-features = false }
 h2 = "0.4"
 heck = "0.5"
 hex = "0.4"
+hickory-resolver = "0.24"
 http = "1"
 http-body = "1"
 http-body-util = "0.1"

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -27,11 +27,13 @@ chrono.workspace = true
 faststr.workspace = true
 futures.workspace = true
 futures-util.workspace = true
+hickory-resolver.workspace = true
 http.workspace = true
 http-body.workspace = true
 http-body-util.workspace = true
 hyper = { workspace = true, features = ["client", "server", "http1"] }
 hyper-util = { workspace = true, features = ["tokio"] }
+lazy_static.workspace = true
 metainfo.workspace = true
 mime.workspace = true
 motore.workspace = true

--- a/volo-http/src/client/utils.rs
+++ b/volo-http/src/client/utils.rs
@@ -1,94 +1,192 @@
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 
 use faststr::FastStr;
-use http::{uri::Scheme, Uri};
-use tokio::net::lookup_host;
+use hickory_resolver::{AsyncResolver, Resolver, TokioAsyncResolver};
+use http::uri::{Scheme, Uri};
+use lazy_static::lazy_static;
 use volo::net::Address;
 
+use super::ClientInner;
 use crate::{
-    error::client::{bad_host_name, bad_scheme, builder_error, uri_without_host, Result},
+    context::client::CalleeName,
+    error::client::{bad_host_name, bad_scheme, no_address, unreachable_builder_error, Result},
     utils::consts,
 };
 
-pub trait IntoUri {
-    fn into_uri(self) -> Result<Uri>;
+lazy_static! {
+    static ref SYNC_RESOLVER: Resolver =
+        Resolver::from_system_conf().expect("failed to init dns resolver");
+    static ref ASYNC_RESOLVER: TokioAsyncResolver =
+        AsyncResolver::tokio_from_system_conf().expect("failed to init dns resolver");
 }
 
-impl IntoUri for Uri {
-    fn into_uri(self) -> Result<Uri> {
-        if self.scheme().is_none() {
-            Err(uri_without_host(self))
-        } else {
-            Ok(self)
+#[derive(Clone)]
+pub struct Target {
+    pub addr: Address,
+    #[cfg(feature = "__tls")]
+    pub use_tls: bool,
+    pub(crate) callee_name: FastStr,
+}
+
+#[derive(Clone, Default)]
+pub enum TargetBuilder {
+    #[default]
+    None,
+    Address {
+        addr: Address,
+        #[cfg(feature = "__tls")]
+        use_tls: bool,
+    },
+    Host {
+        scheme: Option<Scheme>,
+        host: FastStr,
+        port: Option<u16>,
+    },
+}
+
+impl TargetBuilder {
+    pub fn is_none(&self) -> bool {
+        matches!(self, Self::None)
+    }
+
+    #[cfg(feature = "__tls")]
+    pub fn is_tls(&self) -> bool {
+        match self {
+            Self::None => false,
+            Self::Address { use_tls, .. } => *use_tls,
+            Self::Host { scheme, .. } => {
+                // If scheme is none, use https by default
+                scheme.as_ref() == Some(&Scheme::HTTPS) || scheme.is_none()
+            }
         }
     }
-}
 
-impl<'a> IntoUri for &'a str {
-    fn into_uri(self) -> Result<Uri> {
-        match self.parse::<Uri>() {
-            Ok(uri) => uri.into_uri(),
-            Err(err) => Err(builder_error(err)),
+    pub(crate) fn gen_callee_name(&self, mode: &CalleeName, orig_callee_name: &FastStr) -> FastStr {
+        match *mode {
+            CalleeName::None => FastStr::empty(),
+            CalleeName::TargetName => match self {
+                Self::None => FastStr::empty(),
+                Self::Address { addr, .. } => FastStr::from_string(format!("{addr}")),
+                Self::Host {
+                    ref scheme,
+                    host,
+                    port,
+                } => match port {
+                    Some(port) => {
+                        if get_port(scheme.as_ref()) == Some(*port) {
+                            host.clone()
+                        } else {
+                            FastStr::from_string(format!("{host}:{port}"))
+                        }
+                    }
+                    None => host.clone(),
+                },
+            },
+            CalleeName::OriginalCalleeName => orig_callee_name.clone(),
         }
     }
-}
 
-impl IntoUri for String {
-    fn into_uri(self) -> Result<Uri> {
-        self.as_str().into_uri()
+    pub fn resolve_sync(self) -> Result<Address> {
+        match self {
+            Self::None => Err(no_address()),
+            Self::Address { addr, .. } => Ok(addr),
+            Self::Host { scheme, host, port } => resolve_sync(scheme, &host, port),
+        }
     }
-}
 
-impl IntoUri for FastStr {
-    fn into_uri(self) -> Result<Uri> {
-        self.as_str().into_uri()
+    pub async fn resolve(self) -> Result<Address> {
+        match self {
+            Self::None => Err(no_address()),
+            Self::Address { addr, .. } => Ok(addr),
+            Self::Host { scheme, host, port } => resolve(scheme, &host, port).await,
+        }
     }
-}
 
-fn get_port(uri: &Uri) -> Result<u16> {
-    let port = match uri.port_u16() {
-        Some(port) => port,
-        None => {
-            let scheme = match uri.scheme() {
-                Some(scheme) => scheme,
-                None => {
-                    return Err(bad_scheme(uri.to_owned()));
-                }
-            };
-            // `match` is unavailable here, ref:
-            // https://doc.rust-lang.org/stable/std/marker/trait.StructuralPartialEq.html
+    pub(crate) async fn into_target(self, client_inner: &ClientInner) -> Result<Option<Target>> {
+        if matches!(self, Self::None) {
+            return Ok(None);
+        }
+        let callee_name =
+            self.gen_callee_name(&client_inner.config.callee_name, &client_inner.callee_name);
+        #[cfg(feature = "__tls")]
+        let use_tls = self.is_tls();
+        Ok(Some(Target {
+            addr: self.resolve().await?,
             #[cfg(feature = "__tls")]
-            if scheme == &Scheme::HTTPS {
-                return Ok(consts::HTTPS_DEFAULT_PORT);
-            }
-            if scheme == &Scheme::HTTP {
-                consts::HTTP_DEFAULT_PORT
-            } else {
-                return Err(bad_scheme(uri.to_owned()));
-            }
-        }
-    };
-    Ok(port)
+            use_tls,
+            callee_name,
+        }))
+    }
 }
 
-pub async fn resolve(uri: &Uri) -> Result<Address> {
+fn get_port(scheme: Option<&Scheme>) -> Option<u16> {
+    // `match` is unavailable here, ref:
+    // https://doc.rust-lang.org/stable/std/marker/trait.StructuralPartialEq.html
+    #[cfg(feature = "__tls")]
+    if scheme == Some(&Scheme::HTTPS) || scheme.is_none() {
+        return Some(consts::HTTPS_DEFAULT_PORT);
+    }
+    if scheme == Some(&Scheme::HTTP) || scheme.is_none() {
+        return Some(consts::HTTP_DEFAULT_PORT);
+    }
+
+    None
+}
+
+fn prepare_host_and_port(
+    scheme: Option<Scheme>,
+    host: &str,
+    port: Option<u16>,
+) -> Result<(&str, u16)> {
     // Trim the brackets from the host name if it's an IPv6 address.
     //
     // e.g., for `http://[::1]:8080/`, it can be trimed to `::1` rather than `[::1]`
-    let host = uri
-        .host()
-        .ok_or(uri_without_host(uri.to_owned()))?
-        .trim_start_matches('[')
-        .trim_end_matches(']');
-    let port = get_port(uri)?;
+    let host = host.trim_start_matches('[').trim_end_matches(']');
+    let port = match port {
+        Some(port) => port,
+        None => get_port(scheme.as_ref()).ok_or_else(|| {
+            if let Some(scheme) = scheme {
+                if let Ok(uri) = Uri::try_from(format!("{}://{}", scheme, host)) {
+                    return bad_scheme(uri);
+                }
+            }
+            unreachable_builder_error()
+        })?,
+    };
 
-    // Parse the adddress directly.
-    if let Ok(addr) = host.parse::<IpAddr>() {
-        return Ok(Address::from(SocketAddr::new(addr, port)));
-    }
+    Ok((host, port))
+}
+
+fn resolve_sync(scheme: Option<Scheme>, host: &str, port: Option<u16>) -> Result<Address> {
+    let (host, port) = prepare_host_and_port(scheme, host, port)?;
+
+    // The Resolver will try to parse the host as an IP address first, so we don't need
+    // to parse it manually.
+    if let Ok(resp) = SYNC_RESOLVER.lookup_ip(host) {
+        if let Some(addr) = resp.iter().next() {
+            return Ok(Address::Ip(SocketAddr::new(addr, port)));
+        }
+    };
+
+    Err(bad_host_name(
+        Uri::try_from(host).map_err(|_| unreachable_builder_error())?,
+    ))
+}
+
+async fn resolve(scheme: Option<Scheme>, host: &str, port: Option<u16>) -> Result<Address> {
+    let (host, port) = prepare_host_and_port(scheme, host, port)?;
 
     // The address may be a domain name, so we need to resolve it.
-    let mut iter = lookup_host((host, port)).await.map_err(builder_error)?;
-    let addr = iter.next().ok_or_else(|| bad_host_name(uri.to_owned()))?;
-    Ok(Address::Ip(addr))
+    //
+    // Note that the Resolver will try to parse the host as an IP address first, so we don't need
+    // to parse it manually.
+    if let Ok(resp) = ASYNC_RESOLVER.lookup_ip(host).await {
+        if let Some(addr) = resp.iter().next() {
+            return Ok(Address::Ip(SocketAddr::new(addr, port)));
+        }
+    };
+
+    Err(bad_host_name(
+        Uri::try_from(host).map_err(|_| unreachable_builder_error())?,
+    ))
 }

--- a/volo-http/src/error/client.rs
+++ b/volo-http/src/error/client.rs
@@ -174,8 +174,7 @@ macro_rules! simple_error_with_url {
     };
 }
 
-simple_error!(Builder => NoUri => "uri not found");
-simple_error_with_url!(Builder => UriWithoutHost => "host not found in uri");
+simple_error!(Builder => NoAddress => "missing target address");
 simple_error_with_url!(Builder => BadScheme => "bad scheme");
 simple_error_with_url!(Builder => BadHostName => "bad host name");
-simple_error!(Request => NoAddress => "missing target address");
+simple_error!(Builder => UnreachableBuilderError => "unreachable builder error");


### PR DESCRIPTION
## Motivation

Sometimes we use HTTP client for a fixed target address, this PR adds default target for client, with which client can build a request without setting the target address and send it directly.

In addition, this PR also adds `Target` with its builder.  With them introduced, client and request builder can use a more elegant way for setting target address.

## Solution

1. Support setting target address for `ClientBuilder`
2. Add `TargetBuilder` which can be set to address or hostname and will be resolved to address finally