### PR TITLE
chore(volo-http): use less `Result` in client

### DIFF
--- a/examples/src/http/example-http-client.rs
+++ b/examples/src/http/example-http-client.rs
@@ -55,7 +55,7 @@ async fn main() -> Result<(), BoxError> {
         client
             .request_builder()
             .host("httpbin.org")
-            .uri("/get")?
+            .uri("/get")
             .send()
             .await?
             .into_string()
@@ -65,7 +65,7 @@ async fn main() -> Result<(), BoxError> {
     println!(
         "{}",
         client
-            .get("http://127.0.0.1:8080/")?
+            .get("http://127.0.0.1:8080/")
             .send()
             .await?
             .into_string()
@@ -77,7 +77,7 @@ async fn main() -> Result<(), BoxError> {
         "{:?}",
         client
             .request_builder()
-            .uri("/user/json_get")?
+            .uri("/user/json_get")
             .send()
             .await?
             .into_json::<Person>()
@@ -86,12 +86,12 @@ async fn main() -> Result<(), BoxError> {
     println!(
         "{:?}",
         client
-            .post("/user/json_post")?
+            .post("/user/json_post")
             .json(&Person {
                 name: "Foo".to_string(),
                 age: 25,
                 phones: vec!["114514".to_string()],
-            })?
+            })
             .send()
             .await?
             .into_string()
@@ -103,7 +103,7 @@ async fn main() -> Result<(), BoxError> {
     println!(
         "{}",
         client
-            .get("http://127.0.0.1:8080/")?
+            .get("http://127.0.0.1:8080/")
             .send()
             .await?
             .into_string()
@@ -114,7 +114,7 @@ async fn main() -> Result<(), BoxError> {
     println!(
         "{:?}",
         client
-            .get("/")?
+            .get("/")
             .send()
             .await
             .expect_err("this request should fail"),

--- a/volo-http/src/client/request_builder.rs
+++ b/volo-http/src/client/request_builder.rs
@@ -25,96 +25,127 @@ use crate::{
 };
 
 /// The builder for building a request.
-pub struct RequestBuilder<'a, S, B = Body> {
-    client: &'a Client<S>,
+pub struct RequestBuilder<S, B = Body> {
+    client: Client<S>,
     target: Target,
     call_opt: Option<CallOpt>,
-    request: ClientRequest<B>,
+    request: Result<ClientRequest<B>>,
     timeout: Option<Duration>,
 }
 
-impl<'a, S> RequestBuilder<'a, S, Body> {
-    pub(crate) fn new(client: &'a Client<S>) -> Self {
+impl<S> RequestBuilder<S, Body> {
+    pub(crate) fn new(client: Client<S>) -> Self {
         Self {
             client,
             target: Default::default(),
             call_opt: Default::default(),
-            request: Default::default(),
+            request: Ok(ClientRequest::default()),
             timeout: None,
         }
     }
 
     /// Set the request body.
-    pub fn data<D>(mut self, data: D) -> Result<Self>
+    pub fn data<D>(mut self, data: D) -> Self
     where
         D: TryInto<Body>,
         D::Error: Error + Send + Sync + 'static,
     {
-        let (parts, _) = self.request.into_parts();
-        self.request = Request::from_parts(parts, data.try_into().map_err(builder_error)?);
+        if self.request.is_err() {
+            return self;
+        }
+        let Ok(req) = self.request else {
+            unreachable!();
+        };
 
-        Ok(self)
+        let body = match data.try_into() {
+            Ok(body) => body,
+            Err(err) => {
+                self.request = Err(builder_error(err));
+                return self;
+            }
+        };
+
+        let (parts, _) = req.into_parts();
+        self.request = Ok(Request::from_parts(parts, body));
+
+        self
     }
 
     /// Set the request body as json from object with [`Serialize`](serde::Serialize).
     #[cfg(feature = "json")]
-    pub fn json<T>(mut self, json: &T) -> Result<Self>
+    pub fn json<T>(mut self, json: &T) -> Self
     where
         T: serde::Serialize,
     {
-        let (mut parts, _) = self.request.into_parts();
+        if self.request.is_err() {
+            return self;
+        }
+        let Ok(req) = self.request else {
+            unreachable!();
+        };
+
+        let json = match crate::utils::json::serialize(json) {
+            Ok(json) => json,
+            Err(err) => {
+                self.request = Err(builder_error(err));
+                return self;
+            }
+        };
+
+        let (mut parts, _) = req.into_parts();
         parts.headers.insert(
             http::header::CONTENT_TYPE,
-            mime::APPLICATION_JSON
-                .essence_str()
-                .parse()
-                .expect("infallible"),
+            crate::utils::consts::APPLICATION_JSON,
         );
-        self.request = Request::from_parts(
-            parts,
-            crate::utils::json::serialize(json)
-                .map_err(builder_error)?
-                .into(),
-        );
+        self.request = Ok(Request::from_parts(parts, Body::from(json)));
 
-        Ok(self)
+        self
     }
 
     /// Set the request body as form from object with [`Serialize`](serde::Serialize).
     #[cfg(feature = "form")]
-    pub fn form<T>(mut self, form: &T) -> Result<Self>
+    pub fn form<T>(mut self, form: &T) -> Self
     where
         T: serde::Serialize,
     {
-        let (mut parts, _) = self.request.into_parts();
+        if self.request.is_err() {
+            return self;
+        }
+        let Ok(req) = self.request else {
+            unreachable!();
+        };
+
+        let form = match serde_urlencoded::to_string(form) {
+            Ok(form) => form,
+            Err(err) => {
+                self.request = Err(builder_error(err));
+                return self;
+            }
+        };
+
+        let (mut parts, _) = req.into_parts();
         parts.headers.insert(
             http::header::CONTENT_TYPE,
-            mime::APPLICATION_WWW_FORM_URLENCODED
-                .essence_str()
-                .parse()
-                .expect("infallible"),
+            crate::utils::consts::APPLICATION_WWW_FORM_URLENCODED,
         );
-        self.request = Request::from_parts(
-            parts,
-            serde_urlencoded::to_string(form)
-                .map_err(builder_error)?
-                .into(),
-        );
+        self.request = Ok(Request::from_parts(parts, Body::from(form)));
 
-        Ok(self)
+        self
     }
 }
 
-impl<'a, S, B> RequestBuilder<'a, S, B> {
+impl<S, B> RequestBuilder<S, B> {
     /// Set method for the request.
     pub fn method(mut self, method: Method) -> Self {
-        *self.request.method_mut() = method;
+        if let Ok(req) = self.request.as_mut() {
+            *req.method_mut() = method;
+        }
         self
     }
 
     /// Get a reference to method in the request.
-    pub fn method_ref(&self) -> &Method {
-        self.request.method()
+    pub fn method_ref(&self) -> Option<&Method> {
+        self.request.as_ref().ok().map(Request::method)
     }
 
     /// Set uri for building request.
@@ -125,23 +156,41 @@ impl<'a, S, B> RequestBuilder<'a, S, B> {
     ///
     /// Note that only path and query will be set to the request uri. For setting the full uri, use
     /// `full_uri` instead.
-    pub fn uri<U>(mut self, uri: U) -> Result<Self>
+    pub fn uri<U>(mut self, uri: U) -> Self
     where
         U: TryInto<Uri>,
         U::Error: Into<BoxError>,
     {
-        let uri = uri.try_into().map_err(builder_error)?;
+        if self.request.is_err() {
+            return self;
+        }
+        let uri = match uri.try_into() {
+            Ok(uri) => uri,
+            Err(err) => {
+                self.request = Err(builder_error(err));
+                return self;
+            }
+        };
+        if let Some(target) = Target::from_uri(&uri) {
+            match target {
+                Ok(target) => self.target = target,
+                Err(err) => {
+                    self.request = Err(err);
+                    return self;
+                }
+            }
+        }
         let rela_uri = uri
             .path_and_query()
             .map(PathAndQuery::to_owned)
             .unwrap_or_else(|| PathAndQuery::from_static("/"))
             .into();
-        if let Some(target) = Target::from_uri(&uri) {
-            let target = target?;
-            self.target = target;
-        }
-        *self.request.uri_mut() = rela_uri;
-        Ok(self)
+        let Ok(req) = self.request.as_mut() else {
+            unreachable!();
+        };
+        *req.uri_mut() = rela_uri;
+
+        self
     }
 
     /// Set full uri for building request.
@@ -150,18 +199,36 @@ impl<'a, S, B> RequestBuilder<'a, S, B> {
     /// will be set as the request uri.
     ///
     /// This function is only used for using http(s) proxy.
-    pub fn full_uri<U>(mut self, uri: U) -> Result<Self>
+    pub fn full_uri<U>(mut self, uri: U) -> Self
     where
         U: TryInto<Uri>,
         U::Error: Into<BoxError>,
     {
-        let uri = uri.try_into().map_err(builder_error)?;
-        if let Some(target) = Target::from_uri(&uri) {
-            let target = target?;
-            self.target = target;
+        if self.request.is_err() {
+            return self;
         }
-        *self.request.uri_mut() = uri;
-        Ok(self)
+        let uri = match uri.try_into() {
+            Ok(uri) => uri,
+            Err(err) => {
+                self.request = Err(builder_error(err));
+                return self;
+            }
+        };
+        if let Some(target) = Target::from_uri(&uri) {
+            match target {
+                Ok(target) => self.target = target,
+                Err(err) => {
+                    self.request = Err(err);
+                    return self;
+                }
+            }
+        }
+        let Ok(req) = self.request.as_mut() else {
+            unreachable!();
+        };
+        *req.uri_mut() = uri;
+
+        self
     }
 
     /// Set a [`CallOpt`] to the request.
@@ -176,59 +243,102 @@ impl<'a, S, B> RequestBuilder<'a, S, B> {
 
     /// Set query for the uri in request from object with [`Serialize`](serde::Serialize).
     #[cfg(feature = "query")]
-    pub fn set_query<T>(mut self, query: &T) -> Result<Self>
+    pub fn set_query<T>(mut self, query: &T) -> Self
     where
         T: serde::Serialize,
     {
-        let mut path = self.request.uri().path().to_owned();
+        if self.request.is_err() {
+            return self;
+        }
+        let query_str = match serde_urlencoded::to_string(query) {
+            Ok(query) => query,
+            Err(err) => {
+                self.request = Err(builder_error(err));
+                return self;
+            }
+        };
+        let Ok(req) = self.request.as_mut() else {
+            unreachable!();
+        };
+
+        // We should keep path only without query
+        let path_str = req.uri().path();
+        let mut path = String::with_capacity(path_str.len() + 1 + query_str.len());
+        path.push_str(path_str);
         path.push('?');
-        let query_str = serde_urlencoded::to_string(query).map_err(builder_error)?;
         path.push_str(&query_str);
+        let Ok(uri) = Uri::from_maybe_shared(path) else {
+            // path part is from a valid uri, and the result of urlencoded must be valid.
+            unreachable!();
+        };
 
-        *self.request.uri_mut() = Uri::from_maybe_shared(path).map_err(builder_error)?;
+        *req.uri_mut() = uri;
 
-        Ok(self)
+        self
     }
 
     /// Get a reference to uri in the request.
-    pub fn uri_ref(&self) -> &Uri {
-        self.request.uri()
+    pub fn uri_ref(&self) -> Option<&Uri> {
+        self.request.as_ref().ok().map(Request::uri)
     }
 
     /// Set version of the HTTP request.
     pub fn version(mut self, version: Version) -> Self {
-        *self.request.version_mut() = version;
+        if let Ok(req) = self.request.as_mut() {
+            *req.version_mut() = version;
+        }
         self
     }
 
     /// Get a reference to version in the request.
-    pub fn version_ref(&self) -> Version {
-        self.request.version()
+    pub fn version_ref(&self) -> Option<Version> {
+        self.request.as_ref().ok().map(Request::version)
     }
 
     /// Insert a header into the request header map.
-    pub fn header<K, V>(mut self, key: K, value: V) -> Result<Self>
+    pub fn header<K, V>(mut self, key: K, value: V) -> Self
     where
         K: TryInto<HeaderName>,
         K::Error: Into<http::Error>,
         V: TryInto<HeaderValue>,
         V::Error: Into<http::Error>,
     {
-        self.request.headers_mut().insert(
-            key.try_into().map_err(|e| builder_error(e.into()))?,
-            value.try_into().map_err(|e| builder_error(e.into()))?,
-        );
-        Ok(self)
+        if self.request.is_err() {
+            return self;
+        }
+
+        let key = match key.try_into() {
+            Ok(key) => key,
+            Err(err) => {
+                self.request = Err(builder_error(err.into()));
+                return self;
+            }
+        };
+        let value = match value.try_into() {
+            Ok(value) => value,
+            Err(err) => {
+                self.request = Err(builder_error(err.into()));
+                return self;
+            }
+        };
+
+        let Ok(req) = self.request.as_mut() else {
+            unreachable!();
+        };
+
+        req.headers_mut().insert(key, value);
+
+        self
     }
 
     /// Get a reference to headers in the request.
-    pub fn headers(&self) -> &HeaderMap {
-        self.request.headers()
+    pub fn headers(&self) -> Option<&HeaderMap> {
+        self.request.as_ref().ok().map(Request::headers)
     }
 
     /// Get a mutable reference to headers in the request.
-    pub fn headers_mut(&mut self) -> &mut HeaderMap {
-        self.request.headers_mut()
+    pub fn headers_mut(&mut self) -> Option<&mut HeaderMap> {
+        self.request.as_mut().ok().map(Request::headers_mut)
     }
 
     /// Set target address for the request.
@@ -288,9 +398,14 @@ impl<'a, S, B> RequestBuilder<'a, S, B> {
     }
 
     /// Set a request body.
-    pub fn body<B2>(self, body: B2) -> RequestBuilder<'a, S, B2> {
-        let (parts, _) = self.request.into_parts();
-        let request = Request::from_parts(parts, body);
+    pub fn body<B2>(self, body: B2) -> RequestBuilder<S, B2> {
+        let request = match self.request {
+            Ok(req) => {
+                let (parts, _) = req.into_parts();
+                Ok(Request::from_parts(parts, body))
+            }
+            Err(err) => Err(err),
+        };
 
         RequestBuilder {
             client: self.client,
@@ -302,8 +417,8 @@ impl<'a, S, B> RequestBuilder<'a, S, B> {
     }
 
     /// Get a reference to body in the request.
-    pub fn body_ref(&self) -> &B {
-        self.request.body()
+    pub fn body_ref(&self) -> Option<&B> {
+        self.request.as_ref().ok().map(Request::body)
     }
 
     /// Set maximin idle time for the request.
@@ -316,7 +431,7 @@ impl<'a, S, B> RequestBuilder<'a, S, B> {
     }
 }
 
-impl<'a, S, B> RequestBuilder<'a, S, B>
+impl<S, B> RequestBuilder<S, B>
 where
     S: Service<ClientContext, ClientRequest<B>, Response = ClientResponse, Error = ClientError>
         + Send
@@ -327,7 +442,7 @@ where
     /// Send the request and get the response.
     pub async fn send(self) -> Result<ClientResponse> {
         self.client
-            .send_request(self.target, self.call_opt, self.request, self.timeout)
+            .send_request(self.target, self.call_opt, self.request?, self.timeout)
             .await
     }
 }
@@ -336,8 +451,6 @@ where
 #[cfg(feature = "json")]
 #[cfg(test)]
 mod request_tests {
-    #![allow(unused)]
-
     use std::collections::HashMap;
 
     use serde::Deserialize;
@@ -352,29 +465,69 @@ mod request_tests {
         headers: HashMap<String, String>,
         origin: String,
         url: String,
+        #[serde(default)]
+        form: HashMap<String, String>,
+        #[serde(default)]
+        json: Option<HashMap<String, String>>,
+    }
+
+    fn test_data() -> HashMap<String, String> {
+        HashMap::from([
+            ("key1".to_string(), "val1".to_string()),
+            ("key2".to_string(), "val2".to_string()),
+        ])
     }
 
     #[cfg(feature = "query")]
     #[tokio::test]
     async fn set_query() {
-        let mut builder = Client::builder();
-        builder.host("httpbin.org");
-        let client = builder.build();
-        let query = HashMap::from([
-            ("key".to_string(), "val".to_string()),
-            ("key2".to_string(), "val2".to_string()),
-        ]);
+        let data = test_data();
+
+        let client = Client::builder().build();
         let resp = client
-            .get("/get")
-            .unwrap()
-            .set_query(&query)
-            .unwrap()
+            .get("http://httpbin.org/get")
+            .set_query(&data)
             .send()
             .await
             .unwrap()
             .into_json::<HttpBinResponse>()
             .await
             .unwrap();
-        assert_eq!(resp.args, query);
+        assert_eq!(resp.args, data);
+    }
+
+    #[cfg(feature = "form")]
+    #[tokio::test]
+    async fn set_form() {
+        let data = test_data();
+
+        let client = Client::builder().build();
+        let resp = client
+            .post("http://httpbin.org/post")
+            .form(&data)
+            .send()
+            .await
+            .unwrap()
+            .into_json::<HttpBinResponse>()
+            .await
+            .unwrap();
+        assert_eq!(resp.form, data);
+    }
+
+    #[tokio::test]
+    async fn set_json() {
+        let data = test_data();
+
+        let client = Client::builder().build();
+        let resp = client
+            .post("http://httpbin.org/post")
+            .json(&data)
+            .send()
+            .await
+            .unwrap()
+            .into_json::<HttpBinResponse>()
+            .await
+            .unwrap();
+        assert_eq!(resp.json, Some(data));
     }
 }

--- a/volo-http/src/client/test_helpers.rs
+++ b/volo-http/src/client/test_helpers.rs
@@ -1,3 +1,5 @@
+//! Test utilities for client of Volo-HTTP.
+
 use std::sync::Arc;
 
 use faststr::FastStr;
@@ -143,6 +145,7 @@ impl<IL, OL, C, LB> ClientBuilder<IL, OL, C, LB> {
         };
 
         let client_inner = ClientInner {
+            service,
             caller_name,
             callee_name: self.callee_name,
             // set a default target so that we can create a request without authority
@@ -154,7 +157,6 @@ impl<IL, OL, C, LB> ClientBuilder<IL, OL, C, LB> {
             headers: self.headers,
         };
         let client = Client {
-            service,
             inner: Arc::new(client_inner),
         };
         self.mk_client.mk_client(client)
@@ -223,7 +225,7 @@ mod mock_transport_tests {
     #[tokio::test]
     async fn empty_response_test() {
         let client = ClientBuilder::new().mock(MockTransport::default());
-        let resp = client.get("/").unwrap().send().await.unwrap();
+        let resp = client.get("/").send().await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         assert!(resp.headers().is_empty());
         assert!(resp.into_body().into_vec().await.unwrap().is_empty());
@@ -234,7 +236,7 @@ mod mock_transport_tests {
         {
             let client =
                 ClientBuilder::new().mock(MockTransport::status_code(StatusCode::IM_A_TEAPOT));
-            let resp = client.get("/").unwrap().send().await.unwrap();
+            let resp = client.get("/").send().await.unwrap();
             assert_eq!(resp.status(), StatusCode::IM_A_TEAPOT);
             assert!(resp.headers().is_empty());
             assert!(resp.into_body().into_vec().await.unwrap().is_empty());
@@ -245,7 +247,7 @@ mod mock_transport_tests {
                 builder.fail_on_error_status(true);
                 builder.mock(MockTransport::status_code(StatusCode::IM_A_TEAPOT))
             };
-            assert!(client.get("/").unwrap().send().await.is_err());
+            assert!(client.get("/").send().await.is_err());
         }
     }
 }

--- a/volo-http/src/error/client.rs
+++ b/volo-http/src/error/client.rs
@@ -8,10 +8,8 @@ use paste::paste;
 use super::BoxError;
 use crate::body::BodyConvertError;
 
-/// [`Result`][Result] with [`ClientError`] as its error type
-///
-/// [Result]: std::result::Result
-pub type Result<T> = std::result::Result<T, ClientError>;
+/// [`Result`](std::result::Result) with [`ClientError`] as its error by default.
+pub type Result<T, E = ClientError> = std::result::Result<T, E>;
 
 /// Generic client error
 #[derive(Debug)]

--- a/volo-http/src/utils/consts.rs
+++ b/volo-http/src/utils/consts.rs
@@ -1,6 +1,14 @@
 //! Constants of HTTP(S) protocol.
 
+use http::header::HeaderValue;
+
 /// Default port of HTTP server.
 pub const HTTP_DEFAULT_PORT: u16 = 80;
 /// Default port of HTTPS server.
 pub const HTTPS_DEFAULT_PORT: u16 = 443;
+
+/// `application/json`
+pub const APPLICATION_JSON: HeaderValue = HeaderValue::from_static("application/json");
+/// `application/x-www-form-urlencoded`
+pub const APPLICATION_WWW_FORM_URLENCODED: HeaderValue =
+    HeaderValue::from_static("application/x-www-form-urlencoded");

--- a/volo-http/src/utils/test_helpers.rs
+++ b/volo-http/src/utils/test_helpers.rs
@@ -142,7 +142,6 @@ mod helper_tests {
         {
             let ret = client
                 .get("/get")
-                .unwrap()
                 .send()
                 .await
                 .unwrap()
@@ -154,7 +153,6 @@ mod helper_tests {
         {
             let ret = client
                 .get("http://127.0.0.1/get")
-                .unwrap()
                 .send()
                 .await
                 .unwrap()
@@ -164,11 +162,11 @@ mod helper_tests {
             assert_eq!(ret, HELLO_WORLD);
         }
         {
-            let resp = client.get("/").unwrap().send().await.unwrap();
+            let resp = client.get("/").send().await.unwrap();
             assert_eq!(resp.status(), StatusCode::NOT_FOUND);
         }
         {
-            let resp = client.post("/get").unwrap().send().await.unwrap();
+            let resp = client.post("/get").send().await.unwrap();
             assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
         }
     }


### PR DESCRIPTION
## Motivation

There are too many `Result`s in the return values of `RequestBuilder`'s methods, so a large number of `unwrap`s need to be used, resulting in a poor user experience.

## Solution

This PR updates `Request` to `Result<Request>` in `RequestBuilder`, and makes the methods of `RequestBuilder` no longer use `Result` as the return type.

These methods no longer return `Err` directly, but save it in `Result<Request>` and throw it when trying to send a request.

