### PR TITLE
fix(volo-thrift): clean waiters while failed waiting for idle connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4243,7 +4243,7 @@ version = "0.10.0"
 
 [[package]]
 name = "volo-thrift"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "ahash",
  "anyhow",

--- a/volo-thrift/Cargo.toml
+++ b/volo-thrift/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-thrift"
-version = "0.10.5"
+version = "0.10.6"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true


### PR DESCRIPTION
In the previous implementation of the connection pool , if there is no connection available at all, the tx in the waiter list will keep be inserted and never be cleared, resulting in memory leaks.

This PR solves this problem by clearing the corresponding tx in the waiting queue when rx drops.