### PR TITLE
chore(volo-thrift): use error message rather than panic for the bytes decode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4237,7 +4237,7 @@ version = "0.10.0"
 
 [[package]]
 name = "volo-thrift"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "ahash",
  "anyhow",

--- a/volo-cli/src/repo/add.rs
+++ b/volo-cli/src/repo/add.rs
@@ -30,11 +30,10 @@ pub struct Add {
 impl CliCommand for Add {
     fn run(&self, cx: Context) -> anyhow::Result<()> {
         volo_build::util::with_config(|config| {
-            let entry = if config.entries.contains_key(&cx.entry_name) {
-                config.entries.get_mut(&cx.entry_name).unwrap()
-            } else {
-                unreachable!("The specified entry should exist when add new repo.");
-            };
+            let entry = config
+                .entries
+                .get_mut(&cx.entry_name)
+                .expect("The specified entry should exist when add new repo.");
 
             let mut new_repo = None;
             // repo name is valid when the repo and git arg are not conflicted with the entry's

--- a/volo-cli/src/repo/update.rs
+++ b/volo-cli/src/repo/update.rs
@@ -38,17 +38,19 @@ impl CliCommand for Update {
             }
 
             // check if the repo exists in the config
-            self.repos.iter().for_each(|g| {
-                if !entry.repos.contains_key(&FastStr::new(g)) {
-                    eprintln!("git repo {g} not exists in config");
-                } else {
-                    let r = entry.repos.get_mut(&FastStr::new(g)).unwrap().update();
-                    if r.is_err() {
-                        eprintln!("update git repo {g} failed");
+            self.repos
+                .iter()
+                .for_each(|g| match entry.repos.get_mut(&FastStr::new(g)) {
+                    Some(r) => {
+                        let r = r.update();
+                        if r.is_err() {
+                            eprintln!("update git repo {g} failed");
+                        }
                     }
-                }
-            });
-
+                    None => {
+                        eprintln!("git repo {g} not exists in config");
+                    }
+                });
             Ok(())
         })
     }

--- a/volo-thrift/Cargo.toml
+++ b/volo-thrift/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-thrift"
-version = "0.10.7"
+version = "0.10.8"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-thrift/src/message.rs
+++ b/volo-thrift/src/message.rs
@@ -3,8 +3,8 @@ use std::{future::Future, sync::Arc};
 use bytes::{Buf, Bytes};
 pub use pilota::thrift::Message;
 use pilota::thrift::{
-    TAsyncInputProtocol, TInputProtocol, TLengthProtocol, TMessageIdentifier, TOutputProtocol,
-    ThriftException,
+    ProtocolException, TAsyncInputProtocol, TInputProtocol, TLengthProtocol, TMessageIdentifier,
+    TOutputProtocol, ThriftException,
 };
 
 pub trait EntryMessage: Sized + Send {
@@ -76,7 +76,11 @@ impl EntryMessage for Bytes {
         _protocol: &mut T,
         _msg_ident: &TMessageIdentifier,
     ) -> Result<Self, ThriftException> {
-        unreachable!();
+        Err(ThriftException::Protocol(ProtocolException::new(
+            pilota::thrift::ProtocolExceptionKind::NotImplemented,
+            "Binary repost is not supported in pure Buffered protocol since we don't know the \
+             length of the message",
+        )))
     }
 
     fn size<T: TLengthProtocol>(&self, _protocol: &mut T) -> usize {

--- a/volo-thrift/src/message.rs
+++ b/volo-thrift/src/message.rs
@@ -78,8 +78,8 @@ impl EntryMessage for Bytes {
     ) -> Result<Self, ThriftException> {
         Err(ThriftException::Protocol(ProtocolException::new(
             pilota::thrift::ProtocolExceptionKind::NotImplemented,
-            "Binary repost is not supported in pure Buffered protocol since we don't know the \
-             length of the message",
+            "Binary response decode is not supported for pure Buffered protocol since we don't \
+             know the length of the message",
         )))
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/volo/blob/main/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
We don't support the pure Buffered protocpol for binary repost, and we will panic directly which might confuse the user without error message.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Use error message to tell the user what happened.
