### PR TITLE
fix(volo-cli): modify the local init service path relative to the yml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3136,7 +3136,7 @@ dependencies = [
 
 [[package]]
 name = "volo-build"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3167,7 +3167,7 @@ dependencies = [
 
 [[package]]
 name = "volo-cli"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/volo-build/Cargo.toml
+++ b/volo-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-build"
-version = "0.10.1"
+version = "0.10.2"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-cli/Cargo.toml
+++ b/volo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-cli"
-version = "0.10.1"
+version = "0.10.2"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Motivation
The initialization of local idl is based on the raw path, and the modification of relative path is for the volo.yml has moved into the volo-gen dir generated at the init cmd execution path. However, the modification should occur after the initialization but it was actually not.

## Solution
Modify the local service path relative to the yml file after initialization if the given path is relative.
