### PR TITLE
chore(volo-http): refactor client configs

### DIFF
--- a/volo-http/src/client/utils.rs
+++ b/volo-http/src/client/utils.rs
@@ -106,8 +106,10 @@ impl TargetBuilder {
         if matches!(self, Self::None) {
             return Ok(None);
         }
-        let callee_name =
-            self.gen_callee_name(&client_inner.config.callee_name, &client_inner.callee_name);
+        let callee_name = self.gen_callee_name(
+            &client_inner.callee_name_mode,
+            &client_inner.default_callee_name,
+        );
         #[cfg(feature = "__tls")]
         let use_tls = self.is_tls();
         Ok(Some(Target {

--- a/volo-http/src/context/client.rs
+++ b/volo-http/src/context/client.rs
@@ -1,7 +1,9 @@
+use std::time::Duration;
+
 use chrono::{DateTime, Local};
 use faststr::FastStr;
 use volo::{
-    context::{Context, Reusable, Role, RpcCx, RpcInfo},
+    context::{Reusable, Role, RpcCx, RpcInfo},
     newtype_impl_context,
 };
 
@@ -21,14 +23,6 @@ impl ClientContext {
                 stats: ClientStats::default(),
             },
         ))
-    }
-
-    pub fn enable_stat(&mut self, stat: bool) {
-        self.rpc_info_mut().config_mut().stat_enable = stat;
-    }
-
-    pub(crate) fn stat_enabled(&self) -> bool {
-        self.rpc_info().config().stat_enable
     }
 }
 
@@ -64,27 +58,9 @@ impl ClientStats {
     stat_impl!(transport_end_at);
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Config {
-    pub caller_name: CallerName,
-    pub callee_name: CalleeName,
-    pub stat_enable: bool,
-    pub fail_on_error_status: bool,
-    #[cfg(feature = "__tls")]
-    pub disable_tls: bool,
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            caller_name: CallerName::default(),
-            callee_name: CalleeName::default(),
-            stat_enable: true,
-            fail_on_error_status: false,
-            #[cfg(feature = "__tls")]
-            disable_tls: false,
-        }
-    }
+    pub timeout: Option<Duration>,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/volo-http/src/error/client.rs
+++ b/volo-http/src/error/client.rs
@@ -194,4 +194,5 @@ simple_error!(Builder => NoAddress => "missing target address");
 simple_error_with_url!(Builder => BadScheme => "bad scheme");
 simple_error_with_url!(Builder => BadHostName => "bad host name");
 simple_error!(Builder => UnreachableBuilderError => "unreachable builder error");
+simple_error!(Request => Timeout => "request timeout");
 simple_error!(LoadBalance => NoAvailableEndpoint => "no available endpoint");


### PR DESCRIPTION
## Motivation

The previous config of HTTP client was confusing, some were used for building client, some were used for transporting, and some were generic functions.

## Solution

### Old implementation

The previous config in `ClientContext`:

```rust
pub struct Config {
    pub caller_name: CallerName,
    pub callee_name: CalleeName,
    pub stat_enable: bool,
    pub fail_on_error_status: bool,
    #[cfg(feature = "__tls")]
    pub disable_tls: bool,
}
```

### New implementation

Config for builder:

```rust
struct BuilderConfig {
    caller_name_mode: CallerName,
    callee_name_mode: CalleeName,
    timeout: Option<Duration>,
    stat_enable: bool,
    fail_on_error_status: bool,
    #[cfg(feature = "__tls")]
    disable_tls: bool,
}
```

This config is used in `ClientBuilder` and it will split into four parts for four purposes.

#### `ClientContext`

Config in `ClientContext`:

```rust
struct Config {
    timeout: Option<Duration>,
}
```

This config is used for request, and it has one per request.

#### `ClientInner`

```rust
struct ClientInner {
    /* ...... */
    callee_name_mode: CalleeName,
    /* ...... */
}
```

The `caller_name_mode` is used only in `ClientBuilder::build`, so we do not save it, and only the `callee_name_mode` should be saved. Additionally, this config should have one per client.

#### `MetaService`

```rust
struct MetaServiceConfig {
    default_timeout: Option<Duration>,
    fail_on_error_status: bool,
}
```

There should be a default timeout, it is better to save it in the `MetaService`, and the `fail_on_error_status` should also be in here.

This config should have one per client. Note that the *default* timeout can be overridden by the `timeout` in `ClientContext`.

#### `ClientTransport`

```rust
struct ClientTransportConfig {
    stat_enable: bool,
    #[cfg(feature = "__tls")]
    disable_tls: bool,
}
```

TLS can be force disabled for each client, and TLS related configs can only be used during transport, so it should be saved in `ClientTransport`.

And the stat of Volo-HTTP only records the cost of transporting, so it should also be saved here.

## Others

Additionally, this PR supports timeout for request in `MetaService`, it can be set by `ClientBuilder::set_request_timeout` (for the whole client) or `RequestBuilder::set_request_timeout` (only for the request).