### PR TITLE
chore(volo-http): fix incorrect usage of docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "volo-http"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "ahash",
  "async-broadcast",

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-http"
-version = "0.2.8"
+version = "0.2.9"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-http/src/extension/mod.rs
+++ b/volo-http/src/extension/mod.rs
@@ -5,11 +5,7 @@ use volo::context::Context;
 #[cfg(feature = "server")]
 mod server;
 
-#[cfg(docsrs)]
-use crate::server::extract::FromContext;
-
-/// `Extension` is used for inserting anything into contexts as a [`Layer`] or extracting
-/// anything as an extractor (through [`crate::server::extract::FromContext`]).
+/// Inserting anything into contexts as a [`Layer`] or extracting anything as an extractor
 ///
 /// # Examples
 ///

--- a/volo-http/src/json/mod.rs
+++ b/volo-http/src/json/mod.rs
@@ -28,10 +28,8 @@ where
     sonic_rs::from_slice(data)
 }
 
-#[cfg(docsrs)]
-use crate::server::{extract::FromRequest, response::IntoResponse};
-
-/// A wrapper type with [`FromRequest`] and [`IntoResponse`]
+/// A wrapper type with [`FromRequest`](crate::server::extract::FromRequest) and
+/// [`IntoResponse`](crate::server::response::IntoResponse)
 ///
 /// The [`Json`] can be parameter or response of a handler.
 ///


### PR DESCRIPTION
## Motivation

Incorrect usage:

```rust
#[cfg(docsrs)]
use crate::server::{extract::FromRequest, response::IntoResponse};

/// A wrapper type with [`FromRequest`] and [`IntoResponse`]
```

Correct usage:

```rust
/// A wrapper type with [`FromRequest`](crate::server::extract::FromRequest) and
/// [`IntoResponse`](crate::server::response::IntoResponse)
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
