### PR TITLE
chore(volo-http): add mock transport service for client

### DIFF
--- a/scripts/clippy-and-test.sh
+++ b/scripts/clippy-and-test.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o pipefail
 
 echo_command() {
-	echo "Run \`$@\`"
+	echo "Running $@"
 
 	if [ "${GITHUB_ACTIONS:-}" = "true" ] || [ -n "${DEBUG:-}" ]; then
 		# If we are in GitHub Actions or env `DEBUG` is non-empty,

--- a/scripts/selftest.sh
+++ b/scripts/selftest.sh
@@ -5,12 +5,15 @@ set -o nounset
 set -o pipefail
 
 echo_and_run() {
-	echo "Running \`$@\`..."
-	"$@"
-}
+	echo "Running $@"
 
-quiet() {
-	"$@" > /dev/null 2>&1
+	if [ -n "${DEBUG:-}" ]; then
+		# If env `DEBUG` is non-empty, output all
+		"$@"
+	else
+		# Disable outputs
+		"$@" > /dev/null 2>&1
+	fi
 }
 
 fmt_check() {

--- a/volo-http/src/client/mod.rs
+++ b/volo-http/src/client/mod.rs
@@ -53,6 +53,8 @@ pub mod loadbalance;
 mod meta;
 mod request_builder;
 pub mod target;
+#[cfg(test)]
+pub mod test_helpers;
 mod transport;
 
 pub use self::{request_builder::RequestBuilder, target::Target};
@@ -939,7 +941,6 @@ where
 #[cfg(feature = "json")]
 #[cfg(test)]
 mod client_tests {
-    #![allow(unused)]
 
     use std::{collections::HashMap, future::Future};
 
@@ -954,9 +955,7 @@ mod client_tests {
         get, Client, DefaultClient, Target,
     };
     use crate::{
-        body::BodyConversion,
-        error::client::status_error,
-        utils::consts::{HTTPS_DEFAULT_PORT, HTTP_DEFAULT_PORT},
+        body::BodyConversion, error::client::status_error, utils::consts::HTTP_DEFAULT_PORT,
         ClientBuilder,
     };
 
@@ -964,15 +963,18 @@ mod client_tests {
     struct HttpBinResponse {
         args: HashMap<String, String>,
         headers: HashMap<String, String>,
+        #[allow(unused)]
         origin: String,
         url: String,
     }
 
     const HTTPBIN_GET: &str = "http://httpbin.org/get";
+    #[cfg(feature = "__tls")]
     const HTTPBIN_GET_HTTPS: &str = "https://httpbin.org/get";
     const USER_AGENT_KEY: &str = "User-Agent";
     const USER_AGENT_VAL: &str = "volo-http-unit-test";
 
+    #[allow(unused)]
     fn client_types_check() {
         struct TestLayer;
         struct TestService<S> {
@@ -1114,7 +1116,7 @@ mod client_tests {
     #[tokio::test]
     async fn client_builder_with_address_and_https() {
         let addr = DnsResolver::default()
-            .resolve("httpbin.org", HTTPS_DEFAULT_PORT)
+            .resolve("httpbin.org", crate::utils::consts::HTTPS_DEFAULT_PORT)
             .await
             .unwrap();
         let mut builder = Client::builder();

--- a/volo-http/src/client/test_helpers.rs
+++ b/volo-http/src/client/test_helpers.rs
@@ -1,0 +1,251 @@
+use std::sync::Arc;
+
+use faststr::FastStr;
+use http::{header, header::HeaderValue, status::StatusCode};
+use motore::{
+    layer::{Identity, Layer},
+    service::{BoxService, Service},
+};
+use volo::{client::MkClient, context::Endpoint};
+
+use super::{
+    callopt::CallOpt, meta::MetaService, Client, ClientBuilder, ClientInner, Target,
+    PKG_NAME_WITH_VER,
+};
+use crate::{
+    context::client::{ClientContext, Config},
+    error::ClientError,
+    request::ClientRequest,
+    response::ClientResponse,
+    utils::test_helpers::mock_address,
+};
+
+/// Default mock service of [`Client`]
+pub type ClientMockService = MetaService<MockTransport>;
+/// Default [`Client`] without any extra [`Layer`]s
+pub type DefaultMockClient<IL = Identity, OL = Identity> =
+    Client<<OL as Layer<<IL as Layer<ClientMockService>>::Service>>::Service>;
+
+/// Mock transport [`Service`] without any network connection.
+pub enum MockTransport {
+    /// Always return a default [`ClientResponse`] with given [`StatusCode`], `HTTP/1.1` and
+    /// nothing in headers and body.
+    Status(StatusCode),
+    /// A [`Service`] for processing the request.
+    Service(BoxService<ClientContext, ClientRequest, ClientResponse, ClientError>),
+}
+
+impl Default for MockTransport {
+    fn default() -> Self {
+        Self::Status(StatusCode::OK)
+    }
+}
+
+impl MockTransport {
+    /// Create a default [`MockTransport`] that always responds with an empty response.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a [`MockTransport`] that always return a default [`ClientResponse`] with given
+    /// [`StatusCode`], `HTTP/1.1` and nothing in headers and body.
+    pub fn status_code(status: StatusCode) -> Self {
+        Self::Status(status)
+    }
+
+    /// Create a [`MockTransport`] from a [`Service`] with [`ClientContext`] and [`ClientRequest`].
+    pub fn service<S>(service: S) -> Self
+    where
+        S: Service<ClientContext, ClientRequest, Response = ClientResponse, Error = ClientError>
+            + Send
+            + Sync
+            + 'static,
+    {
+        Self::Service(BoxService::new(service))
+    }
+
+    /// Create a [`MockTransport`] from a [`Service`] with [`ServerContext`] and [`ServerRequest`].
+    ///
+    /// Note that all of [`Router`], [`MethodRouter`] and [`Route`] are server [`Service`], they
+    /// can be used here.
+    ///
+    /// [`ServerContext`]: crate::context::ServerContext
+    /// [`ServerRequest`]: crate::request::ServerRequest
+    /// [`Router`]: crate::server::route::Router
+    /// [`MethodRouter`]: crate::server::route::MethodRouter
+    /// [`Route`]: crate::server::route::Route
+    #[cfg(feature = "server")]
+    pub fn server_service<S>(service: S) -> Self
+    where
+        S: Service<
+                crate::context::ServerContext,
+                crate::request::ServerRequest,
+                Response = crate::response::ServerResponse,
+            > + Send
+            + Sync
+            + 'static,
+        S::Error: Into<crate::error::BoxError>,
+    {
+        Self::Service(BoxService::new(
+            crate::utils::test_helpers::ConvertService::new(service),
+        ))
+    }
+}
+
+impl Service<ClientContext, ClientRequest> for MockTransport {
+    type Response = ClientResponse;
+    type Error = ClientError;
+
+    async fn call(
+        &self,
+        cx: &mut ClientContext,
+        req: ClientRequest,
+    ) -> Result<Self::Response, Self::Error> {
+        match self {
+            Self::Status(status) => {
+                let mut resp = ClientResponse::default();
+                status.clone_into(resp.status_mut());
+                Ok(resp)
+            }
+            Self::Service(srv) => srv.call(cx, req).await,
+        }
+    }
+}
+
+impl<IL, OL, C, LB> ClientBuilder<IL, OL, C, LB> {
+    /// Build a mock HTTP client with a [`MockTransport`] service.
+    pub fn mock(mut self, transport: MockTransport) -> C::Target
+    where
+        IL: Layer<MetaService<MockTransport>>,
+        IL::Service: Send + Sync + 'static,
+        // remove loadbalance here
+        OL: Layer<IL::Service>,
+        OL::Service: Send + Sync + 'static,
+        C: MkClient<Client<OL::Service>>,
+    {
+        let meta_service = MetaService::new(transport);
+        let service = self.outer_layer.layer(self.inner_layer.layer(meta_service));
+
+        let caller_name = if self.caller_name.is_empty() {
+            FastStr::from_static_str(PKG_NAME_WITH_VER)
+        } else {
+            self.caller_name
+        };
+        if !caller_name.is_empty() && self.headers.get(header::USER_AGENT).is_none() {
+            self.headers.insert(
+                header::USER_AGENT,
+                HeaderValue::from_str(caller_name.as_str()).expect("Invalid caller name"),
+            );
+        }
+        let config = Config {
+            timeout: self.builder_config.timeout,
+            fail_on_error_status: self.builder_config.fail_on_error_status,
+        };
+
+        let client_inner = ClientInner {
+            caller_name,
+            callee_name: self.callee_name,
+            // set a default target so that we can create a request without authority
+            default_target: Target::from_address(mock_address()),
+            default_config: config,
+            default_call_opt: self.call_opt,
+            // do nothing
+            target_parser: parse_target,
+            headers: self.headers,
+        };
+        let client = Client {
+            service,
+            inner: Arc::new(client_inner),
+        };
+        self.mk_client.mk_client(client)
+    }
+}
+
+// do nothing
+fn parse_target(_: Target, _: Option<&CallOpt>, _: &mut Endpoint) {}
+
+#[allow(unused)]
+fn client_types_check() {
+    struct TestLayer;
+    struct TestService<S> {
+        inner: S,
+    }
+
+    impl<S> Layer<S> for TestLayer {
+        type Service = TestService<S>;
+
+        fn layer(self, inner: S) -> Self::Service {
+            TestService { inner }
+        }
+    }
+
+    impl<S, Cx, Req> Service<Cx, Req> for TestService<S>
+    where
+        S: Service<Cx, Req>,
+    {
+        type Response = S::Response;
+        type Error = S::Error;
+
+        fn call(
+            &self,
+            cx: &mut Cx,
+            req: Req,
+        ) -> impl std::future::Future<Output = Result<Self::Response, Self::Error>> + Send {
+            self.inner.call(cx, req)
+        }
+    }
+
+    let _: DefaultMockClient = ClientBuilder::new().mock(Default::default());
+    let _: DefaultMockClient<TestLayer> = ClientBuilder::new()
+        .layer_inner(TestLayer)
+        .mock(Default::default());
+    let _: DefaultMockClient<TestLayer> = ClientBuilder::new()
+        .layer_inner_front(TestLayer)
+        .mock(Default::default());
+    let _: DefaultMockClient<Identity, TestLayer> = ClientBuilder::new()
+        .layer_outer(TestLayer)
+        .mock(Default::default());
+    let _: DefaultMockClient<Identity, TestLayer> = ClientBuilder::new()
+        .layer_outer_front(TestLayer)
+        .mock(Default::default());
+    let _: DefaultMockClient<TestLayer, TestLayer> = ClientBuilder::new()
+        .layer_inner(TestLayer)
+        .layer_outer(TestLayer)
+        .mock(Default::default());
+}
+
+mod mock_transport_tests {
+    use http::status::StatusCode;
+
+    use super::MockTransport;
+    use crate::{body::BodyConversion, ClientBuilder};
+
+    #[tokio::test]
+    async fn empty_response_test() {
+        let client = ClientBuilder::new().mock(MockTransport::default());
+        let resp = client.get("/").unwrap().send().await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(resp.headers().is_empty());
+        assert!(resp.into_body().into_vec().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn status_response_test() {
+        {
+            let client =
+                ClientBuilder::new().mock(MockTransport::status_code(StatusCode::IM_A_TEAPOT));
+            let resp = client.get("/").unwrap().send().await.unwrap();
+            assert_eq!(resp.status(), StatusCode::IM_A_TEAPOT);
+            assert!(resp.headers().is_empty());
+            assert!(resp.into_body().into_vec().await.unwrap().is_empty());
+        }
+        {
+            let client = {
+                let mut builder = ClientBuilder::new();
+                builder.fail_on_error_status(true);
+                builder.mock(MockTransport::status_code(StatusCode::IM_A_TEAPOT))
+            };
+            assert!(client.get("/").unwrap().send().await.is_err());
+        }
+    }
+}

--- a/volo-http/src/context/server.rs
+++ b/volo-http/src/context/server.rs
@@ -20,9 +20,7 @@ impl ServerContext {
     pub fn new(peer: Address) -> Self {
         let mut cx = RpcCx::new(
             RpcInfo::<Config>::with_role(Role::Server),
-            ServerCxInner {
-                params: PathParamsVec::default(),
-            },
+            ServerCxInner::default(),
         );
         cx.rpc_info_mut().caller_mut().set_address(peer);
         Self(cx)
@@ -34,7 +32,7 @@ impl_deref_and_deref_mut!(ServerContext, RpcCx<ServerCxInner, Config>, 0);
 newtype_impl_context!(ServerContext, Config, 0);
 
 /// Inner details of [`ServerContext`]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ServerCxInner {
     /// Path params from [`Uri`]
     ///

--- a/volo-http/src/server/layer.rs
+++ b/volo-http/src/server/layer.rs
@@ -244,15 +244,16 @@ where
 #[cfg(test)]
 mod layer_tests {
     use http::{method::Method, status::StatusCode};
+    use motore::{layer::Layer, service::Service};
 
-    use super::*;
     use crate::{
         body::BodyConversion,
         context::ServerContext,
         server::{
             route::{any, get, Route},
-            test_helpers::*,
+            test_helpers::empty_cx,
         },
+        utils::test_helpers::simple_req,
     };
 
     #[tokio::test]

--- a/volo-http/src/server/middleware.rs
+++ b/volo-http/src/server/middleware.rs
@@ -376,8 +376,9 @@ mod middleware_tests {
         server::{
             response::IntoResponse,
             route::{any, get_service},
-            test_helpers::*,
+            test_helpers::empty_cx,
         },
+        utils::test_helpers::simple_req,
     };
 
     async fn print_body_handler(

--- a/volo-http/src/server/test_helpers.rs
+++ b/volo-http/src/server/test_helpers.rs
@@ -4,7 +4,6 @@ use std::{fmt::Debug, marker::PhantomData};
 
 use http::method::Method;
 use motore::{layer::Layer, service::Service};
-use volo::net::Address;
 
 use super::{
     handler::{Handler, HandlerService},
@@ -13,7 +12,7 @@ use super::{
 };
 use crate::{
     body::Body, context::ServerContext, request::ServerRequest, response::ServerResponse,
-    server::Server,
+    server::Server, utils::test_helpers::mock_address,
 };
 
 /// Wrap a [`Handler`] into a [`HandlerService`].
@@ -41,34 +40,11 @@ pub struct TestServer<S, B = Body> {
     _marker: PhantomData<fn(B)>,
 }
 
-/// Create a simple address, the address is `127.0.0.1:8080`.
-pub fn mock_address() -> Address {
-    use std::net;
-    Address::Ip(net::SocketAddr::new(
-        net::IpAddr::V4(net::Ipv4Addr::new(127, 0, 0, 1)),
-        8000,
-    ))
-}
-
 /// Create an empty [`ServerContext`].
 ///
 /// The context has only caller address.
 pub fn empty_cx() -> ServerContext {
     ServerContext::new(mock_address())
-}
-
-/// Create a simple [`ServerRequest`] with only [`Method`], [`Uri`] and [`Body`].
-///
-/// [`Uri`]: http::uri::Uri
-pub fn simple_req<S, B>(method: Method, uri: S, body: B) -> ServerRequest<B>
-where
-    S: AsRef<str>,
-{
-    ServerRequest::builder()
-        .method(method)
-        .uri(uri.as_ref())
-        .body(body)
-        .expect("Failed to build request")
 }
 
 impl<B, E> MethodRouter<B, E>

--- a/volo-http/src/utils/mod.rs
+++ b/volo-http/src/utils/mod.rs
@@ -7,5 +7,7 @@ mod extension;
 #[cfg(feature = "json")]
 pub(crate) mod json;
 pub(crate) mod macros;
+#[cfg(test)]
+pub mod test_helpers;
 
 pub use self::extension::Extension;

--- a/volo-http/src/utils/test_helpers.rs
+++ b/volo-http/src/utils/test_helpers.rs
@@ -1,0 +1,175 @@
+//! Generic test utilities.
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use http::{method::Method, request::Request};
+use volo::net::Address;
+
+#[cfg(all(feature = "client", feature = "server"))]
+pub use self::convert_service::{client_cx_to_server_cx, ConvertService};
+
+/// Create a simple address, the address is `127.0.0.1:8000`.
+pub fn mock_address() -> Address {
+    Address::Ip(SocketAddr::new(
+        IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+        8000,
+    ))
+}
+
+/// Create a simple [`Request`] with only [`Method`], [`Uri`] and [`Body`].
+///
+/// [`Uri`]: http::uri::Uri
+pub fn simple_req<S, B>(method: Method, uri: S, body: B) -> Request<B>
+where
+    S: AsRef<str>,
+{
+    Request::builder()
+        .method(method)
+        .uri(uri.as_ref())
+        .body(body)
+        .expect("Failed to build request")
+}
+
+#[cfg(all(feature = "client", feature = "server"))]
+mod convert_service {
+    use motore::service::Service;
+    use volo::context::{Context, Endpoint, Role, RpcCx, RpcInfo};
+
+    use super::mock_address;
+    use crate::{
+        context::{server::ServerCxInner, ClientContext, ServerContext},
+        error::{client::request_error, BoxError, ClientError},
+        request::{ClientRequest, ServerRequest},
+        response::{ClientResponse, ServerResponse},
+    };
+
+    /// A wrapper that can convert a [`Service`] with [`ServerContext`] and [`ServerRequest`] to
+    /// [`ClientContext`] and [`ClientRequest`].
+    pub struct ConvertService<S> {
+        inner: S,
+    }
+
+    impl<S> ConvertService<S> {
+        /// Create a [`ConvertService`] by a [`Service`] with [`ServerContext`] and
+        /// [`ServerRequest`].
+        pub fn new(inner: S) -> Self {
+            Self { inner }
+        }
+    }
+
+    impl<S> Service<ClientContext, ClientRequest> for ConvertService<S>
+    where
+        S: Service<ServerContext, ServerRequest, Response = ServerResponse> + Send + Sync,
+        S::Error: Into<BoxError>,
+    {
+        type Response = ClientResponse;
+        type Error = ClientError;
+
+        async fn call(
+            &self,
+            cx: &mut ClientContext,
+            req: ClientRequest,
+        ) -> Result<Self::Response, Self::Error> {
+            let mut server_cx = client_cx_to_server_cx(cx);
+            self.inner
+                .call(&mut server_cx, req)
+                .await
+                .map_err(request_error)
+        }
+    }
+
+    fn endpoint_clone(ep: &Endpoint) -> Endpoint {
+        Endpoint {
+            service_name: ep.service_name.clone(),
+            address: ep.address.clone(),
+            faststr_tags: Default::default(),
+            tags: Default::default(),
+        }
+    }
+
+    #[cfg(not(feature = "__tls"))]
+    fn new_server_config(_: &ClientContext) -> crate::context::server::Config {
+        crate::context::server::Config::default()
+    }
+
+    #[cfg(feature = "__tls")]
+    fn new_server_config(client_cx: &ClientContext) -> crate::context::server::Config {
+        let mut config = crate::context::server::Config::default();
+        if client_cx
+            .rpc_info()
+            .callee()
+            .contains::<crate::client::TlsTransport>()
+        {
+            config.set_tls(true);
+        }
+        config
+    }
+
+    /// Convert a [`ClientContext`] to [`ServerContext`] with copy [`Endpoint`]s and TLS status.
+    pub fn client_cx_to_server_cx(client_cx: &ClientContext) -> ServerContext {
+        let client_rpc_info = client_cx.rpc_info();
+        let mut server_rpc_info = RpcInfo::new(
+            Role::Server,
+            client_rpc_info.method().clone(),
+            endpoint_clone(client_rpc_info.caller()),
+            endpoint_clone(client_rpc_info.callee()),
+            new_server_config(client_cx),
+        );
+        if server_rpc_info.caller().address().is_none() {
+            server_rpc_info.caller_mut().set_address(mock_address());
+        }
+        let server_rpc_cx = RpcCx::new(server_rpc_info, ServerCxInner::default());
+        ServerContext(server_rpc_cx)
+    }
+}
+
+#[cfg(all(feature = "client", feature = "server"))]
+mod helper_tests {
+    use http::status::StatusCode;
+
+    use crate::{
+        body::BodyConversion,
+        client::{test_helpers::MockTransport, ClientBuilder},
+        server::route::{get, Router},
+    };
+
+    const HELLO_WORLD: &str = "Hello, World";
+
+    #[tokio::test]
+    async fn client_call_router() {
+        let router: Router = Router::new().route("/get", get(|| async { HELLO_WORLD }));
+        let client = ClientBuilder::new().mock(MockTransport::server_service(router));
+        {
+            let ret = client
+                .get("/get")
+                .unwrap()
+                .send()
+                .await
+                .unwrap()
+                .into_string()
+                .await
+                .unwrap();
+            assert_eq!(ret, HELLO_WORLD);
+        }
+        {
+            let ret = client
+                .get("http://127.0.0.1/get")
+                .unwrap()
+                .send()
+                .await
+                .unwrap()
+                .into_string()
+                .await
+                .unwrap();
+            assert_eq!(ret, HELLO_WORLD);
+        }
+        {
+            let resp = client.get("/").unwrap().send().await.unwrap();
+            assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        }
+        {
+            let resp = client.post("/get").unwrap().send().await.unwrap();
+            assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

Support full-link testing.

## Solution

This PR adds a mock transport service for client, which can replace the default transport and test functions without network. It can respond an empty response with a given status code or a client-side service.

In addition, the `MockTransport` also supports server-side service, e.g., `Router`, and an example has been also updated:

```rust
    #[tokio::test]
    async fn client_call_router() {
        let router: Router = Router::new().route("/get", get(|| async { HELLO_WORLD }));
        let client = ClientBuilder::new().mock(MockTransport::server_service(router));
        {
            let ret = client.get("/get").unwrap().send().await.unwrap().into_string().await.unwrap();
            assert_eq!(ret, HELLO_WORLD);
        }
        {
            let ret = client.get("http://127.0.0.1/get").unwrap().send().await.unwrap().into_string().await.unwrap();
            assert_eq!(ret, HELLO_WORLD);
        }
        {
            let resp = client.get("/").unwrap().send().await.unwrap();
            assert_eq!(resp.status(), StatusCode::NOT_FOUND);
        }
        {
            let resp = client.post("/get").unwrap().send().await.unwrap();
            assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
        }
    }
```