### PR TITLE
fix: add includes for resolving absolute idl path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "volo-build"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "ahash",
  "anyhow",

--- a/volo-build/Cargo.toml
+++ b/volo-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-build"
-version = "0.10.5"
+version = "0.10.6"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-build/src/util.rs
+++ b/volo-build/src/util.rs
@@ -399,7 +399,11 @@ pub fn get_idl_build_path_and_includes(
             .expect("git source requires the repo info for idl")
             .clone();
         let path = dir.join(strip_slash_prefix(idl.path.as_path()));
-        let includes = idl.includes.iter().map(|v| dir.join(v.clone())).collect();
+        let mut includes: Vec<PathBuf> = idl.includes.iter().map(|v| dir.join(v.clone())).collect();
+        // To resolve absolute path dependencies, go back two levels to the domain level
+        if let Some(path) = dir.parent().and_then(|d| d.parent()) {
+            includes.push(path.to_path_buf());
+        }
         (path, includes)
     } else {
         (idl.path.clone(), idl.includes.clone())


### PR DESCRIPTION
```yaml
entries:
  thrift:
    filename: thrift_gen.rs
    protocol: thrift
    repos:
      thrift:
        url: https://github.com/apache/thrift.git
        ref: HEAD
        lock: 9bd1f1bee7bf59080492bbd3213ca1fed57ab4d6
    services:
    - idl:
        source: git
        repo: thrift
        path: test/Service.thrift

    # to solve cases like this or idl contents for include path uses absolute form
    - idl:
        source: git
        repo: thrift
        path: apache/thrift/test/Service.thrift
```