### PR TITLE
chore(volo-build): fix clippy warning `unnecessary_map_or`

### DIFF
--- a/volo-build/src/util.rs
+++ b/volo-build/src/util.rs
@@ -310,7 +310,7 @@ pub fn git_repo_init(path: &Path) -> anyhow::Result<()> {
     fn in_git_repo(path: &Path) -> bool {
         if let Ok(repo) = git2::Repository::discover(path) {
             // Don't check if the working directory itself is ignored.
-            if repo.workdir().map_or(false, |workdir| workdir == path) {
+            if repo.workdir() == Some(path) {
                 true
             } else {
                 !repo.is_path_ignored(path).unwrap_or(false)


### PR DESCRIPTION
## Motivation

Fix clippy warning `unnecessary_map_or`

```
error: this `map_or` is redundant
   --> volo-build/src/util.rs:313:16
    |
313 |             if repo.workdir().map_or(false, |workdir| workdir == path) {
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use a standard comparison instead: `(repo.workdir() == Some(path))`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or
    = note: `-D clippy::unnecessary-map-or` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_map_or)]`
```

## Solution

Fix it