### PR TITLE
fix(volo-http): fix wrong rule of setting header `Host`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4075,7 +4075,7 @@ dependencies = [
 
 [[package]]
 name = "volo-http"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 dependencies = [
  "ahash",
  "async-broadcast",

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-http"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-http/src/client/layer/header.rs
+++ b/volo-http/src/client/layer/header.rs
@@ -199,10 +199,10 @@ where
         mut req: ClientRequest<B>,
     ) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send {
         if !req.headers().contains_key(header::HOST) {
-            if let Some(val) = &self.val {
-                req.headers_mut().insert(header::HOST, val.clone());
-            } else if let Some(val) = gen_host_by_ep(cx.rpc_info().callee()) {
+            if let Some(val) = gen_host_by_ep(cx.rpc_info().callee()) {
                 req.headers_mut().insert(header::HOST, val);
+            } else if let Some(val) = &self.val {
+                req.headers_mut().insert(header::HOST, val.clone());
             }
         }
         self.inner.call(cx, req)


### PR DESCRIPTION
## Motivation

The previous testing was not sufficient, resulting in errors in the header `Host` when used.

## Solution

Fix codes in `Host` layer.

In addition, some unit tests have been added here to improve test coverage.
