### PR TITLE
feat(volo-http): add `Redirect` for http server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3250,7 +3250,7 @@ dependencies = [
 
 [[package]]
 name = "volo-http"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "ahash",
  "async-broadcast",

--- a/examples/src/http/example-http-server.rs
+++ b/examples/src/http/example-http-server.rs
@@ -22,7 +22,7 @@ use volo_http::{
         middleware::{self, Next},
         param::PathParams,
         route::{get, get_service, post, Router},
-        IntoResponse, Server,
+        IntoResponse, Redirect, Server,
     },
     Address,
 };
@@ -187,6 +187,10 @@ async fn full_uri(uri: FullUri) -> String {
     format!("{}\n", uri.0)
 }
 
+async fn redirect_to_index() -> Redirect {
+    Redirect::permanent_redirect("/")
+}
+
 async fn forwarded_getter(_: &mut ServerContext, req: ServerRequest) -> Result<String, Infallible> {
     let (parts, _) = req.into_parts();
     let forwarded = parts.forwarded();
@@ -289,6 +293,9 @@ fn test_router() -> Router {
         .route("/test/forwarded", get_service(service_fn(forwarded_getter)))
         // curl -v http://127.0.0.1:8080/test/full_uri
         .route("/test/full_uri", get(full_uri))
+        // curl -v http://127.0.0.1:8080/test/redirect
+        // curl -L http://127.0.0.1:8080/test/redirect
+        .route("/test/redirect", get(redirect_to_index))
         // curl -v http://127.0.0.1:8080/test/anyaddr?reject_me
         .layer(FilterLayer::new(|uri: Uri| async move {
             if uri.query().is_some() && uri.query().unwrap() == "reject_me" {

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-http"
-version = "0.2.6"
+version = "0.2.7"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-http/src/server/into_response.rs
+++ b/volo-http/src/server/into_response.rs
@@ -174,3 +174,90 @@ where
             .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
     }
 }
+
+pub struct Redirect {
+    status: StatusCode,
+    location: HeaderValue,
+}
+
+impl Redirect {
+    /// Create a new [`Redirect`] with a status code and a target location.
+    ///
+    /// # Panics
+    ///
+    /// If the location is not a valid header value.
+    pub fn with_status_code(status: StatusCode, location: &str) -> Self {
+        debug_assert!(status.is_redirection());
+
+        Self {
+            status,
+            location: HeaderValue::from_str(location)
+                .expect("The target location is not a valid header value"),
+        }
+    }
+
+    /// Create a new [`Redirect`] with [`301 Moved Permanently`][301] status code.
+    ///
+    /// # Panics
+    ///
+    /// If the location is not a valid header value.
+    ///
+    /// [301]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/301
+    pub fn moved_permanently(location: &str) -> Self {
+        Self::with_status_code(StatusCode::MOVED_PERMANENTLY, location)
+    }
+
+    /// Create a new [`Redirect`] with [`302 Found`][302] status code.
+    ///
+    /// # Panics
+    ///
+    /// If the location is not a valid header value.
+    ///
+    /// [302]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302
+    pub fn found(location: &str) -> Self {
+        Self::with_status_code(StatusCode::FOUND, location)
+    }
+
+    /// Create a new [`Redirect`] with [`303 Found`][303] status code.
+    ///
+    /// # Panics
+    ///
+    /// If the location is not a valid header value.
+    ///
+    /// [303]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303
+    pub fn see_other(location: &str) -> Self {
+        Self::with_status_code(StatusCode::SEE_OTHER, location)
+    }
+
+    /// Create a new [`Redirect`] with [`307 Temporary Redirect`][307] status code.
+    ///
+    /// # Panics
+    ///
+    /// If the location is not a valid header value.
+    ///
+    /// [307]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307
+    pub fn temporary_redirect(location: &str) -> Self {
+        Self::with_status_code(StatusCode::TEMPORARY_REDIRECT, location)
+    }
+
+    /// Create a new [`Redirect`] with [`308 Permanent Redirect`][308] status code.
+    ///
+    /// # Panics
+    ///
+    /// If the location is not a valid header value.
+    ///
+    /// [308]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/308
+    pub fn permanent_redirect(location: &str) -> Self {
+        Self::with_status_code(StatusCode::PERMANENT_REDIRECT, location)
+    }
+}
+
+impl IntoResponse for Redirect {
+    fn into_response(self) -> ServerResponse {
+        ServerResponse::builder()
+            .status(self.status)
+            .header(header::LOCATION, self.location)
+            .body(Body::default())
+            .expect("infallible")
+    }
+}

--- a/volo-http/src/server/mod.rs
+++ b/volo-http/src/server/mod.rs
@@ -43,7 +43,10 @@ pub mod middleware;
 pub mod param;
 pub mod route;
 
-pub use self::{into_response::IntoResponse, route::Router};
+pub use self::{
+    into_response::{IntoResponse, Redirect},
+    route::Router,
+};
 
 #[doc(hidden)]
 pub mod prelude {


### PR DESCRIPTION
## Motivation

Add `Redirect` for response 3XX status code with `Location` for redirecting user agent to another location.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
