### PR TITLE
chore(volo-http): optimize user experience

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3579,7 +3579,7 @@ dependencies = [
 
 [[package]]
 name = "volo-http"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "ahash",
  "async-broadcast",

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-http"
-version = "0.2.11"
+version = "0.2.12"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-http/src/client/loadbalance.rs
+++ b/volo-http/src/client/loadbalance.rs
@@ -136,7 +136,7 @@ where
                     match channel.recv().await {
                         Ok(recv) => lb.rebalance(recv),
                         Err(err) => {
-                            tracing::warn!("[VOLO] discovering subscription error: {:?}", err)
+                            tracing::warn!("[Volo-HTTP] discovering subscription error: {:?}", err)
                         }
                     }
                 }

--- a/volo-http/src/client/transport.rs
+++ b/volo-http/src/client/transport.rs
@@ -94,7 +94,6 @@ impl ClientTransport {
             volo::net::conn::ConnStream::Tcp(tcp_stream) => tcp_stream,
             _ => unreachable!(),
         };
-        println!("target_name: {target_name}");
         self.tls_connector
             .connect(target_name, tcp_stream)
             .await

--- a/volo-http/src/server/layer.rs
+++ b/volo-http/src/server/layer.rs
@@ -121,7 +121,7 @@ where
             Ok(Err(res)) => Ok(res.into_response()),
             // something wrong while extracting
             Err(rej) => {
-                tracing::warn!("[VOLO] FilterLayer: something wrong while extracting");
+                tracing::warn!("[Volo-HTTP] FilterLayer: something wrong while extracting");
                 Ok(rej.into_response())
             }
         }

--- a/volo-http/src/server/mod.rs
+++ b/volo-http/src/server/mod.rs
@@ -24,7 +24,6 @@ use motore::{
 use parking_lot::RwLock;
 use scopeguard::defer;
 use tokio::sync::Notify;
-use tracing::{info, trace};
 #[cfg(feature = "__tls")]
 use volo::net::{conn::ConnStream, tls::Acceptor, tls::ServerTlsConfig};
 use volo::{
@@ -274,7 +273,7 @@ impl<S, L> Server<S, L> {
         let server = Arc::new(self.server);
         let service = Arc::new(self.layer.layer(self.service));
         let incoming = mk_incoming.make_incoming().await?;
-        info!("[VOLO] server start at: {:?}", incoming);
+        tracing::info!("[Volo-HTTP] server start at: {:?}", incoming);
 
         // count connections, used for graceful shutdown
         let conn_cnt = Arc::new(AtomicUsize::new(0));
@@ -322,7 +321,7 @@ impl<S, L> Server<S, L> {
         }
 
         if !self.shutdown_hooks.is_empty() {
-            info!("[VOLO] call shutdown hooks");
+            tracing::info!("[Volo-HTTP] call shutdown hooks");
 
             for hook in self.shutdown_hooks {
                 (hook)().await;
@@ -330,7 +329,7 @@ impl<S, L> Server<S, L> {
         }
 
         // received signal, graceful shutdown now
-        info!("[VOLO] received signal, gracefully exiting now");
+        tracing::info!("[Volo-HTTP] received signal, gracefully exiting now");
         *exit_flag.write() = true;
 
         // Now we won't accept new connections.
@@ -345,9 +344,9 @@ impl<S, L> Server<S, L> {
             if conn_cnt.load(Ordering::Relaxed) == 0 {
                 break;
             }
-            trace!(
-                "[VOLO] gracefully exiting, remaining connection count: {}",
-                conn_cnt.load(Ordering::Relaxed)
+            tracing::trace!(
+                "[Volo-HTTP] gracefully exiting, remaining connection count: {}",
+                conn_cnt.load(Ordering::Relaxed),
             );
             tokio::time::sleep(Duration::from_secs(1)).await;
         }
@@ -389,7 +388,7 @@ async fn serve<I, S, E>(
                     let stream = match tls_config.acceptor.accept(stream).await {
                         Ok(conn) => conn,
                         Err(err) => {
-                            trace!("[VOLO] tls handshake error: {err:?}");
+                            tracing::trace!("[Volo-HTTP] tls handshake error: {err:?}");
                             continue;
                         }
                     };
@@ -401,11 +400,11 @@ async fn serve<I, S, E>(
 
         let peer = match conn.info.peer_addr {
             Some(ref peer) => {
-                trace!(" accept connection from: {peer:?}");
+                tracing::trace!("accept connection from: {peer:?}");
                 peer.clone()
             }
             None => {
-                info!("no peer address found from server connection");
+                tracing::info!("no peer address found from server connection");
                 continue;
             }
         };
@@ -447,7 +446,7 @@ async fn serve_conn<S>(
 
     tokio::select! {
         _ = &mut notified => {
-            tracing::trace!("[VOLO] closing a pending connection");
+            tracing::trace!("[Volo-HTTP] closing a pending connection");
             // Graceful shutdown.
             hyper::server::conn::http1::Connection::graceful_shutdown(
                 Pin::new(&mut http_conn)
@@ -455,12 +454,12 @@ async fn serve_conn<S>(
             // Continue to poll this connection until shutdown can finish.
             let result = http_conn.await;
             if let Err(err) = result {
-                tracing::debug!("[VOLO] connection error: {:?}", err);
+                tracing::debug!("[Volo-HTTP] connection error: {:?}", err);
             }
         }
         result = &mut http_conn => {
             if let Err(err) = result {
-                tracing::debug!("[VOLO] connection error: {:?}", err);
+                tracing::debug!("[Volo-HTTP] connection error: {:?}", err);
             }
         },
     }

--- a/volo-http/src/server/utils/serve_dir.rs
+++ b/volo-http/src/server/utils/serve_dir.rs
@@ -93,7 +93,7 @@ where
         let path = req.uri().path();
         let path = path.strip_prefix('/').unwrap_or(path);
 
-        tracing::trace!("ServeDir: path: {path}");
+        tracing::trace!("[Volo-HTTP] ServeDir: path: {path}");
 
         // Join to the serving directory and canonicalize it
         let path = self.path.join(path);
@@ -103,7 +103,7 @@ where
 
         // Reject file which is out of the serving directory
         if path.strip_prefix(self.path.as_path()).is_err() {
-            tracing::debug!("ServeDir: illegal path: {}", path.display());
+            tracing::debug!("[Volo-HTTP] ServeDir: illegal path: {}", path.display());
             return Ok(StatusCode::FORBIDDEN.into_response());
         }
 


### PR DESCRIPTION
## Motivation

- logs from `volo-http` are confusing
- timeout cannot removed
- type of client with layers are complex

## Solution

- unified log format in `volo-http` with prefix `[Volo-HTTP]`
- adjusted the timeout interface, `Dutation` -> `Option<Duration>`
- add generic types for `DefaultClient`