### PR TITLE
chore(volo-http): add docs for important modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3229,7 +3229,7 @@ dependencies = [
 
 [[package]]
 name = "volo-http"
-version = "0.2.0-rc.4"
+version = "0.2.0"
 dependencies = [
  "ahash",
  "bytes",

--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ Volo mainly consists of six crates:
 1. The [`volo`][volo] crate, which contains the common components of the framework.
 2. The [`volo-thrift`][volo-thrift] crate, which provides the Thrift RPC implementation.
 3. The [`volo-grpc`][volo-grpc] crate, which provides the gRPC implementation.
-4. The [`volo-build`][volo-build] crate, which generates thrift and protobuf code.
-5. The [`volo-cli`][volo-cli] crate, which provides the CLI interface to bootstrap a new project and manages the idl files.
-6. The [`volo-macros`][volo-macros] crate, which provides the macros for the framework.
+4. The [`volo-http`][volo-http] crate, which provides the HTTP implementation.
+5. The [`volo-build`][volo-build] crate, which generates thrift and protobuf code.
+6. The [`volo-cli`][volo-cli] crate, which provides the CLI interface to bootstrap a new project and manages the idl files.
+7. The [`volo-macros`][volo-macros] crate, which provides the macros for the framework.
 
 ### Features
 
@@ -66,9 +67,11 @@ For more information, you may refer to [our guide](https://www.cloudwego.io/zh/d
 
 ## Tutorial
 
-Volo-Thrift: https://www.cloudwego.io/zh/docs/volo/volo-thrift/getting-started/
+Volo-Thrift: <https://www.cloudwego.io/zh/docs/volo/volo-thrift/getting-started/>
 
-Volo-gRPC: https://www.cloudwego.io/zh/docs/volo/volo-grpc/getting-started/
+Volo-gRPC: <https://www.cloudwego.io/zh/docs/volo/volo-grpc/getting-started/>
+
+Volo-HTTP: Work In Progess
 
 ## Examples
 
@@ -117,6 +120,7 @@ For the full list, you may refer to the [CREDITS.md](https://github.com/cloudweg
 [volo]: https://docs.rs/volo
 [volo-thrift]: https://docs.rs/volo-thrift
 [volo-grpc]: https://docs.rs/volo-grpc
+[volo-http]: https://docs.rs/volo-http
 [volo-build]: https://docs.rs/volo-build
 [volo-cli]: https://crates.io/crates/volo-cli
 [volo-macros]: https://docs.rs/volo-macros

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-http"
-version = "0.2.0-rc.4"
+version = "0.2.0"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
@@ -71,6 +71,7 @@ sonic-rs = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
+volo = { version = "0.10", path = "../volo" }
 
 [features]
 default = []

--- a/volo-http/src/client/request_builder.rs
+++ b/volo-http/src/client/request_builder.rs
@@ -1,3 +1,5 @@
+#![deny(missing_docs)]
+
 use std::error::Error;
 
 use faststr::FastStr;
@@ -122,11 +124,13 @@ impl<'a, S> RequestBuilder<'a, S, Body> {
 }
 
 impl<'a, S, B> RequestBuilder<'a, S, B> {
+    /// Set method for the request.
     pub fn method(mut self, method: Method) -> Self {
         *self.request.method_mut() = method;
         self
     }
 
+    /// Get the reference of method in the request.
     pub fn method_ref(&self) -> &Method {
         self.request.method()
     }
@@ -182,6 +186,7 @@ impl<'a, S, B> RequestBuilder<'a, S, B> {
         Ok(self)
     }
 
+    /// Set query for the uri in request from object with `Serialize`.
     #[cfg(feature = "query")]
     pub fn set_query<T>(mut self, query: &T) -> Result<Self>
     where

--- a/volo-http/src/lib.rs
+++ b/volo-http/src/lib.rs
@@ -1,3 +1,8 @@
+#![doc(
+    html_logo_url = "https://github.com/cloudwego/volo/raw/main/.github/assets/logo.png?sanitize=true"
+)]
+#![cfg_attr(not(doctest), doc = include_str!("../README.md"))]
+
 pub mod body;
 #[cfg(feature = "client")]
 pub mod client;

--- a/volo-http/src/server/mod.rs
+++ b/volo-http/src/server/mod.rs
@@ -52,6 +52,29 @@ pub mod prelude {
     pub use crate::cookie::CookieJar;
 }
 
+/// High level HTTP server.
+///
+/// # Examples
+///
+/// ```compile_fail
+/// use std::net::SocketAddr;
+///
+/// use volo::net::Address;
+/// use volo_http::server::{
+///     route::{get, Router},
+///     Server,
+/// };
+///
+/// async fn index() -> &'static str {
+///     "Hello, World!"
+/// }
+///
+/// let app = Router::new().route("/", get(index));
+/// let addr = "[::]:8080".parse::<SocketAddr>().unwrap();
+/// let addr = Address::from(addr);
+///
+/// Server::new(app).run(addr).await.unwrap();
+/// ```
 pub struct Server<S, L> {
     service: S,
     layer: L,


### PR DESCRIPTION
## Motivation

This PR add docs for important modules, including `client/mod.rs`, `client/request_builder.rs`, `server/mod.rs` and `server/route.rs`.

`#[deny(missing_docs)]` is also added for `client::request_builer` and `server::route`.

In addition, we bump `volo-http` to `0.2.0` and we will release it after this PR merged.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
