### PR TITLE
feat(volo-http): support nested router and nested service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,6 +1407,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2999,6 +3009,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3153,7 +3172,7 @@ dependencies = [
  "faststr",
  "git2",
  "heck 0.5.0",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "lazy_static",
  "mockall",
  "mockall_double",
@@ -3273,6 +3292,7 @@ dependencies = [
  "memchr",
  "metainfo",
  "mime",
+ "mime_guess",
  "motore",
  "parking_lot 0.12.3",
  "paste",
@@ -3287,6 +3307,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.25.0",
+ "tokio-util",
  "tracing",
  "volo",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ log = "0.4"
 matchit = "0.8"
 memchr = "2"
 mime = "0.3"
+mime_guess = { version = "2", default-features = false }
 mockall = "0.12"
 mockall_double = "0.3"
 mur3 = "0.1"

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -38,6 +38,7 @@ itoa.workspace = true
 memchr.workspace = true
 metainfo.workspace = true
 mime.workspace = true
+mime_guess.workspace = true
 motore.workspace = true
 parking_lot.workspace = true
 paste.workspace = true
@@ -46,12 +47,14 @@ scopeguard.workspace = true
 simdutf8.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = [
+    "fs",
     "time",
     "macros",
     "rt",
     "signal",
     "parking_lot",
 ] }
+tokio-util = { workspace = true, features = ["io"] }
 tracing.workspace = true
 
 # server optional

--- a/volo-http/src/server/mod.rs
+++ b/volo-http/src/server/mod.rs
@@ -45,6 +45,7 @@ pub mod response;
 pub mod route;
 #[cfg(test)]
 pub mod test_helpers;
+pub mod utils;
 
 pub use self::{
     response::{IntoResponse, Redirect},
@@ -63,7 +64,7 @@ pub mod prelude {
 ///
 /// # Examples
 ///
-/// ```compile_fail
+/// ```ignore
 /// use std::net::SocketAddr;
 ///
 /// use volo::net::Address;

--- a/volo-http/src/server/param.rs
+++ b/volo-http/src/server/param.rs
@@ -41,6 +41,19 @@ impl PathParamsVec {
             self.inner.push((k, v));
         }
     }
+
+    pub(crate) fn pop(&mut self) -> Option<(FastStr, FastStr)> {
+        self.inner.pop()
+    }
+}
+
+impl IntoIterator for PathParamsVec {
+    type Item = (FastStr, FastStr);
+    type IntoIter = std::vec::IntoIter<(FastStr, FastStr)>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.into_iter()
+    }
 }
 
 impl Deref for PathParamsVec {
@@ -69,6 +82,15 @@ impl Deref for PathParamsMap {
 
     fn deref(&self) -> &Self::Target {
         &self.inner
+    }
+}
+
+impl IntoIterator for PathParamsMap {
+    type Item = (FastStr, FastStr);
+    type IntoIter = std::collections::hash_map::IntoIter<FastStr, FastStr>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.into_iter()
     }
 }
 

--- a/volo-http/src/server/utils/file_response.rs
+++ b/volo-http/src/server/utils/file_response.rs
@@ -1,0 +1,85 @@
+use std::{
+    fs::File,
+    io,
+    os::unix::fs::MetadataExt,
+    path::Path,
+    pin::Pin,
+    task::{ready, Context, Poll},
+};
+
+use bytes::Bytes;
+use futures::Stream;
+use http::header::{self, HeaderValue};
+use http_body::{Frame, SizeHint};
+use pin_project::pin_project;
+use tokio::io::AsyncRead;
+use tokio_util::io::ReaderStream;
+
+use crate::{body::Body, response::ServerResponse, server::IntoResponse};
+
+const BUF_SIZE: usize = 4096;
+
+pub struct FileResponse {
+    file: File,
+    size: u64,
+    content_type: HeaderValue,
+}
+
+impl FileResponse {
+    pub fn new<P>(path: P, content_type: HeaderValue) -> io::Result<Self>
+    where
+        P: AsRef<Path>,
+    {
+        let file = File::open(path)?;
+        let metadata = file.metadata()?;
+
+        Ok(Self {
+            file,
+            size: metadata.size(),
+            content_type,
+        })
+    }
+}
+
+impl IntoResponse for FileResponse {
+    fn into_response(self) -> ServerResponse {
+        let file = tokio::fs::File::from_std(self.file);
+        ServerResponse::builder()
+            .header(header::CONTENT_TYPE, self.content_type)
+            .body(Body::from_body(FileBody {
+                reader: ReaderStream::with_capacity(file, BUF_SIZE),
+                size: self.size,
+            }))
+            .unwrap()
+    }
+}
+
+#[pin_project]
+struct FileBody<R> {
+    #[pin]
+    reader: ReaderStream<R>,
+    size: u64,
+}
+
+impl<R> http_body::Body for FileBody<R>
+where
+    R: AsyncRead,
+{
+    type Data = Bytes;
+    type Error = io::Error;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        match ready!(self.project().reader.poll_next(cx)) {
+            Some(Ok(chunk)) => Poll::Ready(Some(Ok(Frame::data(chunk)))),
+            Some(Err(err)) => Poll::Ready(Some(Err(err))),
+            None => Poll::Ready(None),
+        }
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        SizeHint::with_exact(self.size)
+    }
+}

--- a/volo-http/src/server/utils/mod.rs
+++ b/volo-http/src/server/utils/mod.rs
@@ -1,0 +1,5 @@
+mod file_response;
+mod serve_dir;
+
+pub use file_response::FileResponse;
+pub use serve_dir::ServeDir;

--- a/volo-http/src/server/utils/serve_dir.rs
+++ b/volo-http/src/server/utils/serve_dir.rs
@@ -1,0 +1,178 @@
+//! Service for serving a directory.
+//!
+//! This module includes [`ServeDir`], which can be used for serving a directory through a
+//! catch-all uri like `/static/{*path}` or `Router::nest_service`.
+//!
+//! # Examples
+//!
+//! ```
+//! use volo_http::server::{
+//!     route::{get, Router},
+//!     utils::ServeDir,
+//! };
+//!
+//! let router: Router = Router::new()
+//!     .route("/", get(|| async { "Hello, World" }))
+//!     .nest_service("/static/", ServeDir::new("."));
+//! ```
+//!
+//! The `"."` means `ServeDir` will serve the CWD (current working directory) and then you can
+//! access any file in the directory.
+
+#![deny(missing_docs)]
+
+use std::{
+    fs,
+    marker::PhantomData,
+    path::{Path, PathBuf},
+};
+
+use http::{header::HeaderValue, status::StatusCode};
+use motore::service::Service;
+
+use super::FileResponse;
+use crate::{
+    context::ServerContext, request::ServerRequest, response::ServerResponse, server::IntoResponse,
+};
+
+/// [`ServeDir`] is a service for sending files from a given directory.
+pub struct ServeDir<E, F> {
+    path: PathBuf,
+    mime_getter: F,
+    _marker: PhantomData<fn(E)>,
+}
+
+impl<E> ServeDir<E, fn(&Path) -> HeaderValue> {
+    /// Create a new [`ServeDir`] service with the given path.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the path is invalid
+    /// - Panics if the path is not a directory
+    pub fn new<P>(path: P) -> Self
+    where
+        P: AsRef<Path>,
+    {
+        let path = fs::canonicalize(path).expect("ServeDir: failed to canonicalize path");
+        assert!(path.is_dir());
+        Self {
+            path,
+            mime_getter: guess_mime,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Set a function for getting mime from file path.
+    ///
+    /// By default, [`ServeDir`] will use `mime_guess` crate for guessing a mime through the file
+    /// extension name.
+    pub fn mime_getter<F>(self, mime_getter: F) -> ServeDir<E, F>
+    where
+        F: Fn(&Path) -> HeaderValue,
+    {
+        ServeDir {
+            path: self.path,
+            mime_getter,
+            _marker: self._marker,
+        }
+    }
+}
+
+impl<B, E, F> Service<ServerContext, ServerRequest<B>> for ServeDir<E, F>
+where
+    B: Send,
+    F: Fn(&Path) -> HeaderValue + Sync,
+{
+    type Response = ServerResponse;
+    type Error = E;
+
+    async fn call(
+        &self,
+        _: &mut ServerContext,
+        req: ServerRequest<B>,
+    ) -> Result<Self::Response, Self::Error> {
+        // Get relative path from uri
+        let path = req.uri().path();
+        let path = path.strip_prefix('/').unwrap_or(path);
+
+        tracing::trace!("ServeDir: path: {path}");
+
+        // Join to the serving directory and canonicalize it
+        let path = self.path.join(path);
+        let Ok(path) = fs::canonicalize(path) else {
+            return Ok(StatusCode::NOT_FOUND.into_response());
+        };
+
+        // Reject file which is out of the serving directory
+        if path.strip_prefix(self.path.as_path()).is_err() {
+            tracing::debug!("ServeDir: illegal path: {}", path.display());
+            return Ok(StatusCode::FORBIDDEN.into_response());
+        }
+
+        // Check metadata and permission
+        if !path.is_file() {
+            return Ok(StatusCode::NOT_FOUND.into_response());
+        }
+
+        // Get mime and return it!
+        let content_type = (self.mime_getter)(&path);
+        let Ok(resp) = FileResponse::new(path, content_type) else {
+            return Ok(StatusCode::INTERNAL_SERVER_ERROR.into_response());
+        };
+        Ok(resp.into_response())
+    }
+}
+
+pub fn guess_mime(path: &Path) -> HeaderValue {
+    mime_guess::from_path(path)
+        .first_raw()
+        .map(HeaderValue::from_static)
+        .unwrap_or_else(|| HeaderValue::from_str(mime::APPLICATION_OCTET_STREAM.as_ref()).unwrap())
+}
+
+#[cfg(test)]
+mod serve_dir_tests {
+    use http::{method::Method, StatusCode};
+
+    use super::ServeDir;
+    use crate::{
+        body::Body,
+        server::{Router, Server},
+    };
+
+    #[tokio::test]
+    async fn read_file() {
+        // volo/volo-http
+        let router: Router<Option<Body>> =
+            Router::new().nest_service("/static/", ServeDir::new("."));
+        let server = Server::new(router).into_test_server();
+        // volo/volo-http/Cargo.toml
+        assert!(server
+            .call_route(Method::GET, "/static/Cargo.toml", None)
+            .await
+            .status()
+            .is_success());
+        // volo/volo-http/src/lib.rs
+        assert!(server
+            .call_route(Method::GET, "/static/src/lib.rs", None)
+            .await
+            .status()
+            .is_success());
+        // volo/volo-http/Cargo.lock, this file does not exist
+        assert_eq!(
+            server
+                .call_route(Method::GET, "/static/Cargo.lock", None)
+                .await
+                .status(),
+            StatusCode::NOT_FOUND
+        );
+        // volo/Cargo.toml, this file should be rejected
+        assert_eq!(
+            server
+                .call_route(Method::GET, "/static/../Cargo.toml", None)
+                .await
+                .status(),
+            StatusCode::FORBIDDEN
+        );
+    }
+}


### PR DESCRIPTION
## Motivation

Add support for nest router.

## Solution

This PR supports nested router and nest service. Unit tests are also updated.

This PR also adds `utils::ServeDir` as an example for serving a directory and sending files from the dir.