### PR TITLE
chore: fix new clippy rule `empty_line_after_doc_comments`

### DIFF
--- a/volo-grpc/src/status.rs
+++ b/volo-grpc/src/status.rs
@@ -169,7 +169,6 @@ impl Status {
     }
 
     /// Create a new [`Status`] with the associated code and message.
-
     pub fn new(code: Code, message: impl Into<String>) -> Self {
         Self {
             code,

--- a/volo-thrift/src/codec/default/thrift.rs
+++ b/volo-thrift/src/codec/default/thrift.rs
@@ -26,15 +26,15 @@ impl MakeThriftCodec {
         }
     }
 
-    /// Whether to use thrift multiplex protocol.
-    ///
-    /// When the multiplexed protocol is used, the name contains the service name,
-    /// a colon : and the method name. The multiplexed protocol is not compatible
-    /// with other protocols.
-    ///
-    /// Spec: <https://github.com/apache/thrift/blob/master/doc/specs/thrift-rpc.md>
-    ///
-    /// This is unimplemented yet.
+    // /// Whether to use thrift multiplex protocol.
+    // ///
+    // /// When the multiplexed protocol is used, the name contains the service name,
+    // /// a colon : and the method name. The multiplexed protocol is not compatible
+    // /// with other protocols.
+    // ///
+    // /// Spec: <https://github.com/apache/thrift/blob/master/doc/specs/thrift-rpc.md>
+    // ///
+    // /// This is unimplemented yet.
     // pub fn with_multiplex(mut self, multiplex: bool) -> Self {
     //     self.multiplex = multiplex;
     //     self


### PR DESCRIPTION
```
error: empty line after doc comment
  --> volo-thrift/src/codec/default/thrift.rs:37:5
   |
37 | /     /// This is unimplemented yet.
38 | |     // pub fn with_multiplex(mut self, multiplex: bool) -> Self {
39 | |     //     self.multiplex = multiplex;
40 | |     //     self
41 | |     // }
42 | |
   | |_
...
45 |       pub fn with_protocol(mut self, protocol: Protocol) -> Self {
   |       ---------------------------------------------------------- the comment documents this method
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#empty_line_after_doc_comments
   = note: `-D clippy::empty-line-after-doc-comments` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::empty_line_after_doc_comments)]`
   = help: if the empty line is unintentional remove it
help: if the doc comment should not document `with_protocol` comment it out
   |
29 ~     // /// Whether to use thrift multiplex protocol.
30 ~     // ///
31 ~     // /// When the multiplexed protocol is used, the name contains the service name,
32 ~     // /// a colon : and the method name. The multiplexed protocol is not compatible
33 ~     // /// with other protocols.
34 ~     // ///
35 ~     // /// Spec: <https://github.com/apache/thrift/blob/master/doc/specs/thrift-rpc.md>
36 ~     // ///
37 ~     // /// This is unimplemented yet.
   |

error: could not compile `volo-thrift` (lib) due to 1 previous error
```