### PR TITLE
chore(volo-http): refactor `RequestPartsExt`

### DIFF
--- a/volo-http/src/context/mod.rs
+++ b/volo-http/src/context/mod.rs
@@ -10,4 +10,4 @@ pub use self::client::ClientContext;
 pub mod server;
 
 #[cfg(feature = "server")]
-pub use self::server::{RequestPartsExt, ServerContext};
+pub use self::server::ServerContext;

--- a/volo-http/src/context/server.rs
+++ b/volo-http/src/context/server.rs
@@ -1,11 +1,5 @@
 //! Context and its utilities of server
 
-use http::{
-    header,
-    header::{HeaderMap, HeaderValue},
-    request::Parts,
-    uri::{Authority, PathAndQuery, Scheme, Uri},
-};
 use volo::{
     context::{Context, Reusable, Role, RpcCx, RpcInfo},
     net::Address,
@@ -14,10 +8,7 @@ use volo::{
 
 use crate::{
     server::param::PathParamsVec,
-    utils::{
-        consts::{HTTPS_DEFAULT_PORT, HTTP_DEFAULT_PORT},
-        macros::{impl_deref_and_deref_mut, impl_getter},
-    },
+    utils::macros::{impl_deref_and_deref_mut, impl_getter},
 };
 
 /// RPC context of http server
@@ -47,12 +38,13 @@ newtype_impl_context!(ServerContext, Config, 0);
 pub struct ServerCxInner {
     /// Path params from [`Uri`]
     ///
-    /// See [`Router::route`][route] and [`PathParamsVec`], [`PathParamsMap`][PathParamsMap] or
-    /// [`PathParams`][PathParams] for more details.
+    /// See [`Router::route`] and [`PathParamsVec`], [`PathParamsMap`] or [`PathParams`] for more
+    /// details.
     ///
-    /// [route]: crate::server::route::Router::route
-    /// [PathParamsMap]: crate::server::param::PathParamsMap
-    /// [PathParams]: crate::server::param::PathParams
+    /// [`Uri`]: http::uri::Uri
+    /// [`Router::route`]: crate::server::route::Router::route
+    /// [`PathParamsMap`]: crate::server::param::PathParamsMap
+    /// [`PathParams`]: crate::server::param::PathParams
     pub params: PathParamsVec,
 }
 
@@ -64,167 +56,26 @@ impl ServerCxInner {
 ///
 /// It is empty currently
 #[derive(Clone, Debug, Default)]
-pub struct Config {}
+pub struct Config {
+    #[cfg(feature = "__tls")]
+    tls: bool,
+}
+
+impl Config {
+    /// Return if the request is using TLS.
+    #[cfg(feature = "__tls")]
+    pub fn is_tls(&self) -> bool {
+        self.tls
+    }
+
+    #[cfg(feature = "__tls")]
+    pub(crate) fn set_tls(&mut self, tls: bool) {
+        self.tls = tls;
+    }
+}
 
 impl Reusable for Config {
-    fn clear(&mut self) {}
-}
-
-/// Utilities of [`request::Parts`][request::Parts]
-///
-/// [request::Parts]: http::request::Parts
-pub trait RequestPartsExt {
-    /// Parse `Forwarded` in headers.
-    fn forwarded(&self) -> Forwarded;
-
-    /// Get the URI in HTTP header of original request.
-    ///
-    /// For most cases, the uri is a path (and query) starting with `/`.
-    fn request_uri(&self) -> Uri;
-
-    /// Get the full URI including scheme, host, port (if any), and path.
-    fn full_uri(&self) -> Option<Uri>;
-
-    /// Get the scheme of the request URI.
-    ///
-    /// In fact, if the TLS is enabled, the scheme is always `https`, otherwise `http`.
-    fn scheme(&self) -> Scheme;
-
-    /// Get host name of the request URI from header `Host`.
-    fn host(&self) -> Option<&str>;
-
-    /// Get port of the request URI.
-    ///
-    /// If the port does not exist in host, it will be inferred from the scheme.
-    fn port(&self) -> Option<u16>;
-}
-
-impl RequestPartsExt for Parts {
-    fn forwarded(&self) -> Forwarded {
-        Forwarded::from_header(&self.headers)
+    fn clear(&mut self) {
+        *self = Default::default();
     }
-
-    fn request_uri(&self) -> Uri {
-        self.uri.clone()
-    }
-
-    fn full_uri(&self) -> Option<Uri> {
-        let scheme = self.scheme();
-        let authority = self.host()?;
-        Uri::builder()
-            .scheme(scheme)
-            .authority(authority)
-            .path_and_query(
-                self.uri
-                    .path_and_query()
-                    .map(PathAndQuery::as_str)
-                    .unwrap_or("/"),
-            )
-            .build()
-            .ok()
-    }
-
-    fn scheme(&self) -> Scheme {
-        self.uri.scheme().unwrap_or(&Scheme::HTTP).to_owned()
-    }
-
-    fn host(&self) -> Option<&str> {
-        match self.headers.get(header::HOST).map(HeaderValue::to_str) {
-            Some(Ok(host)) => Some(host),
-            _ => None,
-        }
-    }
-
-    fn port(&self) -> Option<u16> {
-        if let Some(port) = self.uri.authority().and_then(Authority::port_u16) {
-            return Some(port);
-        }
-        let scheme = self.scheme();
-        if scheme == Scheme::HTTP {
-            Some(HTTP_DEFAULT_PORT)
-        } else if scheme == Scheme::HTTPS {
-            Some(HTTPS_DEFAULT_PORT)
-        } else {
-            None
-        }
-    }
-}
-
-/// Parsed `Forwarded` from HTTP headers
-#[derive(Clone, Debug)]
-pub struct Forwarded<'a> {
-    /// `by` field from `Forwarded`
-    pub by: Option<&'a str>,
-    /// `for` field from `Forwarded`
-    pub r#for: Vec<&'a str>,
-    /// `host` field from `Forwarded`
-    pub host: Option<&'a str>,
-    /// `proto` field from `Forwarded`
-    pub proto: Option<&'a str>,
-}
-
-impl<'a> Forwarded<'a> {
-    fn from_header(headers: &'a HeaderMap) -> Self {
-        let mut forwarded = Forwarded {
-            by: None,
-            r#for: Vec::new(),
-            host: None,
-            proto: None,
-        };
-
-        for (name, val) in headers
-            .get_all(&header::FORWARDED)
-            .into_iter()
-            .filter_map(|hdr| hdr.to_str().ok())
-            // "for=1.2.3.4, for=5.6.7.8; proto=https"
-            .flat_map(|val| val.split(';'))
-            // ["for=1.2.3.4, for=5.6.7.8", " proto=https"]
-            .flat_map(|vals| vals.split(','))
-            // ["for=1.2.3.4", " for=5.6.7.8", " proto=https"]
-            .flat_map(|pair| {
-                let mut items = pair.trim().splitn(2, '=');
-                Some((items.next()?, items.next()?))
-            })
-        {
-            // [(name , val      ), ...                                    ]
-            // [("for", "1.2.3.4"), ("for", "5.6.7.8"), ("proto", "https")]
-
-            // taking the first value for each property is correct because spec states that first
-            // "for" value is client and rest are proxies; multiple values other properties have
-            // no defined semantics
-            //
-            // > In a chain of proxy servers where this is fully utilized, the first
-            // > "for" parameter will disclose the client where the request was first
-            // > made, followed by any subsequent proxy identifiers.
-            // --- https://datatracker.ietf.org/doc/html/rfc7239#section-5.2
-
-            match name.trim().to_lowercase().as_str() {
-                "by" => {
-                    if forwarded.by.is_none() {
-                        forwarded.by = Some(unquote(val));
-                    }
-                }
-                "for" => {
-                    forwarded.r#for.push(unquote(val));
-                }
-                "host" => {
-                    if forwarded.host.is_none() {
-                        forwarded.host = Some(unquote(val));
-                    }
-                }
-                "proto" => {
-                    if forwarded.proto.is_none() {
-                        forwarded.proto = Some(unquote(val));
-                    }
-                }
-                _ => continue,
-            };
-        }
-
-        forwarded
-    }
-}
-
-fn unquote(val: &str) -> &str {
-    val.trim().trim_start_matches('"').trim_end_matches('"')
 }

--- a/volo-http/src/lib.rs
+++ b/volo-http/src/lib.rs
@@ -14,7 +14,6 @@ pub mod request;
 pub mod response;
 #[cfg(feature = "server")]
 pub mod server;
-
 pub mod utils;
 
 #[doc(hidden)]

--- a/volo-http/src/request.rs
+++ b/volo-http/src/request.rs
@@ -1,15 +1,58 @@
-//! Request types for client and server.
+//! Request types and utils.
 
-use hyper::body::Incoming;
+use http::{
+    header::{self, HeaderMap, HeaderName},
+    request::{Parts, Request},
+};
 
-use crate::body::Body;
-
-/// [`Request`][Request] with [`Body`] as default body
+/// [`Request`] with [`Body`] as default body.
 ///
-/// [Request]: http::Request
-pub type ClientRequest<B = Body> = http::Request<B>;
+/// [`Body`]: crate::body::Body
+#[cfg(feature = "client")]
+pub type ClientRequest<B = crate::body::Body> = Request<B>;
 
-/// [`Request`][Request] with [`Incoming`] as default body
+/// [`Request`] with [`Incoming`] as default body.
 ///
-/// [Request]: http::Request
-pub type ServerRequest<B = Incoming> = http::Request<B>;
+/// [`Incoming`]: hyper::body::Incoming
+#[cfg(feature = "server")]
+pub type ServerRequest<B = hyper::body::Incoming> = Request<B>;
+
+/// HTTP header [`X-Forwarded-For`][mdn].
+///
+/// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
+pub const X_FORWARDED_FOR: HeaderName = HeaderName::from_static("x-forwarded-for");
+
+/// HTTP header `X-Real-IP`.
+pub const X_REAL_IP: HeaderName = HeaderName::from_static("x-real-ip");
+
+/// Utilities of [`http::request::Parts`] and [`http::Request`].
+pub trait RequestPartsExt: sealed::SealedRequestPartsExt {
+    /// Get host name of the request URI from header `Host`.
+    fn host(&self) -> Option<&str>;
+}
+
+mod sealed {
+    pub trait SealedRequestPartsExt {
+        fn headers(&self) -> &http::header::HeaderMap;
+    }
+}
+
+impl sealed::SealedRequestPartsExt for Parts {
+    fn headers(&self) -> &HeaderMap {
+        &self.headers
+    }
+}
+impl<B> sealed::SealedRequestPartsExt for Request<B> {
+    fn headers(&self) -> &HeaderMap {
+        self.headers()
+    }
+}
+
+impl<T> RequestPartsExt for T
+where
+    T: sealed::SealedRequestPartsExt,
+{
+    fn host(&self) -> Option<&str> {
+        simdutf8::basic::from_utf8(self.headers().get(header::HOST)?.as_bytes()).ok()
+    }
+}

--- a/volo-http/src/server/mod.rs
+++ b/volo-http/src/server/mod.rs
@@ -121,6 +121,7 @@ impl<S, L> Server<S, L> {
     #[cfg_attr(docsrs, doc(cfg(any(feature = "rustls", feature = "native-tls"))))]
     pub fn tls_config(mut self, config: impl Into<ServerTlsConfig>) -> Self {
         self.tls_config = Some(config.into());
+        self.config.set_tls(true);
         self
     }
 


### PR DESCRIPTION
## Motivation

The previous implementation of `RequestPartsExt` was inelegant and somewhat inaccurate.

## Solution

Remove most functions in `RequestPartsExt`, implement it for both `http::request::Parts` and `http::request::Request`, move it from `volo_http::context::server` to `volo_http::request`.

In addition, we added two `HeaderName` (`X-Forwarded-For` and `X-Real-IP`) for future use.