### PR TITLE
chore(volo-http): add feature `json-utf8-lossy`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.36"
+version = "1.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baee610e9452a8f6f0a1b6194ec09ff9e2d85dea54432acdae41aa0761c95d70"
+checksum = "40545c26d092346d8a8dab71ee48e7685a7a9cba76e634790c215b41a4a7b4cf"
 dependencies = [
  "jobserver",
  "libc",
@@ -443,12 +443,13 @@ dependencies = [
 
 [[package]]
 name = "cookie_store"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4934e6b7e8419148b6ef56950d277af8561060b56afd59e2aadf98b59fce6baa"
+checksum = "2eac901828f88a5241ee0600950ab981148a18f2f756900ffba1b125ca6a3ef9"
 dependencies = [
  "cookie",
- "idna 0.5.0",
+ "document-features",
+ "idna 1.0.3",
  "log",
  "publicsuffix",
  "serde",
@@ -619,6 +620,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
 name = "faststr"
@@ -1077,7 +1087,7 @@ dependencies = [
  "ipnet",
  "once_cell",
  "rand",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tinyvec",
  "tokio",
  "tracing",
@@ -1100,7 +1110,7 @@ dependencies = [
  "rand",
  "resolv-conf",
  "smallvec",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -1486,16 +1496,6 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
@@ -1630,9 +1630,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
 name = "libgit2-sys"
@@ -1698,6 +1698,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1745,9 +1751,9 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+checksum = "bd0aa4b8ca861b08d68afc8702af3250776898c1508b278e1da9d01e01d4b45c"
 
 [[package]]
 name = "memchr"
@@ -2262,7 +2268,7 @@ dependencies = [
  "paste",
  "serde",
  "smallvec",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -2442,7 +2448,7 @@ dependencies = [
  "protobuf-support2",
  "protobuf2",
  "tempfile",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "which",
 ]
 
@@ -2452,7 +2458,7 @@ version = "4.0.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c6e937299e45024fae149d242cee9719048e4890dbc28c0d1838ed0aba8c3ec"
 dependencies = [
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2463,7 +2469,7 @@ checksum = "fc090e26a62f7d66cfc6cd8715ab0973f57287293488a8d05e68fd4d5bb4ad05"
 dependencies = [
  "once_cell",
  "protobuf-support2",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2599,7 +2605,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2788,9 +2794,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.39"
+version = "0.38.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375116bee2be9ed569afe2154ea6a99dfdffd257f533f187498c2a8f5feaf4ee"
+checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -2981,9 +2987,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
+checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3135,21 +3141,19 @@ dependencies = [
 
 [[package]]
 name = "sonic-rs"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e200c991ecfca73485d451fb0ae48c605f60ed7e27e4fcd5b8510f131a7c84"
+checksum = "531b13eca9f20046cbaddc82e60399ed4337f34da923aba1437467a3da3eebac"
 dependencies = [
  "bumpalo",
  "bytes",
  "cfg-if",
  "faststr",
  "itoa",
- "parking_lot 0.12.3",
  "ryu",
  "serde",
  "simdutf8",
- "smallvec",
- "thiserror 1.0.68",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
@@ -3291,9 +3295,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -3329,27 +3333,27 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.68",
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
 name = "thiserror"
-version = "2.0.0"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15291287e9bff1bc6f9ff3409ed9af665bec7a5fc8ac079ea96be07bca0e2668"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
 dependencies = [
- "thiserror-impl 2.0.0",
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3358,9 +3362,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.0"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22efd00f33f93fa62848a7cab956c3d38c8d43095efda1decfc2b3a5dc0b8972"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3435,9 +3439,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.0"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3787,7 +3791,7 @@ dependencies = [
  "log",
  "rand",
  "sha1",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "utf-8",
 ]
 
@@ -3954,7 +3958,7 @@ dependencies = [
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "socket2",
- "thiserror 2.0.0",
+ "thiserror 2.0.3",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.25.0",
@@ -4049,7 +4053,7 @@ dependencies = [
  "hyper 1.5.0",
  "hyper-timeout",
  "hyper-util",
- "matchit 0.8.4",
+ "matchit 0.8.5",
  "metainfo",
  "motore",
  "percent-encoding",
@@ -4091,7 +4095,7 @@ dependencies = [
  "hyper-util",
  "itoa",
  "libc",
- "matchit 0.8.4",
+ "matchit 0.8.5",
  "memchr",
  "metainfo",
  "mime",
@@ -4107,7 +4111,7 @@ dependencies = [
  "serde_urlencoded",
  "simdutf8",
  "sonic-rs",
- "thiserror 2.0.0",
+ "thiserror 2.0.3",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.25.0",
@@ -4146,7 +4150,7 @@ dependencies = [
  "rustc-hash 2.0.0",
  "scopeguard",
  "sonic-rs",
- "thiserror 2.0.0",
+ "thiserror 2.0.3",
  "tokio",
  "tracing",
  "volo",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -132,8 +132,8 @@ volo = { path = "../volo" }
 volo-grpc = { path = "../volo-grpc", features = ["grpc-web"] }
 volo-thrift = { path = "../volo-thrift", features = ["multiplex"] }
 volo-http = { path = "../volo-http", features = [
-    "default_client",
-    "default_server",
+    "default-client",
+    "default-server",
     "cookie",
 ] }
 

--- a/scripts/clippy-and-test.sh
+++ b/scripts/clippy-and-test.sh
@@ -30,8 +30,8 @@ echo_command cargo clippy -p volo-grpc --no-default-features --features native-t
 echo_command cargo clippy -p volo-grpc --no-default-features --features native-tls-vendored -- --deny warnings
 echo_command cargo clippy -p volo-grpc --no-default-features --features grpc-web -- --deny warnings
 echo_command cargo clippy -p volo-http --no-default-features -- --deny warnings
-echo_command cargo clippy -p volo-http --no-default-features --features default_client -- --deny warnings
-echo_command cargo clippy -p volo-http --no-default-features --features default_server -- --deny warnings
+echo_command cargo clippy -p volo-http --no-default-features --features default-client -- --deny warnings
+echo_command cargo clippy -p volo-http --no-default-features --features default-server -- --deny warnings
 echo_command cargo clippy -p volo-http --no-default-features --features client,server -- --deny warnings
 echo_command cargo clippy -p volo-http --no-default-features --features full -- --deny warnings
 echo_command cargo clippy -p volo -- --deny warnings
@@ -43,7 +43,7 @@ echo_command cargo clippy -p examples -- --deny warnings
 # Test
 echo_command cargo test -p volo-thrift
 echo_command cargo test -p volo-grpc --features rustls
-echo_command cargo test -p volo-http --features default_client,default_server
+echo_command cargo test -p volo-http --features default-client,default-server
 echo_command cargo test -p volo-http --features full
 echo_command cargo test -p volo --features rustls
 echo_command cargo test -p volo-build

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -93,14 +93,14 @@ tokio-test.workspace = true
 [features]
 default = []
 
-default_client = ["client", "json"]
-default_server = ["server", "query", "form", "json", "multipart"]
+default-client = ["client", "json"]
+default-server = ["server", "query", "form", "json", "multipart"]
 
 full = [
     "client", "server", # core
     "query", "form", "json", # serde
     "tls", # https
-    "cookie", "multipart", "ws",
+    "cookie", "multipart", "ws", # exts
 ]
 
 client = ["hyper/client", "hyper/http1"] # client core
@@ -110,6 +110,7 @@ __serde = ["dep:serde"] # a private feature for enabling `serde` by `serde_xxx`
 query = ["__serde", "dep:serde_urlencoded"]
 form = ["__serde", "dep:serde_urlencoded"]
 json = ["__serde", "dep:sonic-rs"]
+json-utf8-lossy = ["json", "sonic-rs/utf8_lossy"] # json feature
 
 cookie = ["dep:cookie", "dep:cookie_store"]
 multipart = ["dep:multer"]


### PR DESCRIPTION
## Motivation

Since `sonic-rs` added a new feature `utf8_lossy`, it allows to parse JSON with invalid UTF-8 and UTF-16 characters.

When this feature is enabled, invalid characters are replaced with '\uFFFD' (displayed as �) instead of parsing failing due to invalid characters.

## Solution

Add feature `json-utf8-lossy` to Volo-HTTP.

In addition, this PR also unifies the style of feature names, `default_client`, default_server` have been renamed to `default-client`, `default-server`.