### PR TITLE
chore(volo-http): add panic handler for http server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3112,7 +3112,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "volo"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-broadcast",
  "dashmap",

--- a/volo-http/src/server/mod.rs
+++ b/volo-http/src/server/mod.rs
@@ -40,6 +40,7 @@ mod handler;
 mod into_response;
 pub mod layer;
 pub mod middleware;
+pub mod panic_handler;
 pub mod param;
 pub mod route;
 

--- a/volo-http/src/server/panic_handler.rs
+++ b/volo-http/src/server/panic_handler.rs
@@ -1,0 +1,51 @@
+use std::any::Any;
+
+use http::StatusCode;
+use motore::service::Service;
+use volo::catch_panic;
+
+use super::IntoResponse;
+use crate::response::ServerResponse;
+
+/// Panic handler which can return a fixed payload.
+///
+/// This type can be constructed by [`fixed_payload`].
+#[derive(Clone, Debug)]
+pub struct FixedPayload<R> {
+    payload: R,
+}
+
+impl<S, Cx, Req, Resp> catch_panic::Handler<S, Cx, Req> for FixedPayload<Resp>
+where
+    S: Service<Cx, Req, Response = ServerResponse> + Send + Sync + 'static,
+    Cx: Send + 'static,
+    Req: Send + 'static,
+    Resp: IntoResponse + Clone,
+{
+    fn handle(
+        &self,
+        _: &mut Cx,
+        _: Box<dyn Any + Send>,
+        panic_info: catch_panic::PanicInfo,
+    ) -> Result<S::Response, S::Error> {
+        tracing::error!("[Volo-HTTP] panic_handler: {panic_info}");
+        Ok(self.payload.clone().into_response())
+    }
+}
+
+/// This function is a panic handler and can work with [`volo::catch_panic::Layer`], it will always
+/// return `500 Internal Server Error`.
+pub fn always_internal_error<Cx, E>(
+    _: &mut Cx,
+    _: Box<dyn Any + Send>,
+    panic_info: catch_panic::PanicInfo,
+) -> Result<ServerResponse, E> {
+    tracing::error!("[Volo-HTTP] panic_handler: {panic_info}");
+    Ok(StatusCode::INTERNAL_SERVER_ERROR.into_response())
+}
+
+/// Create a panic handler which can work with [`volo::catch_panic::Layer`]. The handler will
+/// always return the specified fixed payload as response.
+pub fn fixed_payload<R>(payload: R) -> FixedPayload<R> {
+    FixedPayload { payload }
+}

--- a/volo/Cargo.toml
+++ b/volo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo"
-version = "0.10.0"
+version = "0.10.1"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo/src/catch_panic/mod.rs
+++ b/volo/src/catch_panic/mod.rs
@@ -28,6 +28,7 @@ use futures::FutureExt;
 ///
 /// Note: not all panics can be caught, for example, if users call `std::process::exit`,
 /// `std::process::abort` or set panic = "abort" in profile, the process will exit immediately.
+#[derive(Clone)]
 pub struct Layer<T> {
     panic_handler: T,
 }
@@ -185,6 +186,7 @@ impl<S, T> crate::layer::Layer<S> for Layer<T> {
     }
 }
 
+#[derive(Clone)]
 pub struct Service<S, T> {
     inner: S,
     panic_handler: T,


### PR DESCRIPTION
## Motivation

Since Volo already supports `catch_panic`, Volo-HTTP should provide some common handlers for easy use.

## Solution

Add two panic handlers, one that always returns `500 Internal Server Error`, and another that returns a fixed payload that implements `IntoResponse` and `Clone`.
