### PR TITLE
refactor(server): Remove the decreasing operation of the connection c…

### DIFF
--- a/volo-thrift/src/server/mod.rs
+++ b/volo-thrift/src/server/mod.rs
@@ -475,5 +475,4 @@ async fn handle_conn_multiplex<R, W, Req, Svc, Resp, MkC>(
         peer_addr,
     )
     .await;
-    conn_cnt.fetch_sub(1, Ordering::Relaxed);
 }


### PR DESCRIPTION
…ounter

The 'conn_cnt. fetch_stub (1, Ordering:: Relaxed)' function has been removed because the management of the connection counter is already handled by other mechanisms and there is no need to repeat the operation here

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/volo/blob/main/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
