### PR TITLE
fix(volo-cli): use the raw given path of local idl file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3621,7 +3621,7 @@ dependencies = [
 
 [[package]]
 name = "volo-cli"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/volo-cli/Cargo.toml
+++ b/volo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-cli"
-version = "0.10.3"
+version = "0.10.4"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-cli/src/idl/add.rs
+++ b/volo-cli/src/idl/add.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, path::PathBuf};
 use clap::{value_parser, Parser};
 use volo_build::{
     model::{Entry, GitSource, Idl, Service, Source},
-    util::{check_and_get_repo_name, create_git_service, detect_protocol, strip_slash_prefix},
+    util::{check_and_get_repo_name, create_git_service, detect_protocol},
 };
 
 use crate::{command::CliCommand, context::Context};
@@ -67,7 +67,7 @@ impl CliCommand for Add {
             let local_service = if self.repo.is_none() && self.git.is_none() {
                 let local_idl = Idl {
                     source: Source::Local,
-                    path: strip_slash_prefix(self.idl.as_path()),
+                    path: self.idl.clone(),
                     includes: self.includes.clone(),
                 };
                 // only ensure readable when idl is from local


### PR DESCRIPTION
## Motivation
The process of local idl path is incorrect, which will break the absolute path.

## Solution
Use the origin input path. 
