### PR TITLE
chore: fix nightly clippy rule `needless_lifetimes`

### DIFF
--- a/scripts/clippy-and-test.sh
+++ b/scripts/clippy-and-test.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o pipefail
 
 echo_command() {
-	echo "Running $@"
+	echo "$@"
 
 	if [ "${GITHUB_ACTIONS:-}" = "true" ] || [ -n "${DEBUG:-}" ]; then
 		# If we are in GitHub Actions or env `DEBUG` is non-empty,

--- a/scripts/selftest.sh
+++ b/scripts/selftest.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o pipefail
 
 echo_and_run() {
-	echo "Running $@"
+	echo "$@"
 
 	if [ -n "${DEBUG:-}" ]; then
 		# If env `DEBUG` is non-empty, output all

--- a/scripts/volo-cli-test.sh
+++ b/scripts/volo-cli-test.sh
@@ -9,7 +9,7 @@ quiet() {
 }
 
 echo_command() {
-	echo "Run \`$@\`"
+	echo "\`$@\`"
 
 	if [ "${GITHUB_ACTIONS:-}" = "true" ] || [ -n "${DEBUG:-}" ]; then
 		# If we are in GitHub Actions or env `DEBUG` is non-empty,

--- a/volo-grpc/src/client/meta.rs
+++ b/volo-grpc/src/client/meta.rs
@@ -35,9 +35,9 @@ where
 
     type Error = S::Error;
 
-    async fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut ClientContext,
+    async fn call(
+        &self,
+        cx: &mut ClientContext,
         mut volo_req: Request<T>,
     ) -> Result<Self::Response, Self::Error> {
         let metadata = volo_req.metadata_mut();

--- a/volo-grpc/src/client/mod.rs
+++ b/volo-grpc/src/client/mod.rs
@@ -590,9 +590,9 @@ macro_rules! impl_client {
             type Response = S::Response;
             type Error = S::Error;
 
-            async fn call<'s, 'cx>(
-                &'s $self,
-                $cx: &'cx mut crate::context::ClientContext,
+            async fn call(
+                &$self,
+                $cx: &mut crate::context::ClientContext,
                 $req: Req,
             ) -> Result<Self::Response, Self::Error> {
                 $e
@@ -613,9 +613,9 @@ macro_rules! impl_client {
             type Response = S::Response;
             type Error = S::Error;
 
-            async fn call<'cx>(
+            async fn call(
                 $self,
-                $cx: &'cx mut crate::context::ClientContext,
+                $cx: &mut crate::context::ClientContext,
                 $req: Req,
             ) -> Result<Self::Response, Self::Error> {
                 $e

--- a/volo-grpc/src/layer/cross_origin.rs
+++ b/volo-grpc/src/layer/cross_origin.rs
@@ -24,9 +24,9 @@ where
     type Response = T::Response;
     type Error = T::Error;
 
-    async fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut Cx,
+    async fn call(
+        &self,
+        cx: &mut Cx,
         req: Request<ReqBody>,
     ) -> Result<Self::Response, Self::Error> {
         // split the header and body

--- a/volo-grpc/src/layer/grpc_timeout.rs
+++ b/volo-grpc/src/layer/grpc_timeout.rs
@@ -95,9 +95,9 @@ where
     type Response = S::Response;
     type Error = Status;
 
-    async fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut Cx,
+    async fn call(
+        &self,
+        cx: &mut Cx,
         req: hyper::Request<ReqBody>,
     ) -> Result<Self::Response, Self::Error> {
         // parse the client_timeout

--- a/volo-grpc/src/layer/loadbalance/mod.rs
+++ b/volo-grpc/src/layer/loadbalance/mod.rs
@@ -87,11 +87,7 @@ where
 
     type Error = S::Error;
 
-    async fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut Cx,
-        req: Request<T>,
-    ) -> Result<Self::Response, Self::Error> {
+    async fn call(&self, cx: &mut Cx, req: Request<T>) -> Result<Self::Response, Self::Error> {
         let callee = cx.rpc_info().callee();
 
         let mut picker = match &callee.address {

--- a/volo-grpc/src/layer/user_agent.rs
+++ b/volo-grpc/src/layer/user_agent.rs
@@ -35,9 +35,9 @@ where
     type Response = T::Response;
     type Error = T::Error;
 
-    async fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut Cx,
+    async fn call(
+        &self,
+        cx: &mut Cx,
         mut req: Request<ReqBody>,
     ) -> Result<Self::Response, Self::Error> {
         req.headers_mut()

--- a/volo-grpc/src/server/router.rs
+++ b/volo-grpc/src/server/router.rs
@@ -94,9 +94,9 @@ where
     type Response = Response<BoxBody>;
     type Error = Status;
 
-    async fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut ServerContext,
+    async fn call(
+        &self,
+        cx: &mut ServerContext,
         req: Request<B>,
     ) -> Result<Self::Response, Self::Error> {
         let path = cx.rpc_info.method();

--- a/volo-grpc/src/server/service.rs
+++ b/volo-grpc/src/server/service.rs
@@ -121,9 +121,9 @@ where
     type Response = Response<BoxBody>;
     type Error = Status;
 
-    async fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut ServerContext,
+    async fn call(
+        &self,
+        cx: &mut ServerContext,
         req: Request<BoxBody>,
     ) -> Result<Self::Response, Self::Error> {
         let (metadata, extensions, body) = req.into_parts();

--- a/volo-grpc/src/transport/client.rs
+++ b/volo-grpc/src/transport/client.rs
@@ -115,9 +115,9 @@ where
 
     type Error = Status;
 
-    async fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut ClientContext,
+    async fn call(
+        &self,
+        cx: &mut ClientContext,
         volo_req: Request<T>,
     ) -> Result<Self::Response, Self::Error> {
         let mut http_client = self.http_client.clone();

--- a/volo-http/src/utils/extension.rs
+++ b/volo-http/src/utils/extension.rs
@@ -62,11 +62,7 @@ where
     type Response = S::Response;
     type Error = S::Error;
 
-    async fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut Cx,
-        req: Req,
-    ) -> Result<Self::Response, Self::Error> {
+    async fn call(&self, cx: &mut Cx, req: Req) -> Result<Self::Response, Self::Error> {
         cx.extensions_mut().insert(self.ext.clone());
         self.inner.call(cx, req).await
     }

--- a/volo-thrift/src/client/layer/timeout.rs
+++ b/volo-thrift/src/client/layer/timeout.rs
@@ -20,11 +20,7 @@ where
 
     type Error = S::Error;
 
-    async fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut ClientContext,
-        req: Req,
-    ) -> Result<Self::Response, Self::Error> {
+    async fn call(&self, cx: &mut ClientContext, req: Req) -> Result<Self::Response, Self::Error> {
         match cx.rpc_info.config().rpc_timeout() {
             Some(duration) => {
                 let start = std::time::Instant::now();

--- a/volo-thrift/src/client/mod.rs
+++ b/volo-thrift/src/client/mod.rs
@@ -529,11 +529,7 @@ where
 
     type Error = ClientError;
 
-    async fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut ClientContext,
-        req: Req,
-    ) -> Result<Self::Response, Self::Error> {
+    async fn call(&self, cx: &mut ClientContext, req: Req) -> Result<Self::Response, Self::Error> {
         let msg = ThriftMessage::mk_client_msg(cx, req);
         let resp = self.inner.call(cx, msg).await;
         if self.read_biz_error {
@@ -742,9 +738,9 @@ macro_rules! impl_client {
             type Response = S::Response;
             type Error = S::Error;
 
-            async fn call<'s, 'cx>(
-                &'s $self,
-                $cx: &'cx mut crate::context::ClientContext,
+            async fn call(
+                &$self,
+                $cx: &mut crate::context::ClientContext,
                 $req: Req,
             ) -> Result<Self::Response, Self::Error> {
                 $e
@@ -766,9 +762,9 @@ macro_rules! impl_client {
             type Response = S::Response;
             type Error = S::Error;
 
-            async fn call<'cx>(
+            async fn call(
                 $self,
-                $cx: &'cx mut crate::context::ClientContext,
+                $cx: &mut crate::context::ClientContext,
                 $req: Req,
             ) -> Result<Self::Response, Self::Error> {
                 $e

--- a/volo-thrift/src/server/layer/biz_error.rs
+++ b/volo-thrift/src/server/layer/biz_error.rs
@@ -42,11 +42,7 @@ where
     type Error = crate::ServerError;
 
     #[inline]
-    async fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut ServerContext,
-        req: Req,
-    ) -> Result<Self::Response, Self::Error> {
+    async fn call(&self, cx: &mut ServerContext, req: Req) -> Result<Self::Response, Self::Error> {
         let ret = self.inner.call(cx, req).await.map_err(Into::into);
         if let Err(ServerError::Biz(err)) = ret.as_ref() {
             cx.common_stats.set_biz_error(err.clone());

--- a/volo-thrift/src/transport/multiplex/client.rs
+++ b/volo-thrift/src/transport/multiplex/client.rs
@@ -124,9 +124,9 @@ where
 
     type Error = ClientError;
 
-    async fn call<'cx, 's>(
-        &'s self,
-        cx: &'cx mut ClientContext,
+    async fn call(
+        &self,
+        cx: &mut ClientContext,
         req: ThriftMessage<Req>,
     ) -> Result<Self::Response, Self::Error> {
         let rpc_info = &cx.rpc_info;

--- a/volo-thrift/src/transport/pingpong/client.rs
+++ b/volo-thrift/src/transport/pingpong/client.rs
@@ -106,9 +106,9 @@ where
     type Error = crate::ClientError;
 
     #[inline]
-    async fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut ClientContext,
+    async fn call(
+        &self,
+        cx: &mut ClientContext,
         req: ThriftMessage<Req>,
     ) -> Result<Self::Response, Self::Error> {
         let rpc_info = &cx.rpc_info;

--- a/volo/src/loadbalance/layer.rs
+++ b/volo/src/loadbalance/layer.rs
@@ -57,11 +57,7 @@ where
 
     type Error = S::Error;
 
-    async fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut Cx,
-        req: Req,
-    ) -> Result<Self::Response, Self::Error> {
+    async fn call(&self, cx: &mut Cx, req: Req) -> Result<Self::Response, Self::Error> {
         let callee = cx.rpc_info().callee();
 
         let picker = match &callee.address {


### PR DESCRIPTION
## Motivation

The latest `cargo-clippy` adds a new rule:

```
error: the following explicit lifetimes could be elided: 's, 'cx
  --> volo/src/loadbalance/layer.rs:60:19
   |
60 |     async fn call<'s, 'cx>(
   |                   ^^  ^^^
61 |         &'s self,
   |          ^^
62 |         cx: &'cx mut Cx,
   |              ^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
   = note: `-D clippy::needless-lifetimes` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::needless_lifetimes)]`
```


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Fix them