### PR TITLE
chore(volo-http): update re-exported types and cli templates

### DIFF
--- a/volo-cli/src/templates/http/cargo_toml
+++ b/volo-cli/src/templates/http/cargo_toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 # we recommend to use the latest framework version for new features and bug fixes
 volo = "*"
-volo-http = "*"
+volo-http = {{ version = "*", features = ["default_server"] }}
 
 tokio = {{ version = "1", features = ["full"] }}
 

--- a/volo-cli/src/templates/http/src/bin/server_rs
+++ b/volo-cli/src/templates/http/src/bin/server_rs
@@ -1,17 +1,16 @@
 use std::{{net::SocketAddr, time::Duration}};
 
-use volo_http::{{layer::TimeoutLayer, route::Router, server::Server, Address, StatusCode}};
+use volo_http::{{
+    Address,
+    server::{{layer::TimeoutLayer, route::Router, Server}},
+}};
 use {name}::example_router;
-
-async fn timeout_handler() -> (StatusCode, &'static str) {{
-    (StatusCode::INTERNAL_SERVER_ERROR, "Timeout!\n")
-}}
 
 #[volo::main]
 async fn main() {{
     let app = Router::new()
         .merge(example_router())
-        .layer(TimeoutLayer::new(Duration::from_secs(1), timeout_handler));
+        .layer(TimeoutLayer::new(Duration::from_secs(1)));
 
     let addr = "[::]:8080".parse::<SocketAddr>().unwrap();
     let addr = Address::from(addr);

--- a/volo-cli/src/templates/http/src/lib_rs
+++ b/volo-cli/src/templates/http/src/lib_rs
@@ -1,4 +1,4 @@
-use volo_http::route::{{get, Router}};
+use volo_http::server::route::{{get, Router}};
 
 async fn index_handler() -> &'static str {{
     "It Works!\n"

--- a/volo-http/src/client/mod.rs
+++ b/volo-http/src/client/mod.rs
@@ -25,7 +25,6 @@ use volo::{
 use self::{
     loadbalance::{DefaultLB, LbConfig},
     meta::MetaService,
-    request_builder::RequestBuilder,
     transport::{ClientConfig, ClientTransport},
     utils::{Target, TargetBuilder},
 };
@@ -47,6 +46,13 @@ mod meta;
 mod request_builder;
 mod transport;
 pub mod utils;
+
+pub use request_builder::RequestBuilder;
+
+#[doc(hidden)]
+pub mod prelude {
+    pub use super::{Client, ClientBuilder};
+}
 
 const PKG_NAME_WITH_VER: &str = concat!(env!("CARGO_PKG_NAME"), '/', env!("CARGO_PKG_VERSION"));
 

--- a/volo-http/src/client/request_builder.rs
+++ b/volo-http/src/client/request_builder.rs
@@ -24,6 +24,7 @@ use crate::{
     response::ClientResponse,
 };
 
+/// The builder for building a request.
 pub struct RequestBuilder<'a, S, B = Body> {
     client: &'a Client<S>,
     target: TargetBuilder,

--- a/volo-http/src/lib.rs
+++ b/volo-http/src/lib.rs
@@ -27,6 +27,8 @@ pub mod prelude {
     pub use hyper;
     pub use volo::net::Address;
 
+    #[cfg(feature = "client")]
+    pub use crate::client::prelude::*;
     pub use crate::extension::Extension;
     #[cfg(feature = "__json")]
     pub use crate::json::Json;

--- a/volo-http/src/server/mod.rs
+++ b/volo-http/src/server/mod.rs
@@ -35,21 +35,22 @@ use crate::{
     response::ServerResponse,
 };
 
-mod into_response;
-pub use self::into_response::IntoResponse;
-
 pub mod extract;
 mod handler;
+mod into_response;
 pub mod layer;
 pub mod middleware;
 pub mod param;
 pub mod route;
 
+pub use self::{into_response::IntoResponse, route::Router};
+
 #[doc(hidden)]
 pub mod prelude {
-    pub use super::{param::PathParamsVec, route::Router, Server};
-    #[cfg(feature = "cookie")]
-    pub use crate::cookie::CookieJar;
+    #[cfg(feature = "__tls")]
+    pub use volo::net::tls::ServerTlsConfig;
+
+    pub use super::{param::PathParams, route::Router, Server};
 }
 
 /// High level HTTP server.


### PR DESCRIPTION
This PR organized re-exported types in `volo-http` for adapting client and others.

In addition, template of `volo-http` from `volo-cli` is also updated.
