### PR TITLE
fix(volo): select rustls crypto provider through feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4045,7 +4045,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "volo"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "async-broadcast",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ url_path = "0.1"
 walkdir = "2"
 
 # Optional dependencies
-rustls = "0.23"
+rustls = { version = "0.23", default-features = false, features = ["std", "tls12"] }
 rustls-pemfile = "2"
 rustls-pki-types = "1"
 webpki-roots = "0.26"

--- a/scripts/clippy-and-test.sh
+++ b/scripts/clippy-and-test.sh
@@ -35,6 +35,8 @@ echo_command cargo clippy -p volo-http --no-default-features --features default-
 echo_command cargo clippy -p volo-http --no-default-features --features client,server -- --deny warnings
 echo_command cargo clippy -p volo-http --no-default-features --features full -- --deny warnings
 echo_command cargo clippy -p volo -- --deny warnings
+echo_command cargo clippy -p volo --no-default-features --features rustls-aws-lc-rs -- --deny warnings
+echo_command cargo clippy -p volo --no-default-features --features rustls-ring -- --deny warnings
 echo_command cargo clippy -p volo-build -- --deny warnings
 echo_command cargo clippy -p volo-cli -- --deny warnings
 echo_command cargo clippy -p volo-macros -- --deny warnings

--- a/volo/Cargo.toml
+++ b/volo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo"
-version = "0.10.5"
+version = "0.10.6"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
@@ -64,8 +64,11 @@ default = []
 unsafe_unchecked = [
 ] # This will use unwrap_unchecked instead of unwrap in some places.
 
+tls = ["rustls"]
 __tls = []
-rustls = [
+
+rustls = ["rustls-aws-lc-rs"]
+__rustls = [
     "__tls",
     "dep:rustls",
     "dep:rustls-pemfile",
@@ -73,5 +76,8 @@ rustls = [
     "dep:webpki-roots",
     "dep:tokio-rustls",
 ]
+rustls-aws-lc-rs = ["__rustls", "rustls/aws_lc_rs"]
+rustls-ring = ["__rustls", "rustls/ring"]
+
 native-tls = ["__tls", "dep:native-tls", "dep:tokio-native-tls"]
 native-tls-vendored = ["native-tls", "tokio-native-tls/vendored"]


### PR DESCRIPTION
## Motivation

`rustls` 0.23 uses `aws_lc_rs` as its crypto provider by default, while `ring` is another available crypto provider. If there is only one crypto provider, `rustls` will use it. But if more than one provider is selected, `rustls` will panic.

## Solution

To fix it, we introduced the features `rustls-aws-lc-rs` and `rustls-ring`, the former `rustls` is now an alias for `rustls-aws-lc-rs`.
