### PR TITLE
fix(volo-thrift): fix clippy lint `too_long_first_doc_paragraph`

### DIFF
--- a/volo-thrift/src/codec/default/mod.rs
+++ b/volo-thrift/src/codec/default/mod.rs
@@ -43,8 +43,9 @@ use crate::{context::ThriftContext, EntryMessage, ThriftMessage};
 pub mod framed;
 pub mod thrift;
 pub mod ttheader;
-// mod mesh_header;
 
+/// Trait for encoding a [`ThriftMessage`] in place.
+///
 /// [`ZeroCopyEncoder`] tries to encode a message without copying large data taking the advantage
 /// of [`LinkedBytes`], which can insert a [`Bytes`] into the middle of a [`bytes::BytesMut`] and
 /// uses writev.
@@ -74,6 +75,8 @@ pub trait ZeroCopyEncoder: Send + Sync + 'static {
     ) -> Result<(usize, usize), ThriftException>;
 }
 
+/// Trait for decoding a [`ThriftMessage`] in place.
+///
 /// [`ZeroCopyDecoder`] tries to decode a message without copying large data, so the [`Bytes`] in
 /// the `decode` method is not designed to be reused, and the implementation can use
 /// `Bytes::split_to` to get a [`Bytes`] and hand it to the user directly.

--- a/volo/src/discovery/mod.rs
+++ b/volo/src/discovery/mod.rs
@@ -63,6 +63,8 @@ pub struct Change<K> {
     pub removed: Vec<Arc<Instance>>,
 }
 
+/// Get the difference of two address lists.
+///
 /// [`diff_address`] provides a naive implementation that compares prev and next only by the
 /// address, and returns the [`Change`], which means that the `updated` is always empty when using
 /// this implementation.


### PR DESCRIPTION
## Motivation

https://rust-lang.github.io/rust-clippy/master/index.html#/too_long_first_doc_paragraph

```plain
$ cargo clippy -p volo-thrift --no-default-features -- --deny warnings
    Checking volo v0.10.2 (/root/volo/volo)
error: first doc comment paragraph is too long
  --> volo/src/discovery/mod.rs:66:1
   |
66 | / /// [`diff_address`] provides a naive implementation that compares prev and next only by the
67 | | /// address, and returns the [`Change`], which means that the `updated` is always empty when using
68 | | /// this implementation.
69 | | ///
70 | | /// The bool in the return value indicates whether there's diff between prev and next, which means
   | |_
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_long_first_doc_paragraph
   = note: `-D clippy::too-long-first-doc-paragraph` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::too_long_first_doc_paragraph)]`

error: could not compile `volo` (lib) due to 1 previous error


$ cargo clippy -p volo-thrift --no-default-features -- --deny warnings
    Checking volo-thrift v0.10.3 (/root/volo/volo-thrift)
error: first doc comment paragraph is too long
  --> volo-thrift/src/codec/default/mod.rs:48:1
   |
48 | / /// [`ZeroCopyEncoder`] tries to encode a message without copying large data taking the advantage
49 | | /// of [`LinkedBytes`], which can insert a [`Bytes`] into the middle of a [`bytes::BytesMut`] and
50 | | /// uses writev.
51 | | ///
52 | | /// The recommended length threshold to use `LinkedBytes::insert` is 4KB.
   | |_
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_long_first_doc_paragraph
   = note: `-D clippy::too-long-first-doc-paragraph` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::too_long_first_doc_paragraph)]`

error: first doc comment paragraph is too long
  --> volo-thrift/src/codec/default/mod.rs:77:1
   |
77 | / /// [`ZeroCopyDecoder`] tries to decode a message without copying large data, so the [`Bytes`] in
78 | | /// the `decode` method is not designed to be reused, and the implementation can use
79 | | /// `Bytes::split_to` to get a [`Bytes`] and hand it to the user directly.
   | |_
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_long_first_doc_paragraph

error: could not compile `volo-thrift` (lib) due to 2 previous errors
```

## Solution

Add short first doc paragraphs for those idents.