### PR TITLE
chore(ci): reuse scripts in selftest and ci, patch deps in cli test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,29 +57,7 @@ jobs:
         run: |
           apt update
           apt install -y libssl-dev
-          cargo clippy -p volo-thrift --no-default-features -- --deny warnings
-          cargo clippy -p volo-thrift --no-default-features --features multiplex -- --deny warnings
-          cargo clippy -p volo-thrift --no-default-features --features unsafe-codec -- --deny warnings
-          cargo clippy -p volo-grpc --no-default-features -- --deny warnings
-          cargo clippy -p volo-grpc --no-default-features --features rustls -- --deny warnings
-          cargo clippy -p volo-grpc --no-default-features --features native-tls -- --deny warnings
-          cargo clippy -p volo-grpc --no-default-features --features native-tls-vendored -- --deny warnings
-          cargo clippy -p volo-http --no-default-features -- --deny warnings
-          cargo clippy -p volo-http --no-default-features --features default_client -- --deny warnings
-          cargo clippy -p volo-http --no-default-features --features default_server -- --deny warnings
-          cargo clippy -p volo-http --no-default-features --features client,server,serde_json -- --deny warnings
-          cargo clippy -p volo-http --no-default-features --features full -- --deny warnings
-          cargo clippy -p volo -- --deny warnings
-          cargo clippy -p volo-build -- --deny warnings
-          cargo clippy -p volo-cli -- --deny warnings
-          cargo clippy -p volo-macros -- --deny warnings
-          cargo clippy -p examples -- --deny warnings
-          cargo test -p volo-thrift
-          cargo test -p volo-grpc --features rustls
-          cargo test -p volo-http --features full
-          cargo test -p volo --features rustls
-          cargo test -p volo-build
-          cargo test -p volo-cli
+          bash scripts/clippy-and-test.sh
 
   test-linux-aarch64:
     runs-on: [self-hosted, arm]
@@ -97,29 +75,7 @@ jobs:
         run: |
           apt update
           apt install -y libssl-dev
-          cargo clippy -p volo-thrift --no-default-features -- --deny warnings
-          cargo clippy -p volo-thrift --no-default-features --features multiplex -- --deny warnings
-          cargo clippy -p volo-thrift --no-default-features --features unsafe-codec -- --deny warnings
-          cargo clippy -p volo-grpc --no-default-features -- --deny warnings
-          cargo clippy -p volo-grpc --no-default-features --features rustls -- --deny warnings
-          cargo clippy -p volo-grpc --no-default-features --features native-tls -- --deny warnings
-          cargo clippy -p volo-grpc --no-default-features --features native-tls-vendored -- --deny warnings
-          cargo clippy -p volo-http --no-default-features -- --deny warnings
-          cargo clippy -p volo-http --no-default-features --features default_client -- --deny warnings
-          cargo clippy -p volo-http --no-default-features --features default_server -- --deny warnings
-          cargo clippy -p volo-http --no-default-features --features client,server,serde_json -- --deny warnings
-          cargo clippy -p volo-http --no-default-features --features full -- --deny warnings
-          cargo clippy -p volo -- --deny warnings
-          cargo clippy -p volo-build -- --deny warnings
-          cargo clippy -p volo-cli -- --deny warnings
-          cargo clippy -p volo-macros -- --deny warnings
-          cargo clippy -p examples -- --deny warnings
-          cargo test -p volo-thrift
-          cargo test -p volo-grpc --features rustls
-          cargo test -p volo-http --features full
-          cargo test -p volo --features rustls
-          cargo test -p volo-build
-          cargo test -p volo-cli
+          bash scripts/clippy-and-test.sh
 
   test-macos:
     runs-on: macos-latest
@@ -136,29 +92,7 @@ jobs:
       # - uses: Swatinem/rust-cache@v1
       - name: Run tests
         run: |
-          cargo clippy -p volo-thrift --no-default-features -- --deny warnings
-          cargo clippy -p volo-thrift --no-default-features --features multiplex -- --deny warnings
-          cargo clippy -p volo-thrift --no-default-features --features unsafe-codec -- --deny warnings
-          cargo clippy -p volo-grpc --no-default-features -- --deny warnings
-          cargo clippy -p volo-grpc --no-default-features --features rustls -- --deny warnings
-          cargo clippy -p volo-grpc --no-default-features --features native-tls -- --deny warnings
-          cargo clippy -p volo-grpc --no-default-features --features native-tls-vendored -- --deny warnings
-          cargo clippy -p volo-http --no-default-features -- --deny warnings
-          cargo clippy -p volo-http --no-default-features --features default_client -- --deny warnings
-          cargo clippy -p volo-http --no-default-features --features default_server -- --deny warnings
-          cargo clippy -p volo-http --no-default-features --features client,server,serde_json -- --deny warnings
-          cargo clippy -p volo-http --no-default-features --features full -- --deny warnings
-          cargo clippy -p volo -- --deny warnings
-          cargo clippy -p volo-build -- --deny warnings
-          cargo clippy -p volo-cli -- --deny warnings
-          cargo clippy -p volo-macros -- --deny warnings
-          cargo clippy -p examples -- --deny warnings
-          cargo test -p volo-thrift
-          cargo test -p volo-grpc --features rustls
-          cargo test -p volo-http --features full
-          cargo test -p volo --features rustls
-          cargo test -p volo-build
-          cargo test -p volo-cli
+          bash scripts/clippy-and-test.sh
 
   test-windows:
     runs-on: windows-latest
@@ -175,29 +109,7 @@ jobs:
       # - uses: Swatinem/rust-cache@v1
       - name: Run tests
         run: |
-          cargo clippy -p volo-thrift --no-default-features -- --deny warnings
-          cargo clippy -p volo-thrift --no-default-features --features multiplex -- --deny warnings
-          cargo clippy -p volo-thrift --no-default-features --features unsafe-codec -- --deny warnings
-          cargo clippy -p volo-grpc --no-default-features -- --deny warnings
-          cargo clippy -p volo-grpc --no-default-features --features rustls -- --deny warnings
-          cargo clippy -p volo-grpc --no-default-features --features native-tls -- --deny warnings
-          cargo clippy -p volo-grpc --no-default-features --features native-tls-vendored -- --deny warnings
-          cargo clippy -p volo-http --no-default-features -- --deny warnings
-          cargo clippy -p volo-http --no-default-features --features default_client -- --deny warnings
-          cargo clippy -p volo-http --no-default-features --features default_server -- --deny warnings
-          cargo clippy -p volo-http --no-default-features --features client,server,serde_json -- --deny warnings
-          cargo clippy -p volo-http --no-default-features --features full -- --deny warnings
-          cargo clippy -p volo -- --deny warnings
-          cargo clippy -p volo-build -- --deny warnings
-          cargo clippy -p volo-cli -- --deny warnings
-          cargo clippy -p volo-macros -- --deny warnings
-          cargo clippy -p examples -- --deny warnings
-          cargo test -p volo-thrift
-          cargo test -p volo-grpc --features rustls
-          cargo test -p volo-http --features full
-          cargo test -p volo --features rustls
-          cargo test -p volo-build
-          cargo test -p volo-cli
+          bash scripts/clippy-and-test.sh
 
   test-cli:
     runs-on: [self-hosted, X64]
@@ -213,19 +125,4 @@ jobs:
           toolchain: ${{matrix.rust}}
       - name: Cli tests
         run: |
-          rm -rf /tmp/volo-cli-test
-          mkdir -p /tmp/volo-cli-test/{thrift/idl,grpc/idl,http}
-          cp examples/thrift_idl/echo.thrift /tmp/volo-cli-test/thrift/idl
-          cp examples/proto/echo.proto /tmp/volo-cli-test/grpc/idl
-          cargo build -p volo-cli
-          cp target/debug/volo /tmp/volo-cli-test/volo
-          cd /tmp/volo-cli-test/thrift
-          ../volo init thrift-test idl/echo.thrift
-          cargo build
-          cd /tmp/volo-cli-test/grpc
-          ../volo init --includes idl grpc-test idl/echo.proto
-          cargo build
-          cd /tmp/volo-cli-test/http
-          ../volo http init http-test
-          cargo build
-          rm -rf /tmp/volo-cli-test
+          bash scripts/volo-cli-test.sh

--- a/scripts/clippy-and-test.sh
+++ b/scripts/clippy-and-test.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo_command() {
+	echo "Run \`$@\`"
+
+	if [ "${GITHUB_ACTIONS:-}" = "true" ] || [ -n "${DEBUG:-}" ]; then
+		# If we are in GitHub Actions or env `DEBUG` is non-empty,
+		# output all
+		"$@"
+	else
+		# Disable outputs
+		"$@" > /dev/null 2>&1
+	fi
+}
+
+# Setup error handler
+trap 'echo "Failed to run $LINENO: $BASH_COMMAND (exit code: $?)" && exit 1' ERR
+
+# Clippy
+echo_command cargo clippy -p volo-thrift --no-default-features -- --deny warnings
+echo_command cargo clippy -p volo-thrift --no-default-features --features multiplex -- --deny warnings
+echo_command cargo clippy -p volo-thrift --no-default-features --features unsafe-codec -- --deny warnings
+echo_command cargo clippy -p volo-grpc --no-default-features -- --deny warnings
+echo_command cargo clippy -p volo-grpc --no-default-features --features rustls -- --deny warnings
+echo_command cargo clippy -p volo-grpc --no-default-features --features native-tls -- --deny warnings
+echo_command cargo clippy -p volo-grpc --no-default-features --features native-tls-vendored -- --deny warnings
+echo_command cargo clippy -p volo-http --no-default-features -- --deny warnings
+echo_command cargo clippy -p volo-http --no-default-features --features default_client -- --deny warnings
+echo_command cargo clippy -p volo-http --no-default-features --features default_server -- --deny warnings
+echo_command cargo clippy -p volo-http --no-default-features --features client,server,serde_json -- --deny warnings
+echo_command cargo clippy -p volo-http --no-default-features --features full -- --deny warnings
+echo_command cargo clippy -p volo -- --deny warnings
+echo_command cargo clippy -p volo-build -- --deny warnings
+echo_command cargo clippy -p volo-cli -- --deny warnings
+echo_command cargo clippy -p volo-macros -- --deny warnings
+echo_command cargo clippy -p examples -- --deny warnings
+
+# Test
+echo_command cargo test -p volo-thrift
+echo_command cargo test -p volo-grpc --features rustls
+echo_command cargo test -p volo-http --features full
+echo_command cargo test -p volo --features rustls
+echo_command cargo test -p volo-build
+echo_command cargo test -p volo-cli

--- a/scripts/selftest.sh
+++ b/scripts/selftest.sh
@@ -13,78 +13,21 @@ quiet() {
 	"$@" > /dev/null 2>&1
 }
 
-test_in_empty_dir() {
-	local tmp_dir="$(mktemp --tmpdir --directory volo_cli.XXXX)"
-	quiet pushd "${tmp_dir}"
-
-	echo_and_run "$@"
-
-	quiet popd
-	rm -rf "${tmp_dir}"
-}
-
 fmt_check() {
 	echo_and_run cargo fmt -- --check
 }
 
-clippy_check() {
-	# check and clippy for all crates and common features
-	echo_and_run cargo clippy -p volo-thrift --no-default-features -- --deny warnings
-	echo_and_run cargo clippy -p volo-thrift --no-default-features --features multiplex -- --deny warnings
-	echo_and_run cargo clippy -p volo-thrift --no-default-features --features unsafe-codec -- --deny warnings
-	echo_and_run cargo clippy -p volo-grpc --no-default-features -- --deny warnings
-	echo_and_run cargo clippy -p volo-grpc --no-default-features --features rustls -- --deny warnings
-	echo_and_run cargo clippy -p volo-grpc --no-default-features --features native-tls -- --deny warnings
-	echo_and_run cargo clippy -p volo-grpc --no-default-features --features native-tls-vendored -- --deny warnings
-	echo_and_run cargo clippy -p volo-http --no-default-features -- --deny warnings
-	echo_and_run cargo clippy -p volo-http --no-default-features --features default_client -- --deny warnings
-	echo_and_run cargo clippy -p volo-http --no-default-features --features default_server -- --deny warnings
-	echo_and_run cargo clippy -p volo-http --no-default-features --features client,server,serde_json -- --deny warnings
-	echo_and_run cargo clippy -p volo-http --no-default-features --features full -- --deny warnings
-	echo_and_run cargo clippy -p volo -- --deny warnings
-	echo_and_run cargo clippy -p volo-build -- --deny warnings
-	echo_and_run cargo clippy -p volo-cli -- --deny warnings
-	echo_and_run cargo clippy -p volo-macros -- --deny warnings
-	echo_and_run cargo clippy -p examples -- --deny warnings
-}
-
-unit_test() {
-	echo_and_run cargo test -p volo-thrift
-	echo_and_run cargo test -p volo-grpc --features rustls
-	echo_and_run cargo test -p volo-http --features full
-	echo_and_run cargo test -p volo -- features rustls
-	echo_and_run cargo test -p volo-build
-	echo_and_run cargo test -p volo-cli
+clippy_and_test() {
+	bash "scripts/clippy-and-test.sh"
 }
 
 volo_cli_test() {
-	cargo build -p volo-cli -j `nproc`
-	local volo_cli="$PWD/target/debug/volo"
-	local thrift_idl="$PWD/examples/thrift_idl/echo.thrift"
-	local pb_idl="$PWD/examples/proto/echo.proto"
-	local pb_idl_filename="$(basename "${pb_idl}")"
-
-	# thrift
-	test_in_empty_dir bash -c "\
-\"${volo_cli}\" init thrift-test \"${thrift_idl}\" && \
-cargo build -j \`nproc\`"
-
-	# grpc
-	test_in_empty_dir bash -c "\
-mkdir idl && cp \"${pb_idl}\" idl && \
-\"${volo_cli}\" init --includes idl grpc-test \"idl/${pb_idl_filename}\" && \
-cargo build -j \`nproc\`"
-
-	# http
-	test_in_empty_dir bash -c "\
-\"${volo_cli}\" http init http-test && \
-cargo build -j \`nproc\`"
+	bash "scripts/volo-cli-test.sh"
 }
 
 main() {
 	fmt_check
-	clippy_check
-	unit_test
+	clippy_and_test
 	volo_cli_test
 }
 

--- a/scripts/volo-cli-test.sh
+++ b/scripts/volo-cli-test.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+quiet() {
+	"$@" > /dev/null 2>&1
+}
+
+echo_command() {
+	echo "Run \`$@\`"
+
+	if [ "${GITHUB_ACTIONS:-}" = "true" ] || [ -n "${DEBUG:-}" ]; then
+		# If we are in GitHub Actions or env `DEBUG` is non-empty,
+		# output all
+		"$@"
+	else
+		# Disable outputs
+		quiet "$@"
+	fi
+}
+
+enter_tmp_dir() {
+	export __TMP_DIR="$(mktemp --tmpdir --directory volo_cli.XXXXXX)"
+	quiet pushd "${__TMP_DIR}"
+}
+
+escape_tmp_dir() {
+	quiet popd
+	rm -rf "${__TMP_DIR}"
+	unset __TMP_DIR
+}
+
+init() {
+	export VOLO_DIR="$PWD"
+	echo_command cargo build -p volo-cli -j `nproc`
+	export VOLO_CLI="$PWD/target/debug/volo"
+	trap 'echo "Failed to run $LINENO: $BASH_COMMAND (exit code: $?)" && exit 1' ERR
+}
+
+append_volo_dep_item() {
+	echo "$1 = { path = \"$VOLO_DIR/$1\" }" >> Cargo.toml
+}
+
+patch_cargo_toml() {
+	echo "[patch.crates-io]" >> Cargo.toml
+	append_volo_dep_item volo
+	append_volo_dep_item volo-build
+	append_volo_dep_item volo-thrift
+	append_volo_dep_item volo-grpc
+	append_volo_dep_item volo-http
+}
+
+thrift_test() {
+	local idl_path="$VOLO_DIR/examples/thrift_idl/echo.thrift"
+
+	enter_tmp_dir
+
+	echo_command "${VOLO_CLI}" init thrift-test "${idl_path}"
+	patch_cargo_toml
+	echo_command cargo build -j `nproc`
+
+	escape_tmp_dir
+}
+
+grpc_test() {
+	local idl_path="$VOLO_DIR/examples/proto/echo.proto"
+	local idl_dir="$(dirname "${idl_path}")"
+
+	enter_tmp_dir
+
+	echo_command "${VOLO_CLI}" init --includes "${idl_dir}" grpc-test "${idl_path}"
+	patch_cargo_toml
+	echo_command cargo build -j `nproc`
+
+	escape_tmp_dir
+}
+
+http_test() {
+	enter_tmp_dir
+
+	echo_command "${VOLO_CLI}" http init http-test
+	patch_cargo_toml
+	echo_command cargo build -j `nproc`
+
+	escape_tmp_dir
+}
+
+main() {
+	init
+	thrift_test
+	grpc_test
+	http_test
+}
+
+main

--- a/volo-http/src/client/discover/mod.rs
+++ b/volo-http/src/client/discover/mod.rs
@@ -249,6 +249,7 @@ impl Target {
         match &self.inner {
             TargetInner::None => None,
             TargetInner::Address(addr) => {
+                #[allow(irrefutable_let_patterns)]
                 if let Address::Ip(socket) = addr {
                     let port = socket.port();
                     // If the port is default port, just ignore it.

--- a/volo-http/src/server/mod.rs
+++ b/volo-http/src/server/mod.rs
@@ -312,7 +312,7 @@ impl<S, L> Server<S, L> {
         #[cfg(target_family = "windows")]
         tokio::select! {
             _ = tokio::signal::ctrl_c() => {}
-            res = handler => {},
+            _ = handler => {},
         }
 
         if !self.shutdown_hooks.is_empty() {

--- a/volo-http/src/server/utils/file_response.rs
+++ b/volo-http/src/server/utils/file_response.rs
@@ -1,7 +1,6 @@
 use std::{
     fs::File,
     io,
-    os::unix::fs::MetadataExt,
     path::Path,
     pin::Pin,
     task::{ready, Context, Poll},
@@ -35,7 +34,7 @@ impl FileResponse {
 
         Ok(Self {
             file,
-            size: metadata.size(),
+            size: metadata.len(),
             content_type,
         })
     }


### PR DESCRIPTION
## Motivation

There are some issues with the current CI and self-test scripts:

- Most commands are the same in CI and self-tests, these commands can be reused
- The cli tests (for `volo-cli` and its generated code) should use local code instead of crates from `crates-io`

## Solution

Refactor CI config and test scripts, reuse most commands.