### PR TITLE
chore(volo-http): fix previously missed changes to `Body`

### DIFF
--- a/volo-http/src/body.rs
+++ b/volo-http/src/body.rs
@@ -36,11 +36,10 @@ pub struct Body {
 enum BodyRepr {
     /// Complete [`Bytes`], with a certain size and content
     Full(#[pin] Full<Bytes>),
-    /// Wrapper of [`hyper::body::Incoming`], it usually appers in request of server or response of
-    /// client.
+    /// Wrapper of [`Incoming`], it usually appears in request of server or response of client.
     ///
-    /// Althrough [`hyper::body::Incoming`] implements [`http_body::Body`], the type is so commonly
-    /// used, we wrap it here as [`Body::Hyper`] to avoid cost of [`Box`] with dynamic dispatch.
+    /// Althrough [`Incoming`] implements [`http_body::Body`], the type is so commonly used, we
+    /// wrap it here as [`BodyRepr::Hyper`] to avoid cost of [`Box`] with dynamic dispatch.
     Hyper(#[pin] Incoming),
     /// Boxed stream with `Item = Result<Frame<Bytes>, BoxError>`
     Stream(#[pin] StreamBody<BoxStream<'static, Result<Frame<Bytes>, BoxError>>>),
@@ -62,7 +61,7 @@ impl Body {
         }
     }
 
-    /// Create a body by [`hyper::body::Incoming`].
+    /// Create a body by [`Incoming`].
     ///
     /// Compared to [`Body::from_body`], this function avoids overhead of allocating by [`Box`]
     /// and dynamic dispatch by [`dyn http_body::Body`][http_body::Body].

--- a/volo-http/src/request.rs
+++ b/volo-http/src/request.rs
@@ -15,9 +15,9 @@ use url::Url;
 #[cfg(feature = "client")]
 pub type ClientRequest<B = crate::body::Body> = Request<B>;
 
-/// [`Request`] with [`Incoming`] as default body.
+/// [`Request`] with [`Body`] as default body.
 ///
-/// [`Incoming`]: hyper::body::Incoming
+/// [`Body`]: crate::body::Body
 #[cfg(feature = "server")]
 pub type ServerRequest<B = crate::body::Body> = Request<B>;
 

--- a/volo-http/src/server/extract.rs
+++ b/volo-http/src/server/extract.rs
@@ -16,7 +16,6 @@ use http::{
 };
 use http_body::Body;
 use http_body_util::BodyExt;
-use hyper::body::Incoming;
 use volo::{context::Context, net::Address};
 
 use super::IntoResponse;
@@ -64,7 +63,7 @@ pub trait FromContext: Sized {
 ///
 /// [`FromRequest`] will consume [`ServerRequest`], so it can only be used once in a handler. If
 /// your extractor does not need to consume [`ServerRequest`], please use [`FromContext`] instead.
-pub trait FromRequest<B = Incoming, M = private::ViaRequest>: Sized {
+pub trait FromRequest<B = crate::body::Body, M = private::ViaRequest>: Sized {
     /// If the extractor fails, it will return this `Rejection` type.
     ///
     /// The `Rejection` should implement [`IntoResponse`]. If extractor fails in handler, the
@@ -614,10 +613,9 @@ mod extract_tests {
     use std::convert::Infallible;
 
     use http::request::Parts;
-    use hyper::body::Incoming;
 
     use super::{FromContext, FromRequest};
-    use crate::{context::ServerContext, server::handler::Handler};
+    use crate::{body::Body, context::ServerContext, server::handler::Handler};
 
     struct SomethingFromCx;
 
@@ -638,7 +636,7 @@ mod extract_tests {
         async fn from_request(
             _: &mut ServerContext,
             _: Parts,
-            _: Incoming,
+            _: Body,
         ) -> Result<Self, Self::Rejection> {
             unimplemented!()
         }
@@ -648,7 +646,7 @@ mod extract_tests {
     fn extractor() {
         fn assert_handler<H, T>(_: H)
         where
-            H: Handler<T, Incoming, Infallible>,
+            H: Handler<T, Body, Infallible>,
         {
         }
 


### PR DESCRIPTION
## Motivation

The previous PR #504 updated most `hyper::body::Incoming` to `volo_http::body::Body`, but some codes were missed.

## Solution

This PR fixes previously missed changes.