### PR TITLE
fix(volo-http): add mime parsing in server, do not always prefer ipv4 in client dns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4187,7 +4187,7 @@ dependencies = [
 
 [[package]]
 name = "volo-http"
-version = "0.3.0-rc.3"
+version = "0.3.0"
 dependencies = [
  "ahash",
  "async-broadcast",

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -22,29 +22,22 @@ maintenance = { status = "actively-developed" }
 volo = { version = "0.10", path = "../volo" }
 
 ahash.workspace = true
-async-broadcast.workspace = true
 bytes.workspace = true
-chrono.workspace = true
 faststr.workspace = true
 futures.workspace = true
 futures-util.workspace = true
-hickory-resolver.workspace = true
 http.workspace = true
 http-body.workspace = true
 http-body-util.workspace = true
 hyper.workspace = true
 hyper-util = { workspace = true, features = ["tokio"] }
-ipnet.workspace = true
 itoa.workspace = true
-memchr.workspace = true
 metainfo.workspace = true
 mime.workspace = true
-mime_guess.workspace = true
 motore.workspace = true
 parking_lot.workspace = true
 paste.workspace = true
 pin-project.workspace = true
-scopeguard.workspace = true
 simdutf8.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = [
@@ -62,7 +55,16 @@ url.workspace = true
 # =====optional=====
 
 # server optional
-matchit = { workspace = true, optional = true }
+ipnet = { workspace = true, optional = true } # client ip
+matchit = { workspace = true, optional = true } # route matching
+memchr = { workspace = true, optional = true } # sse
+scopeguard = { workspace = true, optional = true } # defer
+
+# client optional
+async-broadcast = { workspace = true, optional = true } # service discover
+chrono = { workspace = true, optional = true } # stat
+hickory-resolver = { workspace = true, optional = true } # dns resolver
+mime_guess = { workspace = true, optional = true }
 
 # serde and form, query, json
 serde = { workspace = true, optional = true }
@@ -106,8 +108,14 @@ full = [
 
 http1 = ["hyper/http1", "hyper-util/http1"]
 
-client = ["http1", "hyper/client"] # client core
-server = ["http1", "hyper-util/server", "dep:matchit"] # server core
+client = [
+    "http1", "hyper/client",
+    "dep:async-broadcast", "dep:chrono", "dep:hickory-resolver",
+] # client core
+server = [
+    "http1", "hyper-util/server",
+    "dep:ipnet", "dep:matchit", "dep:memchr", "dep:scopeguard", "dep:mime_guess",
+] # server core
 
 __serde = ["dep:serde"] # a private feature for enabling `serde` by `serde_xxx`
 query = ["__serde", "dep:serde_urlencoded"]

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-http"
-version = "0.3.0-rc.3"
+version = "0.3.0"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Motivation

This PR fixes two bugs

### `Form` extractor reject mime of form with charset

In the previous implementation, the `Form` extractor directly compared `Content-Type` and rejected the form if `Content-Type` was not `application/x-www-form-urlencoded`.

But sometimes `Content-Type` could be `application/x-www-form-urlencoded; charset=utf-8`, which is actually a valid mime for the form, but we incorrectly rejected it.

### DNS resolver always prefer IPv4 addresses

We use the `hickory_resolver` crate to resolve domain names, but we found that it always prefers IPv4 addresses, which doesn't work if the client is running in an IPv6 only environment.

## Solution

- Check `Content-Type` by parsing instead of directly comparing the string.
- Check the first name server, if the address is an IPv4 address we keep preferring IPv4 addresses, if it is an IPv6 address we set the resolver to prefer IPv6 addresses.

In addition, we bump Volo-HTTP to 0.3.0 here.