### PR TITLE
chore(volo-http): implement `source` for `Error`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3868,7 +3868,7 @@ dependencies = [
 
 [[package]]
 name = "volo-http"
-version = "0.2.14"
+version = "0.3.0-rc.1"
 dependencies = [
  "ahash",
  "async-broadcast",

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-http"
-version = "0.2.14"
+version = "0.3.0-rc.1"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
@@ -14,8 +14,6 @@ categories = ["asynchronous", "network-programming", "web-programming"]
 keywords = ["async", "rpc", "http"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -61,27 +59,29 @@ tracing.workspace = true
 url.workspace = true
 
 # =====optional=====
-multer = { workspace = true, optional = true }
 
 # server optional
 matchit = { workspace = true, optional = true }
 
-# protocol optional
+# serde and form, query, json
+serde = { workspace = true, optional = true }
+serde_urlencoded = { workspace = true, optional = true }
+sonic-rs = { workspace = true, optional = true }
+
+# cookie support
+cookie = { workspace = true, optional = true, features = ["percent-encode"] }
+cookie_store = { workspace = true, optional = true }
+
+# multipart optional
+multer = { workspace = true, optional = true }
+
+# websocket optional
 tungstenite = { workspace = true, optional = true }
 tokio-tungstenite = { workspace = true, optional = true }
 
 # tls optional
 tokio-rustls = { workspace = true, optional = true }
 tokio-native-tls = { workspace = true, optional = true }
-
-# cookie support
-cookie = { workspace = true, optional = true, features = ["percent-encode"] }
-cookie_store = { workspace = true, optional = true }
-
-# serde and form, query, json
-serde = { workspace = true, optional = true }
-serde_urlencoded = { workspace = true, optional = true }
-sonic-rs = { workspace = true, optional = true }
 
 [dev-dependencies]
 async-stream.workspace = true
@@ -96,11 +96,22 @@ default = []
 default_client = ["client", "json"]
 default_server = ["server", "query", "form", "json", "multipart"]
 
-full = ["client", "server", "rustls", "cookie", "query", "form", "json", "multipart", "tls", "ws"]
+full = [
+    "client", "server", # core
+    "query", "form", "json", # serde
+    "tls", # https
+    "cookie", "multipart", "ws",
+]
 
 client = ["hyper/client", "hyper/http1"] # client core
 server = ["hyper/server", "hyper/http1", "dep:matchit"] # server core
 
+__serde = ["dep:serde"] # a private feature for enabling `serde` by `serde_xxx`
+query = ["__serde", "dep:serde_urlencoded"]
+form = ["__serde", "dep:serde_urlencoded"]
+json = ["__serde", "dep:sonic-rs"]
+
+cookie = ["dep:cookie", "dep:cookie_store"]
 multipart = ["dep:multer"]
 ws = ["dep:tungstenite", "dep:tokio-tungstenite"]
 
@@ -109,13 +120,6 @@ __tls = []
 rustls = ["__tls", "dep:tokio-rustls", "volo/rustls"]
 native-tls = ["__tls", "dep:tokio-native-tls", "volo/native-tls"]
 native-tls-vendored = ["native-tls", "volo/native-tls-vendored"]
-
-cookie = ["dep:cookie", "dep:cookie_store"]
-
-__serde = ["dep:serde"] # a private feature for enabling `serde` by `serde_xxx`
-query = ["__serde", "dep:serde_urlencoded"]
-form = ["__serde", "dep:serde_urlencoded"]
-json = ["__serde", "dep:sonic-rs"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/volo-http/src/body.rs
+++ b/volo-http/src/body.rs
@@ -278,7 +278,15 @@ impl fmt::Display for BodyConvertError {
     }
 }
 
-impl Error for BodyConvertError {}
+impl Error for BodyConvertError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            #[cfg(feature = "json")]
+            Self::JsonDeserializeError(e) => Some(e),
+            _ => None,
+        }
+    }
+}
 
 impl From<()> for Body {
     fn from(_: ()) -> Self {

--- a/volo-http/src/error/server.rs
+++ b/volo-http/src/error/server.rs
@@ -38,6 +38,19 @@ impl fmt::Display for ExtractBodyError {
     }
 }
 
+impl Error for ExtractBodyError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Generic(e) => Some(e),
+            Self::String(e) => Some(e),
+            #[cfg(feature = "json")]
+            Self::Json(e) => Some(e),
+            #[cfg(feature = "form")]
+            Self::Form(e) => Some(e),
+        }
+    }
+}
+
 impl IntoResponse for ExtractBodyError {
     fn into_response(self) -> ServerResponse {
         let status = match self {

--- a/volo-http/src/server/param.rs
+++ b/volo-http/src/server/param.rs
@@ -282,7 +282,14 @@ impl fmt::Display for PathParamsRejection {
     }
 }
 
-impl Error for PathParamsRejection {}
+impl Error for PathParamsRejection {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::LengthMismatch => None,
+            Self::ParseError(e) => Some(e.as_ref()),
+        }
+    }
+}
 
 impl IntoResponse for PathParamsRejection {
     fn into_response(self) -> ServerResponse {

--- a/volo-http/src/server/route/utils.rs
+++ b/volo-http/src/server/route/utils.rs
@@ -91,7 +91,15 @@ impl fmt::Display for MatcherError {
     }
 }
 
-impl Error for MatcherError {}
+impl Error for MatcherError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::UriConflict(_) => None,
+            Self::RouterInsertError(e) => Some(e),
+            Self::RouterMatchError(e) => Some(e),
+        }
+    }
+}
 
 pub(super) struct StripPrefixLayer;
 

--- a/volo-http/src/server/utils/ws.rs
+++ b/volo-http/src/server/utils/ws.rs
@@ -39,6 +39,7 @@
 
 use std::{
     borrow::Cow,
+    error::Error,
     fmt,
     future::Future,
     ops::{Deref, DerefMut},
@@ -467,7 +468,13 @@ impl fmt::Display for WebSocketError {
     }
 }
 
-impl std::error::Error for WebSocketError {}
+impl Error for WebSocketError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Upgrade(e) => Some(e),
+        }
+    }
+}
 
 /// What to do when a connection upgrade fails.
 ///
@@ -498,7 +505,6 @@ impl OnFailedUpgrade for DefaultOnFailedUpgrade {
 
 /// [`Error`]s while extracting [`WebSocketUpgrade`].
 ///
-/// [`Error`]: std::error::Error
 /// [`WebSocketUpgrade`]: crate::server::utils::ws::WebSocketUpgrade
 #[derive(Debug)]
 pub enum WebSocketUpgradeRejectionError {
@@ -530,7 +536,7 @@ impl WebSocketUpgradeRejectionError {
     }
 }
 
-impl std::error::Error for WebSocketUpgradeRejectionError {}
+impl Error for WebSocketUpgradeRejectionError {}
 
 impl fmt::Display for WebSocketUpgradeRejectionError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
## Motivation

We only implemented the trait `Error` for `xxxError`, but not `fn source`, so we can't get more details about the error.

## Solution

Implement `fn source` for `Error`s if possible.