### PR TITLE
fix(volo-thrift): remove static lifetime anno for context method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3328,7 +3328,7 @@ version = "0.10.0"
 
 [[package]]
 name = "volo-thrift"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "ahash",
  "anyhow",

--- a/volo-cli/src/migrate.rs
+++ b/volo-cli/src/migrate.rs
@@ -56,7 +56,7 @@ impl CliCommand for Migrate {
                 });
             Ok(())
         })
-        .map_err(|e| {
+        .inspect_err(|_| {
             if let Err(e) = std::fs::rename(backup_path.as_path(), path.as_path()) {
                 eprintln!(
                     "failed to restore backup file: {}, please manually rename it to volo.yml \
@@ -64,7 +64,6 @@ impl CliCommand for Migrate {
                     e
                 );
             }
-            e
         })?;
         std::fs::remove_file(backup_path)?;
         Ok(())

--- a/volo-thrift/Cargo.toml
+++ b/volo-thrift/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-thrift"
-version = "0.10.1"
+version = "0.10.2"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-thrift/src/client/mod.rs
+++ b/volo-thrift/src/client/mod.rs
@@ -657,8 +657,8 @@ struct ClientInner {
     seq_id: AtomicI32,
 }
 
-impl<S> Client<S> {
-    pub fn make_cx(&self, method: &'static str, oneway: bool) -> ClientContext {
+impl<'m, S> Client<S> {
+    pub fn make_cx(&self, method: &'m str, oneway: bool) -> ClientContext {
         CLIENT_CONTEXT_CACHE.with(|cache| {
             let mut cache = cache.borrow_mut();
             cache
@@ -687,8 +687,7 @@ impl<S> Client<S> {
                         cx.rpc_info_mut().callee_mut().set_address(target.clone());
                     }
                     cx.rpc_info_mut().set_config(self.inner.config);
-                    cx.rpc_info_mut()
-                        .set_method(FastStr::from_static_str(method));
+                    cx.rpc_info_mut().set_method(FastStr::new(method));
                     cx
                 })
                 .unwrap_or_else(|| {
@@ -707,7 +706,7 @@ impl<S> Client<S> {
         })
     }
 
-    fn make_rpc_info(&self, method: &'static str) -> RpcInfo<Config> {
+    fn make_rpc_info(&self, method: &'m str) -> RpcInfo<Config> {
         let caller = Endpoint::new(self.inner.caller_name.clone());
         let mut callee = Endpoint::new(self.inner.callee_name.clone());
         if let Some(target) = &self.inner.address {
@@ -715,7 +714,7 @@ impl<S> Client<S> {
         }
         let config = self.inner.config;
 
-        RpcInfo::new(Role::Client, method.into(), caller, callee, config)
+        RpcInfo::new(Role::Client, FastStr::new(method), caller, callee, config)
     }
 
     pub fn with_opt<Opt>(self, opt: Opt) -> Client<WithOptService<S, Opt>> {

--- a/volo-thrift/src/client/mod.rs
+++ b/volo-thrift/src/client/mod.rs
@@ -657,8 +657,8 @@ struct ClientInner {
     seq_id: AtomicI32,
 }
 
-impl<'m, S> Client<S> {
-    pub fn make_cx(&self, method: &'m str, oneway: bool) -> ClientContext {
+impl<S> Client<S> {
+    pub fn make_cx(&self, method: &str, oneway: bool) -> ClientContext {
         CLIENT_CONTEXT_CACHE.with(|cache| {
             let mut cache = cache.borrow_mut();
             cache
@@ -706,7 +706,7 @@ impl<'m, S> Client<S> {
         })
     }
 
-    fn make_rpc_info(&self, method: &'m str) -> RpcInfo<Config> {
+    fn make_rpc_info(&self, method: &str) -> RpcInfo<Config> {
         let caller = Endpoint::new(self.inner.caller_name.clone());
         let mut callee = Endpoint::new(self.inner.callee_name.clone());
         if let Some(target) = &self.inner.address {

--- a/volo-thrift/src/codec/default/mod.rs
+++ b/volo-thrift/src/codec/default/mod.rs
@@ -140,10 +140,9 @@ impl<E: ZeroCopyEncoder, W: AsyncWrite + Unpin + Send + Sync + 'static> Encoder
         let mut write_result: Result<(), ThriftException> = self
             .encoder
             .encode(cx, &mut self.linked_bytes, msg)
-            .map_err(|e| {
+            .inspect_err(|_| {
                 // record the error time
                 cx.stats_mut().record_encode_end_at();
-                e
             });
         if write_result.is_ok() {
             cx.stats_mut().record_encode_end_at();

--- a/volo-thrift/src/codec/default/thrift.rs
+++ b/volo-thrift/src/codec/default/thrift.rs
@@ -177,9 +177,8 @@ impl ZeroCopyDecoder for ThriftCodec {
 
         // detect protocol
         // TODO: support using protocol from TTHeader
-        let protocol = detect(buf).map_err(|e| {
+        let protocol = detect(buf).inspect_err(|_| {
             cx.stats_mut().record_read_end_at();
-            e
         })?;
         // TODO: do we need to check the response protocol at client side?
         let res = match protocol {


### PR DESCRIPTION
## Motivation
Method as one field of client context is assigned by user. However, the previous lifetime bound would only receive 'static str, which might be impossible for user, for example, the universal interface platform, which get method from upstream.

## Solution
We relax the lifetime constraint for make_cx interface. 