### PR TITLE
chore: add attributes for docsrs

### DIFF
--- a/volo-grpc/src/client/mod.rs
+++ b/volo-grpc/src/client/mod.rs
@@ -454,6 +454,7 @@ impl<IL, OL, C, LB, T, U> ClientBuilder<IL, OL, C, LB, T, U> {
 
     /// Sets the [`ClientTlsConfig`] for the client.
     #[cfg(feature = "__tls")]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "rustls", feature = "native-tls"))))]
     pub fn tls_config(mut self, tls_config: volo::net::tls::ClientTlsConfig) -> Self {
         self.tls_config = Some(tls_config);
         self

--- a/volo-grpc/src/server/mod.rs
+++ b/volo-grpc/src/server/mod.rs
@@ -70,6 +70,7 @@ impl Server<Identity> {
 
 impl<L> Server<L> {
     #[cfg(feature = "__tls")]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "rustls", feature = "native-tls"))))]
     /// Sets the TLS configuration for the server.
     ///
     /// If not set, the server will not use TLS.

--- a/volo-grpc/src/transport/client.rs
+++ b/volo-grpc/src/transport/client.rs
@@ -72,7 +72,8 @@ impl<U> ClientTransport<U> {
         }
     }
 
-    #[cfg(any(feature = "rustls", feature = "native-tls"))]
+    #[cfg(feature = "__tls")]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "rustls", feature = "native-tls"))))]
     pub fn new_with_tls(
         http2_config: &Http2Config,
         rpc_config: &Config,

--- a/volo-grpc/src/transport/connect.rs
+++ b/volo-grpc/src/transport/connect.rs
@@ -13,6 +13,7 @@ use hyper_util::client::legacy::connect::{Connected, Connection};
 use motore::{make::MakeConnection, service::UnaryService};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 #[cfg(feature = "__tls")]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "rustls", feature = "native-tls"))))]
 use volo::net::tls::{ClientTlsConfig, TlsMakeTransport};
 use volo::net::{
     conn::Conn,
@@ -24,6 +25,7 @@ use volo::net::{
 pub enum Connector {
     Default(DefaultMakeTransport),
     #[cfg(feature = "__tls")]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "rustls", feature = "native-tls"))))]
     Tls(TlsMakeTransport),
 }
 
@@ -39,6 +41,7 @@ impl Connector {
     }
 
     #[cfg(feature = "__tls")]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "rustls", feature = "native-tls"))))]
     pub fn new_with_tls(cfg: Option<Config>, tls_config: ClientTlsConfig) -> Self {
         let mut mt = TlsMakeTransport::new(cfg.unwrap_or_default(), tls_config);
         if let Some(cfg) = cfg {

--- a/volo-http/src/body.rs
+++ b/volo-http/src/body.rs
@@ -163,6 +163,7 @@ where
     }
 
     #[cfg(feature = "__json")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     fn into_json<T>(self) -> impl Future<Output = Result<T, ResponseConvertError>> + Send
     where
         T: DeserializeOwned,
@@ -186,6 +187,7 @@ pub enum ResponseConvertError {
     BodyCollectionError,
     StringUtf8Error,
     #[cfg(feature = "__json")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     JsonDeserializeError(crate::json::Error),
 }
 

--- a/volo-http/src/client/mod.rs
+++ b/volo-http/src/client/mod.rs
@@ -360,7 +360,13 @@ impl<IL, OL, C, LB> ClientBuilder<IL, OL, C, LB> {
     /// Set the target address of the client.
     ///
     /// If there is no target specified when building a request, client will use this address.
-    pub fn address<A>(&mut self, address: A, #[cfg(feature = "__tls")] use_tls: bool) -> &mut Self
+    pub fn address<A>(
+        &mut self,
+        address: A,
+        #[cfg(feature = "__tls")]
+        #[cfg_attr(docsrs, doc(cfg(any(feature = "rustls", feature = "native-tls"))))]
+        use_tls: bool,
+    ) -> &mut Self
     where
         A: Into<Address>,
     {
@@ -428,6 +434,7 @@ impl<IL, OL, C, LB> ClientBuilder<IL, OL, C, LB> {
 
     /// Set tls config for the client.
     #[cfg(feature = "__tls")]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "rustls", feature = "native-tls"))))]
     pub fn set_tls_config<T>(&mut self, tls_config: T) -> &mut Self
     where
         T: Into<volo::net::tls::TlsConnector>,
@@ -491,6 +498,7 @@ impl<IL, OL, C, LB> ClientBuilder<IL, OL, C, LB> {
     ///
     /// Default is false, when TLS related feature is enabled, TLS is enabled by default.
     #[cfg(feature = "__tls")]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "rustls", feature = "native-tls"))))]
     pub fn disable_tls(&mut self, disable: bool) -> &mut Self {
         self.builder_config.disable_tls = disable;
         self

--- a/volo-http/src/client/request_builder.rs
+++ b/volo-http/src/client/request_builder.rs
@@ -82,6 +82,7 @@ impl<'a, S> RequestBuilder<'a, S, Body> {
 
     /// Set the request body as json from object with `Serialize`.
     #[cfg(feature = "__json")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     pub fn json<T>(mut self, json: &T) -> Result<Self>
     where
         T: serde::Serialize,
@@ -104,6 +105,7 @@ impl<'a, S> RequestBuilder<'a, S, Body> {
 
     /// Set the request body as form from object with `Serialize`.
     #[cfg(feature = "form")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "form")))]
     pub fn form<T>(mut self, form: &T) -> Result<Self>
     where
         T: serde::Serialize,
@@ -192,6 +194,7 @@ impl<'a, S, B> RequestBuilder<'a, S, B> {
 
     /// Set query for the uri in request from object with `Serialize`.
     #[cfg(feature = "query")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "query")))]
     pub fn set_query<T>(mut self, query: &T) -> Result<Self>
     where
         T: serde::Serialize,
@@ -248,7 +251,13 @@ impl<'a, S, B> RequestBuilder<'a, S, B> {
     }
 
     /// Set the target address for the request.
-    pub fn address<A>(mut self, address: A, #[cfg(feature = "__tls")] use_tls: bool) -> Self
+    pub fn address<A>(
+        mut self,
+        address: A,
+        #[cfg(feature = "__tls")]
+        #[cfg_attr(docsrs, doc(cfg(any(feature = "rustls", feature = "native-tls"))))]
+        use_tls: bool,
+    ) -> Self
     where
         A: Into<Address>,
     {

--- a/volo-http/src/client/transport.rs
+++ b/volo-http/src/client/transport.rs
@@ -172,6 +172,7 @@ impl ClientConfig {
 pub(super) struct ClientTransportConfig {
     pub stat_enable: bool,
     #[cfg(feature = "__tls")]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "rustls", feature = "native-tls"))))]
     pub disable_tls: bool,
 }
 

--- a/volo-http/src/client/utils.rs
+++ b/volo-http/src/client/utils.rs
@@ -24,6 +24,7 @@ lazy_static! {
 pub struct Target {
     pub addr: Address,
     #[cfg(feature = "__tls")]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "rustls", feature = "native-tls"))))]
     pub use_tls: bool,
     pub(crate) callee_name: FastStr,
 }
@@ -50,6 +51,7 @@ impl TargetBuilder {
     }
 
     #[cfg(feature = "__tls")]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "rustls", feature = "native-tls"))))]
     pub fn is_tls(&self) -> bool {
         match self {
             Self::None => false,

--- a/volo-http/src/context/client.rs
+++ b/volo-http/src/context/client.rs
@@ -14,7 +14,11 @@ pub struct ClientContext(pub(crate) RpcCx<ClientCxInner, Config>);
 
 impl ClientContext {
     #[allow(clippy::new_without_default)]
-    pub fn new(#[cfg(feature = "__tls")] tls: bool) -> Self {
+    pub fn new(
+        #[cfg(feature = "__tls")]
+        #[cfg_attr(docsrs, doc(cfg(any(feature = "rustls", feature = "native-tls"))))]
+        tls: bool,
+    ) -> Self {
         Self(RpcCx::new(
             RpcInfo::<Config>::with_role(Role::Client),
             ClientCxInner {
@@ -41,6 +45,7 @@ pub struct ClientCxInner {
 
 impl ClientCxInner {
     #[cfg(feature = "__tls")]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "rustls", feature = "native-tls"))))]
     pub fn is_tls(&self) -> bool {
         self.tls
     }

--- a/volo-http/src/context/mod.rs
+++ b/volo-http/src/context/mod.rs
@@ -1,11 +1,15 @@
 #[cfg(feature = "client")]
+#[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 pub mod client;
 
 #[cfg(feature = "client")]
+#[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 pub use self::client::ClientContext;
 
 #[cfg(feature = "server")]
+#[cfg_attr(docsrs, doc(cfg(feature = "server")))]
 pub mod server;
 
 #[cfg(feature = "server")]
+#[cfg_attr(docsrs, doc(cfg(feature = "server")))]
 pub use self::server::{RequestPartsExt, ServerContext};

--- a/volo-http/src/cookie.rs
+++ b/volo-http/src/cookie.rs
@@ -37,6 +37,7 @@ impl Deref for CookieJar {
 }
 
 #[cfg(feature = "server")]
+#[cfg_attr(docsrs, doc(cfg(feature = "server")))]
 impl FromContext for CookieJar {
     type Rejection = Infallible;
 

--- a/volo-http/src/error/mod.rs
+++ b/volo-http/src/error/mod.rs
@@ -1,13 +1,17 @@
 use std::error::Error;
 
 #[cfg(feature = "client")]
+#[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 pub mod client;
 #[cfg(feature = "client")]
+#[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 pub use self::client::ClientError;
 
 #[cfg(feature = "server")]
+#[cfg_attr(docsrs, doc(cfg(feature = "server")))]
 pub mod server;
 #[cfg(feature = "server")]
+#[cfg_attr(docsrs, doc(cfg(feature = "server")))]
 pub use self::server::ExtractBodyError;
 
 pub type BoxError = Box<dyn Error + Send + Sync>;

--- a/volo-http/src/error/server.rs
+++ b/volo-http/src/error/server.rs
@@ -10,8 +10,10 @@ pub enum ExtractBodyError {
     Common(CommonRejectionError),
     String(simdutf8::basic::Utf8Error),
     #[cfg(feature = "__json")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     Json(crate::json::Error),
     #[cfg(feature = "form")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "form")))]
     Form(serde_urlencoded::de::Error),
 }
 

--- a/volo-http/src/lib.rs
+++ b/volo-http/src/lib.rs
@@ -5,17 +5,21 @@
 
 pub mod body;
 #[cfg(feature = "client")]
+#[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 pub mod client;
 pub mod context;
 #[cfg(feature = "cookie")]
+#[cfg_attr(docsrs, doc(cfg(feature = "cookie")))]
 pub mod cookie;
 pub mod error;
 pub mod extension;
 #[cfg(feature = "__json")]
+#[cfg_attr(docsrs, doc(cfg(feature = "json")))]
 pub mod json;
 pub mod request;
 pub mod response;
 #[cfg(feature = "server")]
+#[cfg_attr(docsrs, doc(cfg(feature = "server")))]
 pub mod server;
 
 pub(crate) mod utils;
@@ -28,11 +32,14 @@ pub mod prelude {
     pub use volo::net::Address;
 
     #[cfg(feature = "client")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "client")))]
     pub use crate::client::prelude::*;
     pub use crate::extension::Extension;
     #[cfg(feature = "__json")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     pub use crate::json::Json;
     #[cfg(feature = "server")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "server")))]
     pub use crate::server::prelude::*;
 }
 

--- a/volo-http/src/server/extract.rs
+++ b/volo-http/src/server/extract.rs
@@ -123,6 +123,7 @@ impl FromContext for Method {
 }
 
 #[cfg(feature = "query")]
+#[cfg_attr(docsrs, doc(cfg(feature = "query")))]
 impl<T> FromContext for Query<T>
 where
     T: serde::de::DeserializeOwned,
@@ -140,6 +141,7 @@ where
 }
 
 #[cfg(feature = "query")]
+#[cfg_attr(docsrs, doc(cfg(feature = "query")))]
 impl IntoResponse for serde_urlencoded::de::Error {
     fn into_response(self) -> crate::response::ServerResponse {
         http::StatusCode::BAD_REQUEST.into_response()
@@ -283,6 +285,7 @@ impl<T> FromRequest for MaybeInvalid<T> {
 }
 
 #[cfg(feature = "form")]
+#[cfg_attr(docsrs, doc(cfg(feature = "form")))]
 impl<T> FromRequest for Form<T>
 where
     T: serde::de::DeserializeOwned,

--- a/volo-http/src/server/mod.rs
+++ b/volo-http/src/server/mod.rs
@@ -103,6 +103,7 @@ impl<S> Server<S, Identity> {
 
 impl<S, L> Server<S, L> {
     #[cfg(feature = "__tls")]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "rustls", feature = "native-tls"))))]
     /// Enable TLS with the specified configuration.
     ///
     /// If not set, the server will not use TLS.

--- a/volo-thrift/src/transport/mod.rs
+++ b/volo-thrift/src/transport/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod incoming;
 #[cfg(feature = "multiplex")]
+#[cfg_attr(docsrs, doc(cfg(feature = "multiplex")))]
 pub mod multiplex;
 pub mod pingpong;
 pub mod pool;

--- a/volo/src/lib.rs
+++ b/volo/src/lib.rs
@@ -14,6 +14,7 @@ pub mod net;
 pub mod util;
 pub use hack::Unwrap;
 #[cfg(target_family = "unix")]
+#[cfg_attr(docsrs, doc(cfg(target_family = "unix")))]
 pub mod hotrestart;
 
 pub mod client;
@@ -23,7 +24,7 @@ mod macros;
 pub use faststr::FastStr;
 pub use metainfo::METAINFO;
 
-/// volo::spawn will spawn a task and derive the metainfo
+/// `volo::spawn` will spawn a task and derive the metainfo
 pub fn spawn<T>(future: T) -> tokio::task::JoinHandle<T::Output>
 where
     T: futures::Future + Send + 'static,

--- a/volo/src/net/conn.rs
+++ b/volo/src/net/conn.rs
@@ -27,10 +27,13 @@ impl<T> DynStream for T where T: AsyncRead + AsyncWrite + Send + 'static {}
 pub enum ConnStream {
     Tcp(#[pin] TcpStream),
     #[cfg(target_family = "unix")]
+    #[cfg_attr(docsrs, doc(cfg(target_family = "unix")))]
     Unix(#[pin] UnixStream),
     #[cfg(feature = "rustls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rustls")))]
     Rustls(#[pin] tokio_rustls::TlsStream<TcpStream>),
     #[cfg(feature = "native-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
     NativeTls(#[pin] tokio_native_tls::TlsStream<TcpStream>),
 }
 
@@ -44,10 +47,13 @@ type NativeTlsWriteHalf = tokio::io::WriteHalf<tokio_native_tls::TlsStream<TcpSt
 pub enum OwnedWriteHalf {
     Tcp(#[pin] tcp::OwnedWriteHalf),
     #[cfg(target_family = "unix")]
+    #[cfg_attr(docsrs, doc(cfg(target_family = "unix")))]
     Unix(#[pin] unix::OwnedWriteHalf),
     #[cfg(feature = "rustls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rustls")))]
     Rustls(#[pin] RustlsWriteHalf),
     #[cfg(feature = "native-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
     NativeTls(#[pin] NativeTlsWriteHalf),
 }
 
@@ -136,10 +142,13 @@ type NativeTlsReadHalf = tokio::io::ReadHalf<tokio_native_tls::TlsStream<TcpStre
 pub enum OwnedReadHalf {
     Tcp(#[pin] tcp::OwnedReadHalf),
     #[cfg(target_family = "unix")]
+    #[cfg_attr(docsrs, doc(cfg(target_family = "unix")))]
     Unix(#[pin] unix::OwnedReadHalf),
     #[cfg(feature = "rustls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rustls")))]
     Rustls(#[pin] RustlsReadHalf),
     #[cfg(feature = "native-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
     NativeTls(#[pin] NativeTlsReadHalf),
 }
 
@@ -163,7 +172,6 @@ impl AsyncRead for OwnedReadHalf {
 }
 
 impl ConnStream {
-    #[allow(clippy::type_complexity)]
     pub fn into_split(self) -> (OwnedReadHalf, OwnedWriteHalf) {
         match self {
             Self::Tcp(stream) => {
@@ -198,6 +206,7 @@ impl From<TcpStream> for ConnStream {
 }
 
 #[cfg(target_family = "unix")]
+#[cfg_attr(docsrs, doc(cfg(target_family = "unix")))]
 impl From<UnixStream> for ConnStream {
     #[inline]
     fn from(s: UnixStream) -> Self {
@@ -206,6 +215,7 @@ impl From<UnixStream> for ConnStream {
 }
 
 #[cfg(feature = "rustls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rustls")))]
 impl From<tokio_rustls::TlsStream<TcpStream>> for ConnStream {
     #[inline]
     fn from(s: tokio_rustls::TlsStream<TcpStream>) -> Self {
@@ -214,6 +224,7 @@ impl From<tokio_rustls::TlsStream<TcpStream>> for ConnStream {
 }
 
 #[cfg(feature = "native-tls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
 impl From<tokio_native_tls::TlsStream<TcpStream>> for ConnStream {
     #[inline]
     fn from(s: tokio_native_tls::TlsStream<TcpStream>) -> Self {

--- a/volo/src/net/incoming.rs
+++ b/volo/src/net/incoming.rs
@@ -21,6 +21,7 @@ use super::{conn::Conn, Address};
 pub enum DefaultIncoming {
     Tcp(#[pin] TcpListenerStream),
     #[cfg(target_family = "unix")]
+    #[cfg_attr(docsrs, doc(cfg(target_family = "unix")))]
     Unix(#[pin] UnixListenerStream),
 }
 
@@ -33,6 +34,7 @@ impl MakeIncoming for DefaultIncoming {
 }
 
 #[cfg(target_family = "unix")]
+#[cfg_attr(docsrs, doc(cfg(target_family = "unix")))]
 impl From<UnixListener> for DefaultIncoming {
     fn from(l: UnixListener) -> Self {
         DefaultIncoming::Unix(UnixListenerStream::new(l))

--- a/volo/src/net/mod.rs
+++ b/volo/src/net/mod.rs
@@ -2,6 +2,7 @@ pub mod conn;
 pub mod dial;
 pub mod incoming;
 #[cfg(feature = "__tls")]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "rustls", feature = "native-tls"))))]
 pub mod tls;
 
 mod probe;
@@ -24,6 +25,7 @@ use tokio::net::unix::SocketAddr as TokioUnixSocketAddr;
 pub enum Address {
     Ip(SocketAddr),
     #[cfg(target_family = "unix")]
+    #[cfg_attr(docsrs, doc(cfg(target_family = "unix")))]
     Unix(StdUnixSocketAddr),
 }
 
@@ -129,6 +131,7 @@ impl From<SocketAddr> for Address {
 }
 
 #[cfg(target_family = "unix")]
+#[cfg_attr(docsrs, doc(cfg(target_family = "unix")))]
 impl From<StdUnixSocketAddr> for Address {
     fn from(value: StdUnixSocketAddr) -> Self {
         Address::Unix(value)
@@ -136,6 +139,7 @@ impl From<StdUnixSocketAddr> for Address {
 }
 
 #[cfg(target_family = "unix")]
+#[cfg_attr(docsrs, doc(cfg(target_family = "unix")))]
 impl From<TokioUnixSocketAddr> for Address {
     fn from(value: TokioUnixSocketAddr) -> Self {
         // SAFETY: `std::mem::transmute` can ensure both struct has the same size, so there is no

--- a/volo/src/net/tls/mod.rs
+++ b/volo/src/net/tls/mod.rs
@@ -66,6 +66,7 @@ pub trait Acceptor: Sized {
 }
 
 #[cfg(feature = "rustls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rustls")))]
 impl Default for TlsConnector {
     fn default() -> Self {
         Self::Rustls(RustlsConnector::default())
@@ -73,6 +74,7 @@ impl Default for TlsConnector {
 }
 
 #[cfg(not(feature = "rustls"))]
+#[cfg_attr(docsrs, doc(cfg(not(feature = "rustls"))))]
 impl Default for TlsConnector {
     fn default() -> Self {
         Self::NativeTls(NativeTlsConnector::default())


### PR DESCRIPTION
## Motivation

In [`docs.rs`](https://docs.rs), docs of crates can have attributes, but we did not support it before.

## Solution

Add missing attributes.