### PR TITLE
chore(ci): add rustfmt for cli test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -209,6 +209,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
+          components: rustfmt
           toolchain: ${{matrix.rust}}
       - name: Cli tests
         run: |


### PR DESCRIPTION
## Motivation

Fix such problem in GitHub CI:

```plain
error: failed to run custom build command for `volo-gen v0.1.0 (/tmp/volo-cli-test/thrift/volo-gen)`
note: To improve backtraces for build dependencies, set the CARGO_PROFILE_DEV_BUILD_OVERRIDE_DEBUG=true environment variable to enable debug information generation.

Caused by:
  process didn't exit successfully: `/tmp/volo-cli-test/thrift/target/debug/build/volo-gen-a891b5fb690df431/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-changed=volo.yml
  cargo:rerun-if-changed=/tmp/volo-cli-test/thrift/idl/echo.thrift

  --- stderr
  error: 'rustfmt' is not installed for the toolchain 'stable-x86_64-unknown-linux-gnu'.
  To install, run `rustup component add rustfmt`

  Stack backtrace:
     0: anyhow::kind::Adhoc::new
     1: anyhow::__private::format_err.1271
     2: rustup::config::Cfg::create_command_for_toolchain_
     3: rustup::cli::proxy_mode::main
     4: rustup_init::main
     5: std::sys_common::backtrace::__rust_begin_short_backtrace
     6: main
     7: __libc_start_main
     8: <unknown>
Error: Process completed with exit code 101.
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
