### PR TITLE
feat(volo-http): update url param name to path param. 

### DIFF
--- a/examples/src/http/example-http-server.rs
+++ b/examples/src/http/example-http-server.rs
@@ -20,7 +20,7 @@ use volo_http::{
         extract::{Form, FromContext, MaybeInvalid, Query},
         layer::{FilterLayer, TimeoutLayer},
         middleware::{self, Next},
-        param::UrlParams,
+        param::PathParams,
         route::{get, get_service, post, Router},
         IntoResponse, Server,
     },
@@ -115,11 +115,11 @@ async fn timeout_test() {
     tokio::time::sleep(Duration::from_secs(10)).await
 }
 
-async fn echo(UrlParams(echo): UrlParams<String>) -> String {
+async fn echo(PathParams(echo): PathParams<String>) -> String {
     echo
 }
 
-async fn add(UrlParams((p1, p2)): UrlParams<(usize, usize)>) -> String {
+async fn add(PathParams((p1, p2)): PathParams<(usize, usize)>) -> String {
     format!("{}", p1 + p2)
 }
 

--- a/volo-http/src/context/server.rs
+++ b/volo-http/src/context/server.rs
@@ -11,7 +11,7 @@ use volo::{
 };
 
 use crate::{
-    server::param::UrlParamsVec,
+    server::param::PathParamsVec,
     utils::{
         consts::{HTTPS_DEFAULT_PORT, HTTP_DEFAULT_PORT},
         macros::{impl_deref_and_deref_mut, impl_getter},
@@ -26,7 +26,7 @@ impl ServerContext {
         let mut cx = RpcCx::new(
             RpcInfo::<Config>::with_role(Role::Server),
             ServerCxInner {
-                params: UrlParamsVec::default(),
+                params: PathParamsVec::default(),
             },
         );
         cx.rpc_info_mut().caller_mut().set_address(peer);
@@ -40,11 +40,11 @@ newtype_impl_context!(ServerContext, Config, 0);
 
 #[derive(Clone, Debug)]
 pub struct ServerCxInner {
-    pub params: UrlParamsVec,
+    pub params: PathParamsVec,
 }
 
 impl ServerCxInner {
-    impl_getter!(params, UrlParamsVec);
+    impl_getter!(params, PathParamsVec);
 }
 
 #[derive(Clone, Debug, Default)]

--- a/volo-http/src/server/mod.rs
+++ b/volo-http/src/server/mod.rs
@@ -47,7 +47,7 @@ pub mod route;
 
 #[doc(hidden)]
 pub mod prelude {
-    pub use super::{param::UrlParamsVec, route::Router, Server};
+    pub use super::{param::PathParamsVec, route::Router, Server};
     #[cfg(feature = "cookie")]
     pub use crate::cookie::CookieJar;
 }

--- a/volo-http/src/server/param.rs
+++ b/volo-http/src/server/param.rs
@@ -12,13 +12,15 @@ use crate::{
     utils::macros::all_the_tuples,
 };
 
+pub type UrlParamsVec = PathParamsVec;
+pub type UrlParamsMap = PathParamsMap;
+pub type UrlParams<T> = PathParams<T>;
+pub type UrlParamsRejection = PathParamsRejection;
+
 #[derive(Clone, Debug, Default)]
 pub struct PathParamsVec {
     inner: Vec<(FastStr, FastStr)>,
 }
-
-#[deprecated]
-pub type UrlParamsVec = PathParamsVec;
 
 impl PathParamsVec {
     pub(crate) fn extend(&mut self, params: Params) {
@@ -61,9 +63,6 @@ impl FromContext for PathParamsVec {
 pub struct PathParamsMap {
     inner: AHashMap<FastStr, FastStr>,
 }
-
-#[deprecated]
-pub type UrlParamsMap = PathParamsMap;
 
 impl Deref for PathParamsMap {
     type Target = AHashMap<FastStr, FastStr>;
@@ -134,9 +133,6 @@ impl_from_path_param!(FastStr);
 #[derive(Debug, Default, Clone)]
 pub struct PathParams<T>(pub T);
 
-#[deprecated]
-pub type UrlParams<T> = PathParams<T>;
-
 impl<T> FromContext for PathParams<T>
 where
     T: FromPathParam,
@@ -192,9 +188,6 @@ pub enum PathParamsRejection {
     LengthMismatch,
     ParseError(BoxError),
 }
-
-#[deprecated]
-pub type UrlParamsRejection = PathParamsRejection;
 
 impl fmt::Display for PathParamsRejection {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/volo-http/src/server/param.rs
+++ b/volo-http/src/server/param.rs
@@ -13,11 +13,14 @@ use crate::{
 };
 
 #[derive(Clone, Debug, Default)]
-pub struct UrlParamsVec {
+pub struct PathParamsVec {
     inner: Vec<(FastStr, FastStr)>,
 }
 
-impl UrlParamsVec {
+#[deprecated]
+pub type UrlParamsVec = PathParamsVec;
+
+impl PathParamsVec {
     pub(crate) fn extend(&mut self, params: Params) {
         self.inner.reserve(params.len());
 
@@ -38,7 +41,7 @@ impl UrlParamsVec {
     }
 }
 
-impl Deref for UrlParamsVec {
+impl Deref for PathParamsVec {
     type Target = [(FastStr, FastStr)];
 
     fn deref(&self) -> &Self::Target {
@@ -46,7 +49,7 @@ impl Deref for UrlParamsVec {
     }
 }
 
-impl FromContext for UrlParamsVec {
+impl FromContext for PathParamsVec {
     type Rejection = Infallible;
 
     async fn from_context(cx: &mut ServerContext, _: &mut Parts) -> Result<Self, Self::Rejection> {
@@ -55,11 +58,14 @@ impl FromContext for UrlParamsVec {
 }
 
 #[derive(Debug, Default, Clone)]
-pub struct UrlParamsMap {
+pub struct PathParamsMap {
     inner: AHashMap<FastStr, FastStr>,
 }
 
-impl Deref for UrlParamsMap {
+#[deprecated]
+pub type UrlParamsMap = PathParamsMap;
+
+impl Deref for PathParamsMap {
     type Target = AHashMap<FastStr, FastStr>;
 
     fn deref(&self) -> &Self::Target {
@@ -67,8 +73,8 @@ impl Deref for UrlParamsMap {
     }
 }
 
-impl From<UrlParamsVec> for UrlParamsMap {
-    fn from(value: UrlParamsVec) -> Self {
+impl From<PathParamsVec> for PathParamsMap {
+    fn from(value: PathParamsVec) -> Self {
         let mut inner = AHashMap::with_capacity(value.inner.len());
 
         for (k, v) in value.inner.into_iter() {
@@ -79,7 +85,7 @@ impl From<UrlParamsVec> for UrlParamsMap {
     }
 }
 
-impl FromContext for UrlParamsMap {
+impl FromContext for PathParamsMap {
     type Rejection = Infallible;
 
     async fn from_context(cx: &mut ServerContext, _: &mut Parts) -> Result<Self, Self::Rejection> {
@@ -94,71 +100,74 @@ impl FromContext for UrlParamsMap {
     }
 }
 
-trait FromUrlParam: Sized {
-    fn from_url_param(param: &str) -> Result<Self, UrlParamsRejection>;
+trait FromPathParam: Sized {
+    fn from_path_param(param: &str) -> Result<Self, PathParamsRejection>;
 }
 
-macro_rules! impl_from_url_param {
+macro_rules! impl_from_path_param {
     ($ty:ty) => {
-        impl FromUrlParam for $ty {
-            fn from_url_param(param: &str) -> Result<Self, UrlParamsRejection> {
+        impl FromPathParam for $ty {
+            fn from_path_param(param: &str) -> Result<Self, PathParamsRejection> {
                 FromStr::from_str(param)
                     .map_err(Into::into)
-                    .map_err(UrlParamsRejection::ParseError)
+                    .map_err(PathParamsRejection::ParseError)
             }
         }
     };
 }
 
-impl_from_url_param!(bool);
-impl_from_url_param!(u8);
-impl_from_url_param!(u16);
-impl_from_url_param!(u32);
-impl_from_url_param!(u64);
-impl_from_url_param!(usize);
-impl_from_url_param!(i8);
-impl_from_url_param!(i16);
-impl_from_url_param!(i32);
-impl_from_url_param!(i64);
-impl_from_url_param!(isize);
-impl_from_url_param!(char);
-impl_from_url_param!(String);
-impl_from_url_param!(FastStr);
+impl_from_path_param!(bool);
+impl_from_path_param!(u8);
+impl_from_path_param!(u16);
+impl_from_path_param!(u32);
+impl_from_path_param!(u64);
+impl_from_path_param!(usize);
+impl_from_path_param!(i8);
+impl_from_path_param!(i16);
+impl_from_path_param!(i32);
+impl_from_path_param!(i64);
+impl_from_path_param!(isize);
+impl_from_path_param!(char);
+impl_from_path_param!(String);
+impl_from_path_param!(FastStr);
 
 #[derive(Debug, Default, Clone)]
-pub struct UrlParams<T>(pub T);
+pub struct PathParams<T>(pub T);
 
-impl<T> FromContext for UrlParams<T>
+#[deprecated]
+pub type UrlParams<T> = PathParams<T>;
+
+impl<T> FromContext for PathParams<T>
 where
-    T: FromUrlParam,
+    T: FromPathParam,
 {
-    type Rejection = UrlParamsRejection;
+    type Rejection = PathParamsRejection;
 
     async fn from_context(cx: &mut ServerContext, _: &mut Parts) -> Result<Self, Self::Rejection> {
         let mut param_iter = cx.params().iter();
-        let t = T::from_url_param(
+        let t = T::from_path_param(
             param_iter
                 .next()
-                .ok_or(UrlParamsRejection::LengthMismatch)?
+                .ok_or(PathParamsRejection::LengthMismatch)?
                 .1
                 .as_str(),
         )?;
-        Ok(UrlParams(t))
+        Ok(PathParams(t))
     }
 }
 
-macro_rules! impl_url_params_extractor {
+macro_rules! impl_path_params_extractor {
     (
         $($ty:ident),+ $(,)?
     ) => {
         #[allow(non_snake_case)]
-        impl<$($ty,)+> FromContext for UrlParams<($($ty,)+)>
+        impl<$($ty,)+> FromContext for PathParams<($($ty,)+)>
         where
             $(
-                $ty: FromUrlParam,
+                $ty: FromPathParam,
             )+
         {
-            type Rejection = UrlParamsRejection;
+            type Rejection = PathParamsRejection;
 
             async fn from_context(
                 cx: &mut ServerContext,
@@ -166,39 +175,42 @@ macro_rules! impl_url_params_extractor {
             ) -> Result<Self, Self::Rejection> {
                 let mut param_iter = cx.params().iter();
                 $(
-                    let $ty = $ty::from_url_param(
-                        param_iter.next().ok_or(UrlParamsRejection::LengthMismatch)?.1.as_str(),
+                    let $ty = $ty::from_path_param(
+                        param_iter.next().ok_or(PathParamsRejection::LengthMismatch)?.1.as_str(),
                     )?;
                 )+
-                Ok(UrlParams(($($ty,)+)))
+                Ok(PathParams(($($ty,)+)))
             }
         }
     };
 }
 
-all_the_tuples!(impl_url_params_extractor);
+all_the_tuples!(impl_path_params_extractor);
 
 #[derive(Debug)]
-pub enum UrlParamsRejection {
+pub enum PathParamsRejection {
     LengthMismatch,
     ParseError(BoxError),
 }
 
-impl fmt::Display for UrlParamsRejection {
+#[deprecated]
+pub type UrlParamsRejection = PathParamsRejection;
+
+impl fmt::Display for PathParamsRejection {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::LengthMismatch => write!(
                 f,
-                "the number of url params does not match number of types in `UrlParams`"
+                "the number of path params does not match number of types in `PathParams`"
             ),
-            Self::ParseError(e) => write!(f, "url param parse error: {e}"),
+            Self::ParseError(e) => write!(f, "path param parse error: {e}"),
         }
     }
 }
 
-impl Error for UrlParamsRejection {}
+impl Error for PathParamsRejection {}
 
-impl IntoResponse for UrlParamsRejection {
+impl IntoResponse for PathParamsRejection {
     fn into_response(self) -> ServerResponse {
         StatusCode::BAD_REQUEST.into_response()
     }

--- a/volo-http/src/server/route.rs
+++ b/volo-http/src/server/route.rs
@@ -99,32 +99,32 @@ impl<E> Router<E> {
     ///
     /// Named parameters like `/{id}` match anything until the next `/` or the end of the path.
     ///
-    /// The params can be extract by extractor `UrlParamsMap`:
+    /// The params can be extract by extractor `PathParamsMap`:
     ///
     /// ```no_run
     /// use volo::FastStr;
     /// use volo_http::server::{
-    ///     param::UrlParamsMap,
+    ///     param::PathParamsMap,
     ///     route::{get, Router},
     /// };
     ///
-    /// async fn param(map: UrlParamsMap) -> FastStr {
+    /// async fn param(map: PathParamsMap) -> FastStr {
     ///     map.get("id").unwrap().clone()
     /// }
     ///
     /// let router: Router = Router::new().route("/user/{id}", get(param));
     /// ```
     ///
-    /// Or you can use `UrlParams` directly:
+    /// Or you can use `PathParams` directly:
     ///
     /// ```no_run
     /// use volo::FastStr;
     /// use volo_http::server::{
-    ///     param::UrlParams,
+    ///     param::PathParams,
     ///     route::{get, Router},
     /// };
     ///
-    /// async fn param(UrlParams(id): UrlParams<String>) -> String {
+    /// async fn param(PathParams(id): PathParams<String>) -> String {
     ///     id
     /// }
     ///
@@ -136,11 +136,11 @@ impl<E> Router<E> {
     /// ```no_run
     /// use volo::FastStr;
     /// use volo_http::server::{
-    ///     param::UrlParams,
+    ///     param::PathParams,
     ///     route::{get, Router},
     /// };
     ///
-    /// async fn param(UrlParams((user, post)): UrlParams<(usize, usize)>) -> String {
+    /// async fn param(PathParams((user, post)): PathParams<(usize, usize)>) -> String {
     ///     format!("user id: {user}, post id: {post}")
     /// }
     ///
@@ -154,7 +154,7 @@ impl<E> Router<E> {
     ///
     /// ```no_run
     /// use volo_http::server::{
-    ///     param::UrlParams,
+    ///     param::PathParams,
     ///     route::{get, Router},
     /// };
     ///
@@ -162,7 +162,7 @@ impl<E> Router<E> {
     ///     "Hello, World"
     /// }
     ///
-    /// async fn fallback(UrlParams(uri): UrlParams<String>) -> String {
+    /// async fn fallback(PathParams(uri): PathParams<String>) -> String {
     ///     format!("Path `{uri}` is not available")
     /// }
     ///


### PR DESCRIPTION
struct UrlParamsVec name update to PathParamsVec.
struct UrlParamsMap name update to PathParamsMap.
trait FromUrlParam name update to FromPathParam.
struct UrlParams name update to PathParams.
enum UrlParamsRejection name update to PathParamsRejection. macros impl_from_url_param name update to impl_from_path_param. macros impl_url_params_extractor name update to impl_path_params_extractor.

Fixes: https://github.com/cloudwego/volo/issues/415