### PR TITLE
feat(volo-http): add handler for timeout layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3229,7 +3229,7 @@ dependencies = [
 
 [[package]]
 name = "volo-http"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ahash",
  "bytes",

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-http"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Motivation

When refactoring `ServerContext`, we removed handler for `TimeoutLayer` (with `FromContext`), but handler is important for the layer.

## Solution

Add a simple handler for `TimeoutLayer`.  The handler accepts only `FnOnce(&ServerContext) -> impl IntoResponse + Clone` rather than `Handler` with `FromContext`.