### PR TITLE
chore(volo-grpc): fix clippy rule needless_lifetimes

### DIFF
--- a/volo-grpc/src/metadata/key.rs
+++ b/volo-grpc/src/metadata/key.rs
@@ -204,7 +204,7 @@ impl<'a, VE: ValueEncoding> PartialEq<&'a MetadataKey<VE>> for MetadataKey<VE> {
     }
 }
 
-impl<'a, VE: ValueEncoding> PartialEq<MetadataKey<VE>> for &'a MetadataKey<VE> {
+impl<VE: ValueEncoding> PartialEq<MetadataKey<VE>> for &MetadataKey<VE> {
     #[inline]
     fn eq(&self, other: &MetadataKey<VE>) -> bool {
         *other == *self
@@ -260,7 +260,7 @@ impl<'a, VE: ValueEncoding> PartialEq<&'a str> for MetadataKey<VE> {
     }
 }
 
-impl<'a, VE: ValueEncoding> PartialEq<MetadataKey<VE>> for &'a str {
+impl<VE: ValueEncoding> PartialEq<MetadataKey<VE>> for &str {
     /// Performs a case-insensitive comparison of the string against the header
     /// name
     #[inline]

--- a/volo-grpc/src/metadata/map.rs
+++ b/volo-grpc/src/metadata/map.rs
@@ -1286,7 +1286,7 @@ impl<'a> Iterator for IterMut<'a> {
 
 // ===== impl ValueDrain =====
 
-impl<'a, VE: ValueEncoding> Iterator for ValueDrain<'a, VE> {
+impl<VE: ValueEncoding> Iterator for ValueDrain<'_, VE> {
     type Item = MetadataValue<VE>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -1320,7 +1320,7 @@ impl<'a> Iterator for Keys<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for Keys<'a> {}
+impl ExactSizeIterator for Keys<'_> {}
 
 // ===== impl Values ====
 
@@ -1979,7 +1979,7 @@ impl<'a, VE: ValueEncoding> GetAll<'a, VE> {
     }
 }
 
-impl<'a, VE: ValueEncoding> PartialEq for GetAll<'a, VE> {
+impl<VE: ValueEncoding> PartialEq for GetAll<'_, VE> {
     fn eq(&self, other: &Self) -> bool {
         self.inner.iter().eq(other.inner.iter())
     }
@@ -2059,7 +2059,7 @@ mod into_metadata_key {
 
     impl<VE: ValueEncoding> IntoMetadataKey<VE> for MetadataKey<VE> {}
 
-    impl<'a, VE: ValueEncoding> Sealed<VE> for &'a MetadataKey<VE> {
+    impl<VE: ValueEncoding> Sealed<VE> for &MetadataKey<VE> {
         #[inline]
         fn insert(
             self,
@@ -2076,7 +2076,7 @@ mod into_metadata_key {
         }
     }
 
-    impl<'a, VE: ValueEncoding> IntoMetadataKey<VE> for &'a MetadataKey<VE> {}
+    impl<VE: ValueEncoding> IntoMetadataKey<VE> for &MetadataKey<VE> {}
 
     impl<VE: ValueEncoding> Sealed<VE> for &'static str {
         #[inline]
@@ -2175,7 +2175,7 @@ mod as_metadata_key {
 
     impl<VE: ValueEncoding> AsMetadataKey<VE> for MetadataKey<VE> {}
 
-    impl<'a, VE: ValueEncoding> Sealed<VE> for &'a MetadataKey<VE> {
+    impl<VE: ValueEncoding> Sealed<VE> for &MetadataKey<VE> {
         #[inline]
         fn get(self, map: &MetadataMap) -> Option<&MetadataValue<VE>> {
             map.headers
@@ -2211,9 +2211,9 @@ mod as_metadata_key {
         }
     }
 
-    impl<'a, VE: ValueEncoding> AsMetadataKey<VE> for &'a MetadataKey<VE> {}
+    impl<VE: ValueEncoding> AsMetadataKey<VE> for &MetadataKey<VE> {}
 
-    impl<'a, VE: ValueEncoding> Sealed<VE> for &'a str {
+    impl<VE: ValueEncoding> Sealed<VE> for &str {
         #[inline]
         fn get(self, map: &MetadataMap) -> Option<&MetadataValue<VE>> {
             if !VE::is_valid_key(self) {
@@ -2268,7 +2268,7 @@ mod as_metadata_key {
         }
     }
 
-    impl<'a, VE: ValueEncoding> AsMetadataKey<VE> for &'a str {}
+    impl<VE: ValueEncoding> AsMetadataKey<VE> for &str {}
 
     impl<VE: ValueEncoding> Sealed<VE> for String {
         #[inline]
@@ -2326,7 +2326,7 @@ mod as_metadata_key {
 
     impl<VE: ValueEncoding> AsMetadataKey<VE> for String {}
 
-    impl<'a, VE: ValueEncoding> Sealed<VE> for &'a String {
+    impl<VE: ValueEncoding> Sealed<VE> for &String {
         #[inline]
         fn get(self, map: &MetadataMap) -> Option<&MetadataValue<VE>> {
             if !VE::is_valid_key(self) {
@@ -2380,7 +2380,7 @@ mod as_metadata_key {
         }
     }
 
-    impl<'a, VE: ValueEncoding> AsMetadataKey<VE> for &'a String {}
+    impl<VE: ValueEncoding> AsMetadataKey<VE> for &String {}
 }
 
 mod as_encoding_agnostic_metadata_key {
@@ -2415,23 +2415,23 @@ mod as_encoding_agnostic_metadata_key {
 
     impl<VE: ValueEncoding> AsEncodingAgnosticMetadataKey for MetadataKey<VE> {}
 
-    impl<'a, VE: ValueEncoding> Sealed for &'a MetadataKey<VE> {
+    impl<VE: ValueEncoding> Sealed for &MetadataKey<VE> {
         #[inline]
         fn contains_key(&self, map: &MetadataMap) -> bool {
             map.headers.contains_key(&self.inner)
         }
     }
 
-    impl<'a, VE: ValueEncoding> AsEncodingAgnosticMetadataKey for &'a MetadataKey<VE> {}
+    impl<VE: ValueEncoding> AsEncodingAgnosticMetadataKey for &MetadataKey<VE> {}
 
-    impl<'a> Sealed for &'a str {
+    impl Sealed for &str {
         #[inline]
         fn contains_key(&self, map: &MetadataMap) -> bool {
             map.headers.contains_key(*self)
         }
     }
 
-    impl<'a> AsEncodingAgnosticMetadataKey for &'a str {}
+    impl AsEncodingAgnosticMetadataKey for &str {}
 
     impl Sealed for String {
         #[inline]
@@ -2442,14 +2442,14 @@ mod as_encoding_agnostic_metadata_key {
 
     impl AsEncodingAgnosticMetadataKey for String {}
 
-    impl<'a> Sealed for &'a String {
+    impl Sealed for &String {
         #[inline]
         fn contains_key(&self, map: &MetadataMap) -> bool {
             map.headers.contains_key(self.as_str())
         }
     }
 
-    impl<'a> AsEncodingAgnosticMetadataKey for &'a String {}
+    impl AsEncodingAgnosticMetadataKey for &String {}
 }
 
 #[cfg(test)]

--- a/volo-grpc/src/metadata/value.rs
+++ b/volo-grpc/src/metadata/value.rs
@@ -678,14 +678,14 @@ impl<VE: ValueEncoding> PartialOrd<MetadataValue<VE>> for String {
     }
 }
 
-impl<'a, VE: ValueEncoding> PartialEq<MetadataValue<VE>> for &'a MetadataValue<VE> {
+impl<VE: ValueEncoding> PartialEq<MetadataValue<VE>> for &MetadataValue<VE> {
     #[inline]
     fn eq(&self, other: &MetadataValue<VE>) -> bool {
         **self == *other
     }
 }
 
-impl<'a, VE: ValueEncoding> PartialOrd<MetadataValue<VE>> for &'a MetadataValue<VE> {
+impl<VE: ValueEncoding> PartialOrd<MetadataValue<VE>> for &MetadataValue<VE> {
     #[inline]
     fn partial_cmp(&self, other: &MetadataValue<VE>) -> Option<cmp::Ordering> {
         (**self).partial_cmp(other)
@@ -712,14 +712,14 @@ where
     }
 }
 
-impl<'a, VE: ValueEncoding> PartialEq<MetadataValue<VE>> for &'a str {
+impl<VE: ValueEncoding> PartialEq<MetadataValue<VE>> for &str {
     #[inline]
     fn eq(&self, other: &MetadataValue<VE>) -> bool {
         *other == *self
     }
 }
 
-impl<'a, VE: ValueEncoding> PartialOrd<MetadataValue<VE>> for &'a str {
+impl<VE: ValueEncoding> PartialOrd<MetadataValue<VE>> for &str {
     #[inline]
     fn partial_cmp(&self, other: &MetadataValue<VE>) -> Option<cmp::Ordering> {
         self.as_bytes().partial_cmp(other.inner.as_bytes())


### PR DESCRIPTION
## Motivation

```
error: the following explicit lifetimes could be elided: 'a
   --> volo-grpc/src/metadata/key.rs:207:6
    |
207 | impl<'a, VE: ValueEncoding> PartialEq<MetadataKey<VE>> for &'a MetadataKey<VE> {
    |      ^^                                                     ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
    = note: `-D clippy::needless-lifetimes` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::needless_lifetimes)]`
help: elide the lifetimes
    |
207 - impl<'a, VE: ValueEncoding> PartialEq<MetadataKey<VE>> for &'a MetadataKey<VE> {
207 + impl<VE: ValueEncoding> PartialEq<MetadataKey<VE>> for &MetadataKey<VE> {
    |
```

## Solution

Fix them