### PR TITLE
fix(volo): make sure hotrestart sockdir exists

### DIFF
--- a/volo/src/hotrestart/mod.rs
+++ b/volo/src/hotrestart/mod.rs
@@ -128,6 +128,9 @@ impl HotRestart {
         if *state != HotRestartState::Uninitalized {
             return Ok(());
         }
+        if !sock_dir_path.exists() {
+            std::fs::create_dir_all(sock_dir_path)?;
+        }
         self.listener_num
             .store(server_listener_num, Ordering::Relaxed);
         self.parent_sock_path


### PR DESCRIPTION
## Motivation
Prior to this, the hotrestart sockdir must be ensured to exist by the user, otherwise the initialization will fail.

## Solution
This PR fixes it by checking and creating the sockdir in volo itself.
