### PR TITLE
bugfix(volo-http): add unit tests and fix bugs for dns and tls

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,8 +69,17 @@ jobs:
           cargo clippy -p volo-http --no-default-features --features default_server -- --deny warnings
           cargo clippy -p volo-http --no-default-features --features client,server,serde_json -- --deny warnings
           cargo clippy -p volo-http --no-default-features --features full -- --deny warnings
-          cargo clippy -- --deny warnings
-          cargo test
+          cargo clippy -p volo -- --deny warnings
+          cargo clippy -p volo-build -- --deny warnings
+          cargo clippy -p volo-cli -- --deny warnings
+          cargo clippy -p volo-macros -- --deny warnings
+          cargo clippy -p examples -- --deny warnings
+          cargo test -p volo-thrift
+          cargo test -p volo-grpc --features rustls
+          cargo test -p volo-http --features full
+          cargo test -p volo --features rustls
+          cargo test -p volo-build
+          cargo test -p volo-cli
 
   test-linux-aarch64:
     runs-on: [self-hosted, arm]
@@ -100,8 +109,17 @@ jobs:
           cargo clippy -p volo-http --no-default-features --features default_server -- --deny warnings
           cargo clippy -p volo-http --no-default-features --features client,server,serde_json -- --deny warnings
           cargo clippy -p volo-http --no-default-features --features full -- --deny warnings
-          cargo clippy -- --deny warnings
-          cargo test
+          cargo clippy -p volo -- --deny warnings
+          cargo clippy -p volo-build -- --deny warnings
+          cargo clippy -p volo-cli -- --deny warnings
+          cargo clippy -p volo-macros -- --deny warnings
+          cargo clippy -p examples -- --deny warnings
+          cargo test -p volo-thrift
+          cargo test -p volo-grpc --features rustls
+          cargo test -p volo-http --features full
+          cargo test -p volo --features rustls
+          cargo test -p volo-build
+          cargo test -p volo-cli
 
   test-macos:
     runs-on: macos-latest
@@ -130,8 +148,17 @@ jobs:
           cargo clippy -p volo-http --no-default-features --features default_server -- --deny warnings
           cargo clippy -p volo-http --no-default-features --features client,server,serde_json -- --deny warnings
           cargo clippy -p volo-http --no-default-features --features full -- --deny warnings
-          cargo clippy -- --deny warnings
-          cargo test
+          cargo clippy -p volo -- --deny warnings
+          cargo clippy -p volo-build -- --deny warnings
+          cargo clippy -p volo-cli -- --deny warnings
+          cargo clippy -p volo-macros -- --deny warnings
+          cargo clippy -p examples -- --deny warnings
+          cargo test -p volo-thrift
+          cargo test -p volo-grpc --features rustls
+          cargo test -p volo-http --features full
+          cargo test -p volo --features rustls
+          cargo test -p volo-build
+          cargo test -p volo-cli
 
   test-windows:
     runs-on: windows-latest
@@ -160,8 +187,17 @@ jobs:
           cargo clippy -p volo-http --no-default-features --features default_server -- --deny warnings
           cargo clippy -p volo-http --no-default-features --features client,server,serde_json -- --deny warnings
           cargo clippy -p volo-http --no-default-features --features full -- --deny warnings
-          cargo clippy -- --deny warnings
-          cargo test
+          cargo clippy -p volo -- --deny warnings
+          cargo clippy -p volo-build -- --deny warnings
+          cargo clippy -p volo-cli -- --deny warnings
+          cargo clippy -p volo-macros -- --deny warnings
+          cargo clippy -p examples -- --deny warnings
+          cargo test -p volo-thrift
+          cargo test -p volo-grpc --features rustls
+          cargo test -p volo-http --features full
+          cargo test -p volo --features rustls
+          cargo test -p volo-build
+          cargo test -p volo-cli
 
   test-cli:
     runs-on: [self-hosted, X64]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "volo-http"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "ahash",
  "bytes",

--- a/scripts/selftest.sh
+++ b/scripts/selftest.sh
@@ -41,11 +41,20 @@ clippy_check() {
 	echo_and_run cargo clippy -p volo-http --no-default-features --features default_server -- --deny warnings
 	echo_and_run cargo clippy -p volo-http --no-default-features --features client,server,serde_json -- --deny warnings
 	echo_and_run cargo clippy -p volo-http --no-default-features --features full -- --deny warnings
-	echo_and_run cargo clippy -- --deny warnings
+	echo_and_run cargo clippy -p volo -- --deny warnings
+	echo_and_run cargo clippy -p volo-build -- --deny warnings
+	echo_and_run cargo clippy -p volo-cli -- --deny warnings
+	echo_and_run cargo clippy -p volo-macros -- --deny warnings
+	echo_and_run cargo clippy -p examples -- --deny warnings
 }
 
 unit_test() {
-	echo_and_run cargo test
+	echo_and_run cargo test -p volo-thrift
+	echo_and_run cargo test -p volo-grpc --features rustls
+	echo_and_run cargo test -p volo-http --features full
+	echo_and_run cargo test -p volo -- features rustls
+	echo_and_run cargo test -p volo-build
+	echo_and_run cargo test -p volo-cli
 }
 
 volo_cli_test() {

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-http"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -31,7 +31,7 @@ hickory-resolver.workspace = true
 http.workspace = true
 http-body.workspace = true
 http-body-util.workspace = true
-hyper = { workspace = true, features = ["client", "server", "http1"] }
+hyper.workspace = true
 hyper-util = { workspace = true, features = ["tokio"] }
 lazy_static.workspace = true
 metainfo.workspace = true
@@ -79,11 +79,12 @@ default = []
 default_client = ["client", "json"]
 default_server = ["server", "query", "form", "json"]
 
-full = ["client", "server", "rustls", "cookie", "query", "form", "json"]
+full = ["client", "server", "rustls", "cookie", "query", "form", "json", "tls"]
 
-client = ["hyper/client"] # client core
-server = ["hyper/server", "dep:matchit"] # server core
+client = ["hyper/client", "hyper/http1"] # client core
+server = ["hyper/server", "hyper/http1", "dep:matchit"] # server core
 
+tls = ["rustls"]
 __tls = []
 rustls = ["__tls", "dep:tokio-rustls", "volo/rustls"]
 native-tls = ["__tls", "dep:tokio-native-tls", "volo/native-tls"]

--- a/volo-http/src/client/request_builder.rs
+++ b/volo-http/src/client/request_builder.rs
@@ -4,7 +4,6 @@ use std::{error::Error, time::Duration};
 
 use faststr::FastStr;
 use http::{
-    header,
     header::{HeaderMap, HeaderName, HeaderValue},
     uri::{PathAndQuery, Scheme},
     Method, Request, Uri, Version,
@@ -89,7 +88,7 @@ impl<'a, S> RequestBuilder<'a, S, Body> {
     {
         let (mut parts, _) = self.request.into_parts();
         parts.headers.insert(
-            header::CONTENT_TYPE,
+            http::header::CONTENT_TYPE,
             mime::APPLICATION_JSON
                 .essence_str()
                 .parse()
@@ -112,7 +111,7 @@ impl<'a, S> RequestBuilder<'a, S, Body> {
     {
         let (mut parts, _) = self.request.into_parts();
         parts.headers.insert(
-            header::CONTENT_TYPE,
+            http::header::CONTENT_TYPE,
             mime::APPLICATION_WWW_FORM_URLENCODED
                 .essence_str()
                 .parse()
@@ -346,5 +345,47 @@ where
         self.client
             .send_request(self.target, self.request, self.timeout)
             .await
+    }
+}
+
+#[cfg(test)]
+mod request_tests {
+    use std::collections::HashMap;
+
+    use serde::Deserialize;
+
+    use super::Client;
+    use crate::body::BodyConversion;
+
+    #[allow(dead_code)]
+    #[derive(Deserialize)]
+    struct HttpBinResponse {
+        args: HashMap<String, String>,
+        headers: HashMap<String, String>,
+        origin: String,
+        url: String,
+    }
+
+    #[tokio::test]
+    async fn set_query() {
+        let mut builder = Client::builder();
+        builder.host("httpbin.org");
+        let client = builder.build();
+        let query = HashMap::from([
+            ("key".to_string(), "val".to_string()),
+            ("key2".to_string(), "val2".to_string()),
+        ]);
+        let resp = client
+            .get("/get")
+            .unwrap()
+            .set_query(&query)
+            .unwrap()
+            .send()
+            .await
+            .unwrap()
+            .into_json::<HttpBinResponse>()
+            .await
+            .unwrap();
+        assert_eq!(resp.args, query);
     }
 }

--- a/volo-http/src/error/client.rs
+++ b/volo-http/src/error/client.rs
@@ -191,7 +191,7 @@ macro_rules! simple_error_with_url {
 }
 
 simple_error!(Builder => NoAddress => "missing target address");
-simple_error_with_url!(Builder => BadScheme => "bad scheme");
+simple_error!(Builder => BadScheme => "bad scheme");
 simple_error_with_url!(Builder => BadHostName => "bad host name");
 simple_error!(Builder => UnreachableBuilderError => "unreachable builder error");
 simple_error!(Request => Timeout => "request timeout");


### PR DESCRIPTION
## Motivation

This PR adds some unit tests for the HTTP client, which exposed some bugs during testing.

First, `hickory_resolver::Resolver` is a synchronous resolver, and `Resolver::resolve` is a synchronous function, but it uses `Runtime::block_on` of `tokio::runtime::Runtime`, which will **PANIC** when it is within scope of tokio runtime.

Additionally, the config `disable_tls` should prevent HTTPS requests from being sent, but in the previous implementation, when `disable_tls` was set, the client would send it as an HTTP request.

## Solution

This PR removes the dependency on the synchronous resolver from `hickory_resolver`, which means we don't resolve the hostname when building the client, rather than resolving it when the request is sent, during which the asynchronous resolver is available and will not panic on `Runtime`.

This PR will also cause TLS requests with `disable_tls` to fail with the error `BadScheme`.