### PR TITLE
chore(volo-http): do not put meta config in service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3680,7 +3680,7 @@ dependencies = [
 
 [[package]]
 name = "volo-http"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "ahash",
  "async-broadcast",

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-http"
-version = "0.2.12"
+version = "0.2.13"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-http/src/context/client.rs
+++ b/volo-http/src/context/client.rs
@@ -64,6 +64,8 @@ impl ClientStats {
 pub struct Config {
     /// Timeout of the whole request
     pub timeout: Option<Duration>,
+    /// Return `Err` if status code of response is 4XX or 5XX
+    pub fail_on_error_status: bool,
 }
 
 impl Reusable for Config {


### PR DESCRIPTION
## Motivation

Putting request related config in `MetaServiceConfig` will be difficult to maintain.

In addition, use `Option<Duration>` for timeout interfaces is unnecessary, but it will introduce many breaking changes.

## Solution

Move `timeout` and `fail_on_error_status` from `MetaServiceConfig` into context and when client creates a request, it will clone the config into context.

Revert changes for timeout related interfaces.