### PR TITLE
fix(volo-http): use `Option<CallOpt>` rather than `CallOpt`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3454,7 +3454,7 @@ dependencies = [
 
 [[package]]
 name = "volo-http"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "ahash",
  "async-broadcast",

--- a/scripts/clippy-and-test.sh
+++ b/scripts/clippy-and-test.sh
@@ -43,6 +43,7 @@ echo_command cargo clippy -p examples -- --deny warnings
 # Test
 echo_command cargo test -p volo-thrift
 echo_command cargo test -p volo-grpc --features rustls
+echo_command cargo test -p volo-http --features default_client,default_server
 echo_command cargo test -p volo-http --features full
 echo_command cargo test -p volo --features rustls
 echo_command cargo test -p volo-build

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-http"
-version = "0.2.10"
+version = "0.2.11"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-http/src/client/dns.rs
+++ b/volo-http/src/client/dns.rs
@@ -139,7 +139,7 @@ impl Discover for DnsResolver {
 ///
 /// [TargetParser]: crate::client::target::TargetParser
 /// [LoadBalance]: volo::loadbalance::LoadBalance
-pub fn parse_target(target: Target, _: &CallOpt, endpoint: &mut Endpoint) {
+pub fn parse_target(target: Target, _: Option<&CallOpt>, endpoint: &mut Endpoint) {
     match target {
         Target::None => (),
         Target::Remote(rt) => {

--- a/volo-http/src/client/request_builder.rs
+++ b/volo-http/src/client/request_builder.rs
@@ -28,7 +28,7 @@ use crate::{
 pub struct RequestBuilder<'a, S, B = Body> {
     client: &'a Client<S>,
     target: Target,
-    call_opt: CallOpt,
+    call_opt: Option<CallOpt>,
     request: ClientRequest<B>,
     timeout: Option<Duration>,
 }
@@ -168,7 +168,7 @@ impl<'a, S, B> RequestBuilder<'a, S, B> {
     ///
     /// See [`CallOpt`] for more details.
     pub fn with_callopt(mut self, call_opt: CallOpt) -> Self {
-        self.call_opt = call_opt;
+        self.call_opt = Some(call_opt);
         self
     }
 
@@ -276,12 +276,12 @@ impl<'a, S, B> RequestBuilder<'a, S, B> {
     }
 
     /// Get a reference to [`CallOpt`].
-    pub fn callopt_ref(&self) -> &CallOpt {
+    pub fn callopt_ref(&self) -> &Option<CallOpt> {
         &self.call_opt
     }
 
     /// Get a mutable reference to [`CallOpt`].
-    pub fn callopt_mut(&mut self) -> &mut CallOpt {
+    pub fn callopt_mut(&mut self) -> &mut Option<CallOpt> {
         &mut self.call_opt
     }
 

--- a/volo-http/src/server/middleware.rs
+++ b/volo-http/src/server/middleware.rs
@@ -77,11 +77,9 @@ where
 /// With params that implement `FromContext`:
 ///
 /// ```
-/// use http::{status::StatusCode, uri::Uri};
-/// use volo::context::Context;
+/// use http::{header::HeaderMap, status::StatusCode, uri::Uri};
 /// use volo_http::{
 ///     context::ServerContext,
-///     cookie::CookieJar,
 ///     request::ServerRequest,
 ///     response::ServerResponse,
 ///     server::{
@@ -93,27 +91,22 @@ where
 ///
 /// struct Session;
 ///
-/// fn check_session(session: &str) -> Option<Session> {
+/// fn get_session(headers: &HeaderMap) -> Option<Session> {
 ///     unimplemented!()
 /// }
 ///
 /// async fn cookies_check(
 ///     uri: Uri,
-///     cookies: CookieJar,
 ///     cx: &mut ServerContext,
 ///     req: ServerRequest,
 ///     next: Next,
 /// ) -> Result<ServerResponse, StatusCode> {
-///     let session = cookies.get("session");
 ///     // User is not logged in, and not try to login.
+///     let session = get_session(req.headers());
 ///     if uri.path() != "/api/v1/login" && session.is_none() {
 ///         return Err(StatusCode::FORBIDDEN);
 ///     }
-///     let session = session.unwrap().value().to_string();
-///     let Some(session) = check_session(&session) else {
-///         return Err(StatusCode::FORBIDDEN);
-///     };
-///     cx.extensions_mut().insert(session);
+///     // do something
 ///     Ok(next.run(cx, req).await.into_response())
 /// }
 ///


### PR DESCRIPTION
## Motivation

In the previous code, if there was a default `Target` and the request only had a `CallOpt` set, the new `CallOpt` would have no effect because the request had no `Target`.

## Solution

This commit fixes this by replacing `CallOpt` with `Option<CallOpt>`. If we use the default target and there is only one `CallOpt`, we will use it directly, otherwise the target `CallOpt` will be used. If the request target is used, the default `CallOpt` will have no effect.