### PR TITLE
chore(ci): do not use `apt` for self-hosted runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,8 +75,6 @@ jobs:
           toolchain: ${{matrix.rust}}
       - name: Run tests
         run: |
-          apt update
-          apt install -y libssl-dev
           bash scripts/clippy-and-test.sh
 
   test-linux-aarch64:
@@ -93,8 +91,6 @@ jobs:
           toolchain: ${{matrix.rust}}
       - name: Run tests
         run: |
-          apt update
-          apt install -y libssl-dev
           bash scripts/clippy-and-test.sh
 
   test-macos:


### PR DESCRIPTION
## Motivation

Since self-hosted CI runners do not use containers and root, we should also remove the use of `apt`.

## Solution

Remove `apt update` & `apt install -y libssl-dev` for self-hosted runners.
