### PR TITLE
feat(volo-http): impl IntoResponse for Json and Form

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3250,7 +3250,7 @@ dependencies = [
 
 [[package]]
 name = "volo-http"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "ahash",
  "async-broadcast",

--- a/examples/src/http/example-http-client.rs
+++ b/examples/src/http/example-http-client.rs
@@ -1,12 +1,10 @@
 use std::net::SocketAddr;
 
-use http::header;
 use serde::{Deserialize, Serialize};
 use volo_http::{
     body::BodyConversion,
     client::{get, ClientBuilder},
     error::BoxError,
-    Json,
 };
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -89,15 +87,11 @@ async fn main() -> Result<(), BoxError> {
         "{:?}",
         client
             .post("/user/json_post")?
-            // `Content-Type` is needed!
-            //
-            // Without `Content-Type`, server will response with 415 Unsupported Media Type
-            .header(header::CONTENT_TYPE, "application/json")?
-            .data(Json(Person {
+            .json(&Person {
                 name: "Foo".to_string(),
                 age: 25,
                 phones: vec!["114514".to_string()],
-            }))?
+            })?
             .send()
             .await?
             .into_string()

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-http"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-http/src/json/mod.rs
+++ b/volo-http/src/json/mod.rs
@@ -7,8 +7,6 @@ pub use sonic_rs::Error;
 #[cfg(all(feature = "serde_json", feature = "sonic_json"))]
 compile_error!("features `serde_json` and `sonic_json` cannot be enabled at the same time.");
 
-use crate::body::Body;
-
 #[cfg(feature = "server")]
 mod server;
 
@@ -40,14 +38,3 @@ where
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct Json<T>(pub T);
-
-impl<T> TryFrom<Json<T>> for Body
-where
-    T: Serialize,
-{
-    type Error = Error;
-
-    fn try_from(value: Json<T>) -> Result<Self, Self::Error> {
-        serialize(&value.0).map(Body::from)
-    }
-}


### PR DESCRIPTION
## Motivation

Previously, there were `impl TryFrom<Json> for Body` and `impl IntoResponse for T where T: TryInto<Body>`, so `Json` was deduced as `impl IntoResponse`. However, `Content-Type` was not inserted in `IntoResponse`, which may cause problems.

## Solution

This PR implements `IntoResponse` for `Json` and `Form`, and inserts `Content-Type` in the header. To avoid compilation issues, `TryFrom<Json<T>> for Body` has been removed. When the client needs to send json, users can call `json` directly without calling `data` and manually inserting the header.