### PR TITLE
chore(volo-http): wrap `hyper::body::Incoming` by `Body`

### DIFF
--- a/volo-http/src/client/transport.rs
+++ b/volo-http/src/client/transport.rs
@@ -1,6 +1,5 @@
 use std::error::Error;
 
-use http_body::Body;
 use hyper::client::conn::http1;
 use hyper_util::rt::TokioIo;
 use motore::{make::MakeConnection, service::Service};
@@ -116,7 +115,7 @@ impl ClientTransport {
         req: ClientRequest<B>,
     ) -> Result<ClientResponse, ClientError>
     where
-        B: Body + Send + 'static,
+        B: http_body::Body + Send + 'static,
         B::Data: Send,
         B::Error: Into<Box<dyn Error + Send + Sync>> + 'static,
     {
@@ -132,13 +131,13 @@ impl ClientTransport {
             tracing::error!("[Volo-HTTP] failed to send request, error: {err}");
             request_error(err)
         })?;
-        Ok(resp)
+        Ok(resp.map(crate::body::Body::from_incoming))
     }
 }
 
 impl<B> Service<ClientContext, ClientRequest<B>> for ClientTransport
 where
-    B: Body + Send + 'static,
+    B: http_body::Body + Send + 'static,
     B::Data: Send,
     B::Error: Into<Box<dyn Error + Send + Sync>> + 'static,
 {

--- a/volo-http/src/request.rs
+++ b/volo-http/src/request.rs
@@ -15,7 +15,7 @@ pub type ClientRequest<B = crate::body::Body> = Request<B>;
 ///
 /// [`Incoming`]: hyper::body::Incoming
 #[cfg(feature = "server")]
-pub type ServerRequest<B = hyper::body::Incoming> = Request<B>;
+pub type ServerRequest<B = crate::body::Body> = Request<B>;
 
 /// HTTP header [`X-Forwarded-For`][mdn].
 ///

--- a/volo-http/src/response.rs
+++ b/volo-http/src/response.rs
@@ -1,15 +1,15 @@
 //! Response types for client and server.
 
-use hyper::body::Incoming;
-
-use crate::body::Body;
-
-/// [`Response`][Response] with [`Body`] as default body
+/// [`Response`] with [`Body`] as default body
 ///
-/// [Response]: http::Response
-pub type ServerResponse<B = Body> = http::Response<B>;
+/// [`Response`]: http::response::Response
+/// [`Body`]: crate::body::Body
+#[cfg(feature = "server")]
+pub type ServerResponse<B = crate::body::Body> = http::response::Response<B>;
 
-/// [`Response`][Response] with [`Incoming`] as default body
+/// [`Response`] with [`Body`] as default body
 ///
-/// [Response]: http::Response
-pub type ClientResponse<B = Incoming> = http::Response<B>;
+/// [`Response`]: http::response::Response
+/// [`Body`]: crate::body::Body
+#[cfg(feature = "client")]
+pub type ClientResponse<B = crate::body::Body> = http::response::Response<B>;

--- a/volo-http/src/server/middleware.rs
+++ b/volo-http/src/server/middleware.rs
@@ -2,7 +2,6 @@
 
 use std::{convert::Infallible, marker::PhantomData, sync::Arc};
 
-use hyper::body::Incoming;
 use motore::{layer::Layer, service::Service};
 
 use super::{
@@ -10,7 +9,7 @@ use super::{
     route::Route,
     IntoResponse,
 };
-use crate::{context::ServerContext, request::ServerRequest, response::ServerResponse};
+use crate::{body::Body, context::ServerContext, request::ServerRequest, response::ServerResponse};
 
 /// A [`Layer`] from an async function
 ///
@@ -239,7 +238,7 @@ where
 /// response.
 ///
 /// See [`from_fn`] for more details.
-pub struct Next<B = Incoming, E = Infallible> {
+pub struct Next<B = Body, E = Infallible> {
     service: Route<B, E>,
 }
 

--- a/volo-http/src/server/route/method_router.rs
+++ b/volo-http/src/server/route/method_router.rs
@@ -16,12 +16,12 @@
 use std::convert::Infallible;
 
 use http::{method::Method, status::StatusCode};
-use hyper::body::Incoming;
 use motore::{layer::Layer, service::Service, ServiceExt};
 use paste::paste;
 
 use super::{Fallback, Route};
 use crate::{
+    body::Body,
     context::ServerContext,
     request::ServerRequest,
     response::ServerResponse,
@@ -65,7 +65,7 @@ use crate::{
 /// let app: Router = Router::new().route("/", get(index));
 /// let app: Router = Router::new().route("/", get(index).post(index).head(index));
 /// ```
-pub struct MethodRouter<B = Incoming, E = Infallible> {
+pub struct MethodRouter<B = Body, E = Infallible> {
     options: MethodEndpoint<B, E>,
     get: MethodEndpoint<B, E>,
     post: MethodEndpoint<B, E>,
@@ -344,7 +344,7 @@ where
 }
 
 #[derive(Default)]
-enum MethodEndpoint<B = Incoming, E = Infallible> {
+enum MethodEndpoint<B = Body, E = Infallible> {
     #[default]
     None,
     Route(Route<B, E>),

--- a/volo-http/src/server/route/mod.rs
+++ b/volo-http/src/server/route/mod.rs
@@ -11,11 +11,10 @@
 use std::{convert::Infallible, future::Future, marker::PhantomData};
 
 use http::status::StatusCode;
-use hyper::body::Incoming;
 use motore::{layer::Layer, service::Service, ServiceExt};
 
 use super::{handler::Handler, IntoResponse};
-use crate::{context::ServerContext, request::ServerRequest, response::ServerResponse};
+use crate::{body::Body, context::ServerContext, request::ServerRequest, response::ServerResponse};
 
 pub mod method_router;
 pub mod router;
@@ -24,7 +23,7 @@ mod utils;
 pub use self::{method_router::*, router::Router};
 
 /// The route service used for [`Router`].
-pub struct Route<B = Incoming, E = Infallible> {
+pub struct Route<B = Body, E = Infallible> {
     inner: motore::service::BoxService<ServerContext, ServerRequest<B>, ServerResponse, E>,
 }
 
@@ -57,7 +56,7 @@ impl<B, E> Service<ServerContext, ServerRequest<B>> for Route<B, E> {
     }
 }
 
-enum Fallback<B = Incoming, E = Infallible> {
+enum Fallback<B = Body, E = Infallible> {
     Route(Route<B, E>),
 }
 

--- a/volo-http/src/server/route/router.rs
+++ b/volo-http/src/server/route/router.rs
@@ -10,7 +10,6 @@
 use std::{collections::HashMap, convert::Infallible};
 
 use http::status::StatusCode;
-use hyper::body::Incoming;
 use motore::{layer::Layer, service::Service, ServiceExt};
 
 use super::{
@@ -19,6 +18,7 @@ use super::{
     Fallback, Route,
 };
 use crate::{
+    body::Body,
     context::ServerContext,
     request::ServerRequest,
     response::ServerResponse,
@@ -27,7 +27,7 @@ use crate::{
 
 /// The router for routing path to [`Service`]s or handlers.
 #[must_use]
-pub struct Router<B = Incoming, E = Infallible> {
+pub struct Router<B = Body, E = Infallible> {
     matcher: Matcher,
     routes: HashMap<RouteId, Endpoint<B, E>>,
     fallback: Fallback<B, E>,
@@ -428,7 +428,7 @@ where
     }
 }
 
-enum Endpoint<B = Incoming, E = Infallible> {
+enum Endpoint<B = Body, E = Infallible> {
     MethodRouter(MethodRouter<B, E>),
     Service(Route<B, E>),
 }


### PR DESCRIPTION
In order to unify the body type within Volo-HTTP, this commit wraps `hyper::body::Incoming` by `Body`, so that both client and server can use `http::Request` and `http::Response` with `Body`.

In addition, with this commmit, client and server inside Volo-HTTP can communicate by function call without any connection, which is useful for testing.

Althrough `hyper::body::Incoming` implements `http_body::Body`, use `enum` rather than `BoxBody` can avoid overhead of memory allocating by `Box` and dynamic dispatch of `dyn http_body::Body`.

BREAK CHANGE:

- `ServerRequest` has been changed from `http::Request<hyper::body::Incoming>` to `http::Request<Body>`
- `ClientResponse` has been changed from `http::Response<hyper::body::Incoming>` to `http::Response<Body>`

These are imperceptible to most users.