### PR TITLE
chore(volo-http): combine C/S Request and C/S Response types

### DIFF
--- a/volo-http/src/client/cookie.rs
+++ b/volo-http/src/client/cookie.rs
@@ -10,8 +10,8 @@ use tokio::sync::RwLock;
 use crate::{
     context::ClientContext,
     error::ClientError,
-    request::{ClientRequest, RequestPartsExt},
-    response::ClientResponse,
+    request::{Request, RequestPartsExt},
+    response::Response,
     utils::cookie::CookieStore,
 };
 
@@ -32,9 +32,9 @@ impl<S> CookieService<S> {
     }
 }
 
-impl<S, B> Service<ClientContext, ClientRequest<B>> for CookieService<S>
+impl<S, B> Service<ClientContext, Request<B>> for CookieService<S>
 where
-    S: Service<ClientContext, ClientRequest<B>, Response = ClientResponse, Error = ClientError>
+    S: Service<ClientContext, Request<B>, Response = Response, Error = ClientError>
         + Send
         + Sync
         + 'static,
@@ -46,7 +46,7 @@ where
     async fn call(
         &self,
         cx: &mut ClientContext,
-        mut req: ClientRequest<B>,
+        mut req: Request<B>,
     ) -> Result<Self::Response, Self::Error> {
         let url = req.url();
 
@@ -58,7 +58,7 @@ where
                     .await
                     .add_cookie_header(&mut parts.headers, url);
             }
-            req = ClientRequest::from_parts(parts, body);
+            req = Request::from_parts(parts, body);
         }
 
         let resp = self.inner.call(cx, req).await?;

--- a/volo-http/src/client/layer/header.rs
+++ b/volo-http/src/client/layer/header.rs
@@ -21,7 +21,7 @@ use volo::{
 use crate::{
     client::{dns::Port, target::is_default_port},
     error::client::{builder_error, Result},
-    request::ClientRequest,
+    request::Request,
 };
 
 /// [`Layer`] for inserting a header to requests.
@@ -85,9 +85,9 @@ pub struct HeaderService<S> {
     val: HeaderValue,
 }
 
-impl<Cx, B, S> Service<Cx, ClientRequest<B>> for HeaderService<S>
+impl<Cx, B, S> Service<Cx, Request<B>> for HeaderService<S>
 where
-    S: Service<Cx, ClientRequest<B>>,
+    S: Service<Cx, Request<B>>,
 {
     type Response = S::Response;
     type Error = S::Error;
@@ -95,7 +95,7 @@ where
     fn call(
         &self,
         cx: &mut Cx,
-        mut req: ClientRequest<B>,
+        mut req: Request<B>,
     ) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send {
         req.headers_mut().insert(self.key.clone(), self.val.clone());
         self.inner.call(cx, req)
@@ -185,10 +185,10 @@ fn gen_host_by_ep(ep: &Endpoint) -> Option<HeaderValue> {
     gen_host(scheme, name, addr, port)
 }
 
-impl<Cx, B, S> Service<Cx, ClientRequest<B>> for HostService<S>
+impl<Cx, B, S> Service<Cx, Request<B>> for HostService<S>
 where
     Cx: Context,
-    S: Service<Cx, ClientRequest<B>>,
+    S: Service<Cx, Request<B>>,
 {
     type Response = S::Response;
     type Error = S::Error;
@@ -196,7 +196,7 @@ where
     fn call(
         &self,
         cx: &mut Cx,
-        mut req: ClientRequest<B>,
+        mut req: Request<B>,
     ) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send {
         if !req.headers().contains_key(header::HOST) {
             if let Some(val) = gen_host_by_ep(cx.rpc_info().callee()) {
@@ -256,9 +256,9 @@ pub struct UserAgentService<S> {
     val: HeaderValue,
 }
 
-impl<Cx, B, S> Service<Cx, ClientRequest<B>> for UserAgentService<S>
+impl<Cx, B, S> Service<Cx, Request<B>> for UserAgentService<S>
 where
-    S: Service<Cx, ClientRequest<B>>,
+    S: Service<Cx, Request<B>>,
 {
     type Response = S::Response;
     type Error = S::Error;
@@ -266,7 +266,7 @@ where
     fn call(
         &self,
         cx: &mut Cx,
-        mut req: ClientRequest<B>,
+        mut req: Request<B>,
     ) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send {
         if !req.headers().contains_key(header::USER_AGENT) {
             req.headers_mut()

--- a/volo-http/src/client/loadbalance.rs
+++ b/volo-http/src/client/loadbalance.rs
@@ -25,8 +25,8 @@ use crate::{
         client::{lb_error, no_available_endpoint},
         ClientError,
     },
-    request::ClientRequest,
-    response::ClientResponse,
+    request::Request,
+    response::Response,
 };
 
 /// Default load balance with [`DnsResolver`]
@@ -146,13 +146,11 @@ where
     }
 }
 
-impl<LB, D, S, B> Service<ClientContext, ClientRequest<B>> for LoadBalanceService<LB, D, S>
+impl<LB, D, S, B> Service<ClientContext, Request<B>> for LoadBalanceService<LB, D, S>
 where
     LB: LoadBalance<D>,
     D: Discover,
-    S: Service<ClientContext, ClientRequest<B>, Response = ClientResponse, Error = ClientError>
-        + Send
-        + Sync,
+    S: Service<ClientContext, Request<B>, Response = Response, Error = ClientError> + Send + Sync,
     B: Send,
 {
     type Response = S::Response;
@@ -161,7 +159,7 @@ where
     async fn call(
         &self,
         cx: &mut ClientContext,
-        req: ClientRequest<B>,
+        req: Request<B>,
     ) -> Result<Self::Response, Self::Error> {
         let callee = cx.rpc_info().callee();
 

--- a/volo-http/src/client/mod.rs
+++ b/volo-http/src/client/mod.rs
@@ -47,8 +47,8 @@ use crate::{
         client::{builder_error, Result},
         BoxError, ClientError,
     },
-    request::ClientRequest,
-    response::ClientResponse,
+    request::Request,
+    response::Response,
 };
 
 mod callopt;
@@ -856,9 +856,9 @@ impl<S> Client<S> {
     }
 }
 
-impl<S, B> OneShotService<ClientContext, ClientRequest<B>> for Client<S>
+impl<S, B> OneShotService<ClientContext, Request<B>> for Client<S>
 where
-    S: Service<ClientContext, ClientRequest<B>, Error = ClientError> + Send + Sync,
+    S: Service<ClientContext, Request<B>, Error = ClientError> + Send + Sync,
     B: Send,
 {
     type Response = S::Response;
@@ -867,7 +867,7 @@ where
     async fn call(
         self,
         cx: &mut ClientContext,
-        mut req: ClientRequest<B>,
+        mut req: Request<B>,
     ) -> Result<Self::Response, Self::Error> {
         // set target
         self.inner.target.clone().apply(cx)?;
@@ -912,9 +912,9 @@ where
     }
 }
 
-impl<S, B> Service<ClientContext, ClientRequest<B>> for Client<S>
+impl<S, B> Service<ClientContext, Request<B>> for Client<S>
 where
-    S: Service<ClientContext, ClientRequest<B>, Error = ClientError> + Send + Sync,
+    S: Service<ClientContext, Request<B>, Error = ClientError> + Send + Sync,
     B: Send,
 {
     type Response = S::Response;
@@ -923,7 +923,7 @@ where
     fn call(
         &self,
         cx: &mut ClientContext,
-        req: ClientRequest<B>,
+        req: Request<B>,
     ) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send {
         OneShotService::call(self.clone(), cx, req)
     }
@@ -943,7 +943,7 @@ impl<S> MkClient<Client<S>> for DefaultMkClient {
 static CLIENT: LazyLock<DefaultClient> = LazyLock::new(Default::default);
 
 /// Create a GET request to the specified URI.
-pub async fn get<U>(uri: U) -> Result<ClientResponse>
+pub async fn get<U>(uri: U) -> Result<Response>
 where
     U: TryInto<Uri>,
     U::Error: Into<BoxError>,

--- a/volo-http/src/client/transport.rs
+++ b/volo-http/src/client/transport.rs
@@ -13,8 +13,8 @@ use volo::{
 use crate::{
     context::ClientContext,
     error::client::{no_address, request_error, ClientError},
-    request::ClientRequest,
-    response::ClientResponse,
+    request::Request,
+    response::Response,
 };
 
 #[derive(Clone)]
@@ -105,11 +105,7 @@ impl ClientTransport {
         self.connect_to(target_addr).await
     }
 
-    async fn request<B>(
-        &self,
-        cx: &ClientContext,
-        req: ClientRequest<B>,
-    ) -> Result<ClientResponse, ClientError>
+    async fn request<B>(&self, cx: &ClientContext, req: Request<B>) -> Result<Response, ClientError>
     where
         B: http_body::Body + Send + 'static,
         B::Data: Send,
@@ -131,19 +127,19 @@ impl ClientTransport {
     }
 }
 
-impl<B> Service<ClientContext, ClientRequest<B>> for ClientTransport
+impl<B> Service<ClientContext, Request<B>> for ClientTransport
 where
     B: http_body::Body + Send + 'static,
     B::Data: Send,
     B::Error: Into<Box<dyn Error + Send + Sync>> + 'static,
 {
-    type Response = ClientResponse;
+    type Response = Response;
     type Error = ClientError;
 
     async fn call(
         &self,
         cx: &mut ClientContext,
-        req: ClientRequest<B>,
+        req: Request<B>,
     ) -> Result<Self::Response, Self::Error> {
         let stat_enabled = self.config.stat_enable;
 

--- a/volo-http/src/error/server.rs
+++ b/volo-http/src/error/server.rs
@@ -4,7 +4,7 @@ use std::{error::Error, fmt};
 
 use http::StatusCode;
 
-use crate::{response::ServerResponse, server::IntoResponse};
+use crate::{response::Response, server::IntoResponse};
 
 /// [`Error`]s when extracting something from a [`Body`](crate::body::Body)
 #[derive(Debug)]
@@ -52,7 +52,7 @@ impl Error for ExtractBodyError {
 }
 
 impl IntoResponse for ExtractBodyError {
-    fn into_response(self) -> ServerResponse {
+    fn into_response(self) -> Response {
         let status = match self {
             Self::Generic(e) => e.to_status_code(),
             Self::String(_) => StatusCode::UNSUPPORTED_MEDIA_TYPE,
@@ -98,7 +98,7 @@ impl GenericRejectionError {
 }
 
 impl IntoResponse for GenericRejectionError {
-    fn into_response(self) -> ServerResponse {
+    fn into_response(self) -> Response {
         self.to_status_code().into_response()
     }
 }

--- a/volo-http/src/request.rs
+++ b/volo-http/src/request.rs
@@ -4,22 +4,29 @@ use std::str::FromStr;
 
 use http::{
     header::{self, HeaderMap, HeaderName},
-    request::{Parts, Request},
+    request::Parts,
     uri::{Scheme, Uri},
 };
 use url::Url;
 
-/// [`Request`] with [`Body`] as default body.
+use crate::body::Body;
+
+/// [`Request`](http::request::Request) with [`Body`] as default body.
+///
+/// [`Body`]: crate::body::Body
+pub type Request<B = Body> = http::request::Request<B>;
+
+/// [`Request`](http::request::Request) with [`Body`] as default body.
 ///
 /// [`Body`]: crate::body::Body
 #[cfg(feature = "client")]
-pub type ClientRequest<B = crate::body::Body> = Request<B>;
+#[deprecated(note = "`ClientRequest` has been renamed to `Request`")]
+pub type ClientRequest<B = Body> = Request<B>;
 
-/// [`Request`] with [`Body`] as default body.
-///
-/// [`Body`]: crate::body::Body
+/// [`Request`](http::request::Request) with [`Body`] as default body.
 #[cfg(feature = "server")]
-pub type ServerRequest<B = crate::body::Body> = Request<B>;
+#[deprecated(note = "`ServerRequest` has been renamed to `Request`")]
+pub type ServerRequest<B = Body> = Request<B>;
 
 /// HTTP header [`X-Forwarded-For`][mdn].
 ///

--- a/volo-http/src/response.rs
+++ b/volo-http/src/response.rs
@@ -1,15 +1,22 @@
 //! Response types for client and server.
 
-/// [`Response`] with [`Body`] as default body
-///
-/// [`Response`]: http::response::Response
-/// [`Body`]: crate::body::Body
-#[cfg(feature = "server")]
-pub type ServerResponse<B = crate::body::Body> = http::response::Response<B>;
+use crate::body::Body;
 
 /// [`Response`] with [`Body`] as default body
 ///
 /// [`Response`]: http::response::Response
-/// [`Body`]: crate::body::Body
+pub type Response<B = Body> = http::response::Response<B>;
+
+/// [`Response`] with [`Body`] as default body
+///
+/// [`Response`]: http::response::Response
+#[cfg(feature = "server")]
+#[deprecated(note = "`ServerResponse` has been renamed to `Response`")]
+pub type ServerResponse<B = Body> = Response<B>;
+
+/// [`Response`] with [`Body`] as default body
+///
+/// [`Response`]: http::response::Response
 #[cfg(feature = "client")]
-pub type ClientResponse<B = crate::body::Body> = http::response::Response<B>;
+#[deprecated(note = "`ClientResponse` has been renamed to `Response`")]
+pub type ClientResponse<B = Body> = Response<B>;

--- a/volo-http/src/server/mod.rs
+++ b/volo-http/src/server/mod.rs
@@ -34,8 +34,8 @@ use volo::{
 use crate::{
     body::Body,
     context::{server::Config, ServerContext},
-    request::ServerRequest,
-    response::ServerResponse,
+    request::Request,
+    response::Response,
 };
 
 pub mod extract;
@@ -262,13 +262,12 @@ impl<S, L> Server<S, L> {
     /// The main entry point for the server.
     pub async fn run<MI, B, E>(self, mk_incoming: MI) -> Result<(), BoxError>
     where
-        S: Service<ServerContext, ServerRequest<B>, Error = E> + Send + Sync + 'static,
+        S: Service<ServerContext, Request<B>, Error = E> + Send + Sync + 'static,
         S::Response: IntoResponse,
         E: IntoResponse,
         L: Layer<S> + Send + Sync + 'static,
-        L::Service:
-            Service<ServerContext, ServerRequest, Error = Infallible> + Send + Sync + 'static,
-        <L::Service as Service<ServerContext, ServerRequest>>::Response: IntoResponse,
+        L::Service: Service<ServerContext, Request, Error = Infallible> + Send + Sync + 'static,
+        <L::Service as Service<ServerContext, Request>>::Response: IntoResponse,
         MI: MakeIncoming,
     {
         let server = Arc::new(self.server);
@@ -368,7 +367,7 @@ async fn serve<I, S, E>(
     #[cfg(feature = "__tls")] tls_config: Option<ServerTlsConfig>,
 ) where
     I: Incoming,
-    S: Service<ServerContext, ServerRequest, Error = E> + Clone + Send + Sync + 'static,
+    S: Service<ServerContext, Request, Error = E> + Clone + Send + Sync + 'static,
     S::Response: IntoResponse,
     E: IntoResponse,
 {
@@ -479,11 +478,11 @@ type HyperRequest = http::request::Request<hyper::body::Incoming>;
 
 impl<S, E> hyper::service::Service<HyperRequest> for HyperService<S>
 where
-    S: Service<ServerContext, ServerRequest, Error = E> + Clone + Send + Sync + 'static,
+    S: Service<ServerContext, Request, Error = E> + Clone + Send + Sync + 'static,
     S::Response: IntoResponse,
     E: IntoResponse,
 {
-    type Response = ServerResponse;
+    type Response = Response;
     type Error = Infallible;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 

--- a/volo-http/src/server/panic_handler.rs
+++ b/volo-http/src/server/panic_handler.rs
@@ -1,7 +1,7 @@
 //! Collections for some panic handlers
 //!
 //! [`volo::catch_panic::Layer`] can handle panics in services and when panic occurs, it can
-//! respond a [`ServerResponse`]. This module has some useful handlers for handling panics and
+//! respond a [`Response`]. This module has some useful handlers for handling panics and
 //! returning a response.
 
 use std::any::Any;
@@ -11,7 +11,7 @@ use motore::service::Service;
 use volo::catch_panic;
 
 use super::IntoResponse;
-use crate::response::ServerResponse;
+use crate::response::Response;
 
 /// Panic handler which can return a fixed payload.
 ///
@@ -23,7 +23,7 @@ pub struct FixedPayload<R> {
 
 impl<S, Cx, Req, Resp> catch_panic::Handler<S, Cx, Req> for FixedPayload<Resp>
 where
-    S: Service<Cx, Req, Response = ServerResponse> + Send + Sync + 'static,
+    S: Service<Cx, Req, Response = Response> + Send + Sync + 'static,
     Cx: Send + 'static,
     Req: Send + 'static,
     Resp: IntoResponse + Clone,
@@ -45,7 +45,7 @@ pub fn always_internal_error<Cx, E>(
     _: &mut Cx,
     _: Box<dyn Any + Send>,
     panic_info: catch_panic::PanicInfo,
-) -> Result<ServerResponse, E> {
+) -> Result<Response, E> {
     tracing::error!("[Volo-HTTP] panic_handler: {panic_info}");
     Ok(StatusCode::INTERNAL_SERVER_ERROR.into_response())
 }

--- a/volo-http/src/server/param.rs
+++ b/volo-http/src/server/param.rs
@@ -15,8 +15,7 @@ use matchit::Params;
 
 use super::{extract::FromContext, IntoResponse};
 use crate::{
-    context::ServerContext, error::BoxError, response::ServerResponse,
-    utils::macros::all_the_tuples,
+    context::ServerContext, error::BoxError, response::Response, utils::macros::all_the_tuples,
 };
 
 /// Collected params from request uri
@@ -292,7 +291,7 @@ impl Error for PathParamsRejection {
 }
 
 impl IntoResponse for PathParamsRejection {
-    fn into_response(self) -> ServerResponse {
+    fn into_response(self) -> Response {
         StatusCode::BAD_REQUEST.into_response()
     }
 }

--- a/volo-http/src/server/response/redirect.rs
+++ b/volo-http/src/server/response/redirect.rs
@@ -4,7 +4,7 @@ use http::{
 };
 
 use super::IntoResponse;
-use crate::{body::Body, response::ServerResponse};
+use crate::{body::Body, response::Response};
 
 /// Response with 3XX Status Code and specified `Location`
 pub struct Redirect {
@@ -85,8 +85,8 @@ impl Redirect {
 }
 
 impl IntoResponse for Redirect {
-    fn into_response(self) -> ServerResponse {
-        ServerResponse::builder()
+    fn into_response(self) -> Response {
+        Response::builder()
             .status(self.status)
             .header(header::LOCATION, self.location)
             .body(Body::default())

--- a/volo-http/src/server/response/sse.rs
+++ b/volo-http/src/server/response/sse.rs
@@ -18,7 +18,7 @@ use pin_project::pin_project;
 use tokio::time::{Instant, Sleep};
 
 use super::IntoResponse;
-use crate::{body::Body, error::BoxError, response::ServerResponse};
+use crate::{body::Body, error::BoxError, response::Response};
 
 /// Response of [SSE][sse] (Server-Sent Events), inclusing a stream with SSE [`Event`]s.
 ///
@@ -49,8 +49,8 @@ where
     S: Stream<Item = Result<Event, E>> + Send + Sync + 'static,
     E: Into<BoxError>,
 {
-    fn into_response(self) -> ServerResponse {
-        ServerResponse::builder()
+    fn into_response(self) -> Response {
+        Response::builder()
             .header(
                 header::CONTENT_TYPE,
                 HeaderValue::from_str(mime::TEXT_EVENT_STREAM.essence_str()).expect("infallible"),

--- a/volo-http/src/server/route/utils.rs
+++ b/volo-http/src/server/route/utils.rs
@@ -9,7 +9,7 @@ use std::{
 use http::uri::Uri;
 use motore::{layer::Layer, service::Service};
 
-use crate::{context::ServerContext, request::ServerRequest, response::ServerResponse};
+use crate::{context::ServerContext, request::Request, response::Response};
 
 // The `matchit::Router` cannot be converted to `Iterator`, so using
 // `matchit::Router<MethodRouter>` is not convenient enough.
@@ -118,17 +118,17 @@ pub(super) struct StripPrefix<S> {
     inner: S,
 }
 
-impl<S, B, E> Service<ServerContext, ServerRequest<B>> for StripPrefix<S>
+impl<S, B, E> Service<ServerContext, Request<B>> for StripPrefix<S>
 where
-    S: Service<ServerContext, ServerRequest<B>, Response = ServerResponse, Error = E>,
+    S: Service<ServerContext, Request<B>, Response = Response, Error = E>,
 {
-    type Response = ServerResponse;
+    type Response = Response;
     type Error = E;
 
     fn call(
         &self,
         cx: &mut ServerContext,
-        mut req: ServerRequest<B>,
+        mut req: Request<B>,
     ) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send {
         let mut uri = String::from("/");
         if cx

--- a/volo-http/src/server/utils/file_response.rs
+++ b/volo-http/src/server/utils/file_response.rs
@@ -14,7 +14,7 @@ use pin_project::pin_project;
 use tokio::io::AsyncRead;
 use tokio_util::io::ReaderStream;
 
-use crate::{body::Body, response::ServerResponse, server::IntoResponse};
+use crate::{body::Body, response::Response, server::IntoResponse};
 
 const BUF_SIZE: usize = 4096;
 
@@ -52,9 +52,9 @@ impl FileResponse {
 }
 
 impl IntoResponse for FileResponse {
-    fn into_response(self) -> ServerResponse {
+    fn into_response(self) -> Response {
         let file = tokio::fs::File::from_std(self.file);
-        ServerResponse::builder()
+        Response::builder()
             .header(header::CONTENT_TYPE, self.content_type)
             .body(Body::from_body(FileBody {
                 reader: ReaderStream::with_capacity(file, BUF_SIZE),

--- a/volo-http/src/server/utils/multipart.rs
+++ b/volo-http/src/server/utils/multipart.rs
@@ -8,7 +8,7 @@
 //! ```rust
 //! use http::StatusCode;
 //! use volo_http::{
-//!     response::ServerResponse,
+//!     response::Response,
 //!     server::{
 //!         route::post,
 //!         utils::multipart::{Multipart, MultipartRejectionError},
@@ -58,7 +58,7 @@ use crate::{
 /// ```rust
 /// use http::StatusCode;
 /// use volo_http::{
-///     response::ServerResponse,
+///     response::Response,
 ///     server::utils::multipart::{Multipart, MultipartRejectionError},
 /// };
 ///
@@ -217,8 +217,8 @@ mod multipart_tests {
 
     use crate::{
         context::ServerContext,
-        request::ServerRequest,
-        response::ServerResponse,
+        request::Request,
+        response::Response,
         server::{
             test_helpers,
             utils::multipart::{Multipart, MultipartRejectionError},
@@ -239,7 +239,7 @@ mod multipart_tests {
 
     async fn run_handler<S>(service: S, port: u16)
     where
-        S: Service<ServerContext, ServerRequest, Response = ServerResponse, Error = Infallible>
+        S: Service<ServerContext, Request, Response = Response, Error = Infallible>
             + Send
             + Sync
             + 'static,

--- a/volo-http/src/server/utils/serve_dir.rs
+++ b/volo-http/src/server/utils/serve_dir.rs
@@ -29,9 +29,7 @@ use http::{header::HeaderValue, status::StatusCode};
 use motore::service::Service;
 
 use super::FileResponse;
-use crate::{
-    context::ServerContext, request::ServerRequest, response::ServerResponse, server::IntoResponse,
-};
+use crate::{context::ServerContext, request::Request, response::Response, server::IntoResponse};
 
 /// [`ServeDir`] is a service for sending files from a given directory.
 pub struct ServeDir<E, F> {
@@ -76,18 +74,18 @@ impl<E> ServeDir<E, fn(&Path) -> HeaderValue> {
     }
 }
 
-impl<B, E, F> Service<ServerContext, ServerRequest<B>> for ServeDir<E, F>
+impl<B, E, F> Service<ServerContext, Request<B>> for ServeDir<E, F>
 where
     B: Send,
     F: Fn(&Path) -> HeaderValue + Sync,
 {
-    type Response = ServerResponse;
+    type Response = Response;
     type Error = E;
 
     async fn call(
         &self,
         _: &mut ServerContext,
-        req: ServerRequest<B>,
+        req: Request<B>,
     ) -> Result<Self::Response, Self::Error> {
         // Get relative path from uri
         let path = req.uri().path();

--- a/volo-http/src/utils/extension.rs
+++ b/volo-http/src/utils/extension.rs
@@ -76,7 +76,7 @@ mod server {
     use super::Extension;
     use crate::{
         context::ServerContext,
-        response::ServerResponse,
+        response::Response,
         server::{extract::FromContext, IntoResponse},
     };
 
@@ -103,7 +103,7 @@ mod server {
     }
 
     impl IntoResponse for ExtensionRejection {
-        fn into_response(self) -> ServerResponse {
+        fn into_response(self) -> Response {
             StatusCode::INTERNAL_SERVER_ERROR.into_response()
         }
     }

--- a/volo-http/src/utils/test_helpers.rs
+++ b/volo-http/src/utils/test_helpers.rs
@@ -39,36 +39,36 @@ mod convert_service {
     use crate::{
         context::{server::ServerCxInner, ClientContext, ServerContext},
         error::{client::request_error, BoxError, ClientError},
-        request::{ClientRequest, ServerRequest},
-        response::{ClientResponse, ServerResponse},
+        request::Request,
+        response::Response,
     };
 
-    /// A wrapper that can convert a [`Service`] with [`ServerContext`] and [`ServerRequest`] to
-    /// [`ClientContext`] and [`ClientRequest`].
+    /// A wrapper that can convert a [`Service`] with [`ServerContext`] and [`Request`] to
+    /// [`ClientContext`] and [`Request`].
     pub struct ConvertService<S> {
         inner: S,
     }
 
     impl<S> ConvertService<S> {
         /// Create a [`ConvertService`] by a [`Service`] with [`ServerContext`] and
-        /// [`ServerRequest`].
+        /// [`Request`].
         pub fn new(inner: S) -> Self {
             Self { inner }
         }
     }
 
-    impl<S> Service<ClientContext, ClientRequest> for ConvertService<S>
+    impl<S> Service<ClientContext, Request> for ConvertService<S>
     where
-        S: Service<ServerContext, ServerRequest, Response = ServerResponse> + Send + Sync,
+        S: Service<ServerContext, Request, Response = Response> + Send + Sync,
         S::Error: Into<BoxError>,
     {
-        type Response = ClientResponse;
+        type Response = Response;
         type Error = ClientError;
 
         async fn call(
             &self,
             cx: &mut ClientContext,
-            req: ClientRequest,
+            req: Request,
         ) -> Result<Self::Response, Self::Error> {
             let mut server_cx = client_cx_to_server_cx(cx);
             self.inner


### PR DESCRIPTION
## Motivation

Since `Body` types of client and server have been combined, there is no need to split request/response into `ClientXXX` and `ServerXXX`.

## Solution

Combine `ClientRequest` and `ServerResquest` to `Request`, `ClientResponse` and `ServerResponse` to `Response`.

To avoid too many breaking changes, the original types have not been removed but are marked as deprecated.