### PR TITLE
feat(volo-http): support path extractor

### DIFF
--- a/volo-http/src/context/server.rs
+++ b/volo-http/src/context/server.rs
@@ -11,7 +11,7 @@ use volo::{
 };
 
 use crate::{
-    server::param::Params,
+    server::param::UrlParamsVec,
     utils::{
         consts::{HTTPS_DEFAULT_PORT, HTTP_DEFAULT_PORT},
         macros::{impl_deref_and_deref_mut, impl_getter},
@@ -26,7 +26,7 @@ impl ServerContext {
         let mut cx = RpcCx::new(
             RpcInfo::<Config>::with_role(Role::Server),
             ServerCxInner {
-                params: Params::default(),
+                params: UrlParamsVec::default(),
             },
         );
         cx.rpc_info_mut().caller_mut().set_address(peer);
@@ -40,11 +40,11 @@ newtype_impl_context!(ServerContext, Config, 0);
 
 #[derive(Clone, Debug)]
 pub struct ServerCxInner {
-    pub params: Params,
+    pub params: UrlParamsVec,
 }
 
 impl ServerCxInner {
-    impl_getter!(params, Params);
+    impl_getter!(params, UrlParamsVec);
 }
 
 #[derive(Clone, Debug, Default)]

--- a/volo-http/src/error/mod.rs
+++ b/volo-http/src/error/mod.rs
@@ -8,6 +8,6 @@ pub use self::client::ClientError;
 #[cfg(feature = "server")]
 pub mod server;
 #[cfg(feature = "server")]
-pub use self::server::RejectionError;
+pub use self::server::ExtractBodyError;
 
 pub type BoxError = Box<dyn Error + Send + Sync>;

--- a/volo-http/src/error/server.rs
+++ b/volo-http/src/error/server.rs
@@ -1,29 +1,41 @@
+use std::{error::Error, fmt};
+
 use http::StatusCode;
 
 use crate::{response::ServerResponse, server::IntoResponse};
 
 #[derive(Debug)]
 #[non_exhaustive]
-pub enum RejectionError {
+pub enum ExtractBodyError {
     Common(CommonRejectionError),
     String(simdutf8::basic::Utf8Error),
     #[cfg(feature = "__json")]
     Json(crate::json::Error),
-    #[cfg(feature = "query")]
-    Query(serde_urlencoded::de::Error),
     #[cfg(feature = "form")]
     Form(serde_urlencoded::de::Error),
 }
 
-impl IntoResponse for RejectionError {
+impl fmt::Display for ExtractBodyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("failed to extract ")?;
+        match self {
+            Self::Common(e) => write!(f, "data: {e}"),
+            Self::String(e) => write!(f, "string: {e}"),
+            #[cfg(feature = "__json")]
+            Self::Json(e) => write!(f, "json: {e}"),
+            #[cfg(feature = "form")]
+            Self::Form(e) => write!(f, "form: {e}"),
+        }
+    }
+}
+
+impl IntoResponse for ExtractBodyError {
     fn into_response(self) -> ServerResponse {
         let status = match self {
             Self::Common(e) => e.to_status_code(),
             Self::String(_) => StatusCode::UNSUPPORTED_MEDIA_TYPE,
             #[cfg(feature = "__json")]
             Self::Json(_) => StatusCode::BAD_REQUEST,
-            #[cfg(feature = "query")]
-            Self::Query(_) => StatusCode::BAD_REQUEST,
             #[cfg(feature = "form")]
             Self::Form(_) => StatusCode::BAD_REQUEST,
         };
@@ -38,6 +50,17 @@ pub enum CommonRejectionError {
     BodyCollectionError,
     InvalidContentType,
 }
+
+impl fmt::Display for CommonRejectionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BodyCollectionError => write!(f, "failed to collect the response body"),
+            Self::InvalidContentType => write!(f, "invalid content type"),
+        }
+    }
+}
+
+impl Error for CommonRejectionError {}
 
 impl CommonRejectionError {
     pub fn to_status_code(self) -> StatusCode {
@@ -54,10 +77,10 @@ impl IntoResponse for CommonRejectionError {
     }
 }
 
-pub fn body_collection_error() -> RejectionError {
-    RejectionError::Common(CommonRejectionError::BodyCollectionError)
+pub fn body_collection_error() -> ExtractBodyError {
+    ExtractBodyError::Common(CommonRejectionError::BodyCollectionError)
 }
 
-pub fn invalid_content_type() -> RejectionError {
-    RejectionError::Common(CommonRejectionError::InvalidContentType)
+pub fn invalid_content_type() -> ExtractBodyError {
+    ExtractBodyError::Common(CommonRejectionError::InvalidContentType)
 }

--- a/volo-http/src/json/server.rs
+++ b/volo-http/src/json/server.rs
@@ -11,7 +11,7 @@ use serde::de::DeserializeOwned;
 use super::{deserialize, Error, Json};
 use crate::{
     context::ServerContext,
-    error::server::{invalid_content_type, RejectionError},
+    error::server::{invalid_content_type, ExtractBodyError},
     response::ServerResponse,
     server::{extract::FromRequest, IntoResponse},
 };
@@ -26,7 +26,7 @@ impl<T> FromRequest for Json<T>
 where
     T: DeserializeOwned,
 {
-    type Rejection = RejectionError;
+    type Rejection = ExtractBodyError;
 
     async fn from_request(
         cx: &mut ServerContext,
@@ -38,7 +38,7 @@ where
         }
 
         let bytes = Bytes::from_request(cx, parts, body).await?;
-        let json = deserialize(&bytes).map_err(RejectionError::Json)?;
+        let json = deserialize(&bytes).map_err(ExtractBodyError::Json)?;
 
         Ok(Json(json))
     }

--- a/volo-http/src/server/handler.rs
+++ b/volo-http/src/server/handler.rs
@@ -18,7 +18,7 @@ use crate::{
     context::ServerContext,
     request::ServerRequest,
     response::ServerResponse,
-    utils::macros::{all_the_tuples, all_the_tuples_no_last_special_case},
+    utils::macros::{all_the_tuples, all_the_tuples_with_special_case},
 };
 
 pub trait Handler<T, E>: Sized {
@@ -78,7 +78,7 @@ macro_rules! impl_handler {
     };
 }
 
-all_the_tuples!(impl_handler);
+all_the_tuples_with_special_case!(impl_handler);
 
 pub struct HandlerService<H, T, E> {
     handler: H,
@@ -159,7 +159,7 @@ macro_rules! impl_handler_without_request {
     };
 }
 
-all_the_tuples_no_last_special_case!(impl_handler_without_request);
+all_the_tuples!(impl_handler_without_request);
 
 pub trait MiddlewareHandlerFromFn<'r, T, E>: Sized {
     type Future: Future<Output = ServerResponse> + Send + 'r;
@@ -214,7 +214,7 @@ macro_rules! impl_middleware_handler_from_fn {
     };
 }
 
-all_the_tuples!(impl_middleware_handler_from_fn);
+all_the_tuples_with_special_case!(impl_middleware_handler_from_fn);
 
 pub trait MiddlewareHandlerMapResponse<'r, T>: Sized {
     type Future: Future<Output = ServerResponse> + Send + 'r;

--- a/volo-http/src/server/mod.rs
+++ b/volo-http/src/server/mod.rs
@@ -47,7 +47,7 @@ pub mod route;
 
 #[doc(hidden)]
 pub mod prelude {
-    pub use super::{param::Params, route::Router, Server};
+    pub use super::{param::UrlParamsVec, route::Router, Server};
     #[cfg(feature = "cookie")]
     pub use crate::cookie::CookieJar;
 }

--- a/volo-http/src/server/param.rs
+++ b/volo-http/src/server/param.rs
@@ -1,16 +1,24 @@
-use std::collections::{hash_map::Iter, HashMap};
+use std::{convert::Infallible, error::Error, fmt, ops::Deref, str::FromStr};
 
-use ahash::RandomState;
+use ahash::AHashMap;
 use bytes::{BufMut, BytesMut};
 use faststr::FastStr;
+use http::{request::Parts, StatusCode};
+use matchit::Params;
+
+use super::{extract::FromContext, IntoResponse};
+use crate::{
+    context::ServerContext, error::BoxError, response::ServerResponse,
+    utils::macros::all_the_tuples,
+};
 
 #[derive(Clone, Debug, Default)]
-pub struct Params {
-    inner: HashMap<FastStr, FastStr, RandomState>,
+pub struct UrlParamsVec {
+    inner: Vec<(FastStr, FastStr)>,
 }
 
-impl Params {
-    pub(crate) fn extend(&mut self, params: matchit::Params<'_, '_>) {
+impl UrlParamsVec {
+    pub(crate) fn extend(&mut self, params: Params) {
         self.inner.reserve(params.len());
 
         let cap = params.iter().map(|(k, v)| k.len() + v.len()).sum();
@@ -18,30 +26,180 @@ impl Params {
 
         for (k, v) in params.iter() {
             buf.put(k.as_bytes());
-            // SAFETY: The key is from a valid string as path of router
+            // SAFETY: The key is a valid string
             let k = unsafe { FastStr::from_bytes_unchecked(buf.split().freeze()) };
+
             buf.put(v.as_bytes());
-            // SAFETY: The value is from a valid string as requested uri
+            // SAFETY: The value is a valid string
             let v = unsafe { FastStr::from_bytes_unchecked(buf.split().freeze()) };
-            if self.inner.insert(k, v).is_some() {
-                tracing::info!("[VOLO-HTTP] Conflicting key in param");
-            }
+
+            self.inner.push((k, v));
         }
     }
+}
 
-    pub fn len(&self) -> usize {
-        self.inner.len()
+impl Deref for UrlParamsVec {
+    type Target = [(FastStr, FastStr)];
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
     }
+}
 
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
+impl FromContext for UrlParamsVec {
+    type Rejection = Infallible;
+
+    async fn from_context(cx: &mut ServerContext, _: &mut Parts) -> Result<Self, Self::Rejection> {
+        Ok(cx.params().clone())
     }
+}
 
-    pub fn iter(&self) -> Iter<'_, FastStr, FastStr> {
-        self.inner.iter()
+#[derive(Debug, Default, Clone)]
+pub struct UrlParamsMap {
+    inner: AHashMap<FastStr, FastStr>,
+}
+
+impl Deref for UrlParamsMap {
+    type Target = AHashMap<FastStr, FastStr>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
     }
+}
 
-    pub fn get<K: Into<FastStr>>(&self, k: K) -> Option<&FastStr> {
-        self.inner.get(&k.into())
+impl From<UrlParamsVec> for UrlParamsMap {
+    fn from(value: UrlParamsVec) -> Self {
+        let mut inner = AHashMap::with_capacity(value.inner.len());
+
+        for (k, v) in value.inner.into_iter() {
+            inner.insert(k, v);
+        }
+
+        Self { inner }
+    }
+}
+
+impl FromContext for UrlParamsMap {
+    type Rejection = Infallible;
+
+    async fn from_context(cx: &mut ServerContext, _: &mut Parts) -> Result<Self, Self::Rejection> {
+        let params = cx.params();
+        let mut inner = AHashMap::with_capacity(params.len());
+
+        for (k, v) in params.iter() {
+            inner.insert(k.clone(), v.clone());
+        }
+
+        Ok(Self { inner })
+    }
+}
+
+trait FromUrlParam: Sized {
+    fn from_url_param(param: &str) -> Result<Self, UrlParamsRejection>;
+}
+
+macro_rules! impl_from_url_param {
+    ($ty:ty) => {
+        impl FromUrlParam for $ty {
+            fn from_url_param(param: &str) -> Result<Self, UrlParamsRejection> {
+                FromStr::from_str(param)
+                    .map_err(Into::into)
+                    .map_err(UrlParamsRejection::ParseError)
+            }
+        }
+    };
+}
+
+impl_from_url_param!(bool);
+impl_from_url_param!(u8);
+impl_from_url_param!(u16);
+impl_from_url_param!(u32);
+impl_from_url_param!(u64);
+impl_from_url_param!(usize);
+impl_from_url_param!(i8);
+impl_from_url_param!(i16);
+impl_from_url_param!(i32);
+impl_from_url_param!(i64);
+impl_from_url_param!(isize);
+impl_from_url_param!(char);
+impl_from_url_param!(String);
+impl_from_url_param!(FastStr);
+
+#[derive(Debug, Default, Clone)]
+pub struct UrlParams<T>(pub T);
+
+impl<T> FromContext for UrlParams<T>
+where
+    T: FromUrlParam,
+{
+    type Rejection = UrlParamsRejection;
+
+    async fn from_context(cx: &mut ServerContext, _: &mut Parts) -> Result<Self, Self::Rejection> {
+        let mut param_iter = cx.params().iter();
+        let t = T::from_url_param(
+            param_iter
+                .next()
+                .ok_or(UrlParamsRejection::LengthMismatch)?
+                .1
+                .as_str(),
+        )?;
+        Ok(UrlParams(t))
+    }
+}
+
+macro_rules! impl_url_params_extractor {
+    (
+        $($ty:ident),+ $(,)?
+    ) => {
+        #[allow(non_snake_case)]
+        impl<$($ty,)+> FromContext for UrlParams<($($ty,)+)>
+        where
+            $(
+                $ty: FromUrlParam,
+            )+
+        {
+            type Rejection = UrlParamsRejection;
+
+            async fn from_context(
+                cx: &mut ServerContext,
+                _: &mut Parts,
+            ) -> Result<Self, Self::Rejection> {
+                let mut param_iter = cx.params().iter();
+                $(
+                    let $ty = $ty::from_url_param(
+                        param_iter.next().ok_or(UrlParamsRejection::LengthMismatch)?.1.as_str(),
+                    )?;
+                )+
+                Ok(UrlParams(($($ty,)+)))
+            }
+        }
+    };
+}
+
+all_the_tuples!(impl_url_params_extractor);
+
+#[derive(Debug)]
+pub enum UrlParamsRejection {
+    LengthMismatch,
+    ParseError(BoxError),
+}
+
+impl fmt::Display for UrlParamsRejection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::LengthMismatch => write!(
+                f,
+                "the number of url params does not match number of types in `UrlParams`"
+            ),
+            Self::ParseError(e) => write!(f, "url param parse error: {e}"),
+        }
+    }
+}
+
+impl Error for UrlParamsRejection {}
+
+impl IntoResponse for UrlParamsRejection {
+    fn into_response(self) -> ServerResponse {
+        StatusCode::BAD_REQUEST.into_response()
     }
 }

--- a/volo-http/src/utils/macros.rs
+++ b/volo-http/src/utils/macros.rs
@@ -1,5 +1,5 @@
 #[rustfmt::skip]
-macro_rules! all_the_tuples {
+macro_rules! all_the_tuples_with_special_case {
     ($name:ident) => {
         $name!([], T1);
         $name!([T1], T2);
@@ -21,7 +21,7 @@ macro_rules! all_the_tuples {
 }
 
 #[rustfmt::skip]
-macro_rules! all_the_tuples_no_last_special_case {
+macro_rules! all_the_tuples {
     ($name:ident) => {
         $name!(T1);
         $name!(T1, T2);
@@ -107,7 +107,7 @@ macro_rules! stat_impl {
 }
 
 pub(crate) use all_the_tuples;
-pub(crate) use all_the_tuples_no_last_special_case;
+pub(crate) use all_the_tuples_with_special_case;
 pub(crate) use impl_deref_and_deref_mut;
 pub(crate) use impl_getter;
 pub(crate) use stat_impl;


### PR DESCRIPTION
This commit refactors original `Params` and use `UrlParamsVec` instead. The `UrlParamsVec` is saved in `ServerContext` and we can extract it as vector `UrlParamsVec` or map `UrlParamsMap`, or extract as basic types with `UrlParams`, e.g., `UrlParams<String>`, `UrlParams<(usize, String)>`.

Examples are also updated.
