### PR TITLE
chore: bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3539,7 +3539,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "volo"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "async-broadcast",
  "dashmap",
@@ -3725,7 +3725,7 @@ version = "0.10.0"
 
 [[package]]
 name = "volo-thrift"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "ahash",
  "anyhow",

--- a/volo-thrift/Cargo.toml
+++ b/volo-thrift/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-thrift"
-version = "0.10.2"
+version = "0.10.3"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo/Cargo.toml
+++ b/volo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo"
-version = "0.10.1"
+version = "0.10.2"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true


### PR DESCRIPTION
mainly for these two features: https://github.com/cloudwego/volo/pull/443 https://github.com/cloudwego/volo/pull/482

