### PR TITLE
fix(ci): add clippy for examples with tls and fix build errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,11 +212,10 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "de45108900e1f9b9242f7f2e254aa3e2c029c921c258fe9e6b4217eeebd54288"
 dependencies = [
- "async-trait",
  "axum-core",
  "bytes",
  "futures-util",
@@ -218,7 +223,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "itoa",
- "matchit 0.7.3",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -233,13 +238,12 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
 dependencies = [
- "async-trait",
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "http-body-util",
@@ -565,6 +569,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,6 +868,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,6 +1015,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bd114ceda131d3b1d665eba35788690ad37f5916457286b32ab6fd3c438dd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows 0.58.0",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,9 +1091,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "governor"
-version = "0.8.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be93b4ec2e4710b04d9264c0c7350cdd62a8c20e5e4ac732552ebb8f0debe8eb"
+checksum = "3cbe789d04bf14543f03c4b60cd494148aa79438c8440ae7d81a7778147745c3"
 dependencies = [
  "cfg-if",
  "dashmap",
@@ -1063,7 +1101,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "getrandom 0.3.1",
- "no-std-compat",
+ "hashbrown 0.15.2",
  "nonzero_ext",
  "parking_lot 0.12.3",
  "portable-atomic",
@@ -1110,6 +1148,11 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -1140,12 +1183,14 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hickory-proto"
-version = "0.24.4"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
+checksum = "6d844af74f7b799e41c78221be863bade11c430d46042c3b49ca8ae0c6d27287"
 dependencies = [
+ "async-recursion",
  "async-trait",
  "cfg-if",
+ "critical-section",
  "data-encoding",
  "enum-as-inner",
  "futures-channel",
@@ -1154,8 +1199,9 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.8.5",
- "thiserror 1.0.69",
+ "rand 0.9.0",
+ "ring",
+ "thiserror 2.0.11",
  "tinyvec",
  "tokio",
  "tracing",
@@ -1164,21 +1210,21 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.24.4"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
+checksum = "a128410b38d6f931fcc6ca5c107a3b02cabd6c05967841269a4ad65d23c44331"
 dependencies = [
  "cfg-if",
  "futures-util",
  "hickory-proto",
  "ipconfig",
- "lru-cache",
+ "moka",
  "once_cell",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand 0.9.0",
  "resolv-conf",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "tokio",
  "tracing",
 ]
@@ -1644,9 +1690,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libgit2-sys"
@@ -1744,12 +1790,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
-name = "lru-cache"
-version = "0.1.2"
+name = "loom"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
 dependencies = [
- "linked-hash-map",
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1769,15 +1819,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "matchit"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f926ade0c4e170215ae43342bf13b9310a437609c81f29f86c5df6657582ef9"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -1888,6 +1932,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9321642ca94a4282428e6ea4af8cc2ca4eac48ac7a6a4ea8f33f76d0ce70926"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "loom",
+ "parking_lot 0.12.3",
+ "portable-atomic",
+ "rustc_version",
+ "smallvec",
+ "tagptr",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
 name = "motore"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,12 +2048,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "no-std-compat"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2080,6 +2137,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+dependencies = [
+ "bitflags 2.8.0",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2093,6 +2159,10 @@ name = "once_cell"
 version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "oorandom"
@@ -2986,6 +3056,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3293,10 +3372,11 @@ dependencies = [
 
 [[package]]
 name = "sonic-rs"
-version = "0.3.17"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0275f9f2f07d47556fe60c2759da8bc4be6083b047b491b2d476aa0bfa558eb1"
+checksum = "afb178c7e517ce712b9ddfe3ccc0f22e6b44943b690a018fd8eb8df0a47c0311"
 dependencies = [
+ "ahash",
  "bumpalo",
  "bytes",
  "cfg-if",
@@ -3397,16 +3477,15 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.33.1"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+checksum = "a4b93974b3d3aeaa036504b8eefd4c039dced109171c1ae973f1dc63b2c7e4b2"
 dependencies = [
- "core-foundation-sys",
  "libc",
  "memchr",
  "ntapi",
- "rayon",
- "windows",
+ "objc2-core-foundation",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -3429,6 +3508,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
@@ -3710,11 +3795,10 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "85839f0b32fd242bb3209262371d07feda6d780d16ee9d2bc88581b89da1549b"
 dependencies = [
- "async-stream",
  "async-trait",
  "axum",
  "base64",
@@ -3732,7 +3816,7 @@ dependencies = [
  "socket2",
  "tokio",
  "tokio-stream",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3740,19 +3824,17 @@ dependencies = [
 
 [[package]]
 name = "tonic-web"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5299dd20801ad736dccb4a5ea0da7376e59cd98f213bf1c3d478cf53f4834b58"
+checksum = "ad8e4a5564e49598cbdefefb5b982c243b11009bdaf36ad59487c2253cb73379"
 dependencies = [
  "base64",
  "bytes",
  "http",
  "http-body",
- "http-body-util",
  "pin-project",
  "tokio-stream",
  "tonic",
- "tower-http",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3764,15 +3846,6 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3795,22 +3868,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
-dependencies = [
- "bitflags 2.8.0",
- "bytes",
- "http",
- "http-body",
- "http-body-util",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -4024,6 +4081,9 @@ name = "uuid"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
+dependencies = [
+ "getrandom 0.3.1",
+]
 
 [[package]]
 name = "valuable"
@@ -4159,7 +4219,7 @@ dependencies = [
  "hyper",
  "hyper-timeout",
  "hyper-util",
- "matchit 0.8.6",
+ "matchit",
  "metainfo",
  "motore",
  "percent-encoding",
@@ -4202,7 +4262,7 @@ dependencies = [
  "ipnet",
  "itoa",
  "libc",
- "matchit 0.8.6",
+ "matchit",
  "memchr",
  "metainfo",
  "mime",
@@ -4457,6 +4517,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4471,9 +4541,22 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
  "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings",
  "windows-targets 0.52.6",
 ]
 
@@ -4489,10 +4572,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "windows-interface"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,13 +27,7 @@ rust-version = "1.80.0"
 pilota = "0.11"
 pilota-build = "0.11"
 pilota-thrift-parser = "0.11"
-# pilota = { git = "https://github.com/cloudwego/pilota.git", branch = "main" }
-# pilota-build = { git = "https://github.com/cloudwego/pilota.git", branch = "main" }
-# pilota-thrift-parser = { git = "https://github.com/cloudwego/pilota.git", branch = "main" }
-
 motore = "0.4"
-# motore = { git = "https://github.com/cloudwego/motore.git", branch = "main" }
-
 metainfo = "0.7"
 
 ahash = "0.8"
@@ -58,11 +52,11 @@ futures = "0.3"
 futures-util = "0.3"
 flate2 = "1"
 git2 = { version = "0.20", default-features = false }
-governor = "0.8"
+governor = "0.10"
 h2 = "0.4"
 heck = "0.5"
 hex = "0.4"
-hickory-resolver = "0.24"
+hickory-resolver = "0.25"
 http = "1"
 http-body = "1"
 http-body-util = "0.1"
@@ -110,17 +104,17 @@ serde_urlencoded = "0.7"
 serde_yaml = "0.9"
 simdutf8 = "0.1"
 socket2 = "0.5"
-sonic-rs = "0.3"
+sonic-rs = "0.5"
 syn = "2"
-sysinfo = "0.33"
+sysinfo = "0.34"
 tempfile = "3"
 thiserror = "2"
 tokio = "1"
 tokio-stream = "0.1"
 tokio-test = "0.4"
 tokio-util = "0.7"
-tonic = "0.12"
-tonic-web = "0.12"
+tonic = "0.13"
+tonic-web = "0.13"
 tower = "0.5"
 tracing = "0.1"
 tracing-subscriber = "0.3"
@@ -152,3 +146,10 @@ codegen-units = 1
 panic = 'unwind'
 incremental = false
 overflow-checks = false
+
+[patch.crates-io]
+# pilota = { git = "https://github.com/cloudwego/pilota.git", branch = "main" }
+# pilota-build = { git = "https://github.com/cloudwego/pilota.git", branch = "main" }
+# pilota-thrift-parser = { git = "https://github.com/cloudwego/pilota.git", branch = "main" }
+# motore = { git = "https://github.com/cloudwego/motore.git", branch = "main" }
+# metainfo = { git = "https://github.com/cloudwego/metainfo.git", branch = "main"}

--- a/benchmark/src/runner/counter.rs
+++ b/benchmark/src/runner/counter.rs
@@ -103,6 +103,6 @@ impl Counter {
                 total
             )
         };
-        println!("{}", result);
+        println!("{result}");
     }
 }

--- a/benchmark/src/runner/processor.rs
+++ b/benchmark/src/runner/processor.rs
@@ -35,6 +35,6 @@ pub async fn process_request(recoder: &Recoder, req: Request) -> Response {
 
 pub fn process_response(action: &str, msg: &str) {
     if action == REPORT_ACTION {
-        println!("{}", msg);
+        println!("{msg}");
     }
 }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -140,6 +140,8 @@ volo-http = { path = "../volo-http", features = [
 volo-gen = { path = "./volo-gen" }
 
 [features]
+tls = ["rustls"]
+
 __tls = []
 rustls = ["__tls", "volo/rustls", "volo-grpc/rustls", "volo-http/rustls"]
 native-tls = [

--- a/examples/src/grpc/grpc-web/client.rs
+++ b/examples/src/grpc/grpc-web/client.rs
@@ -43,13 +43,13 @@ fn build_request(base_uri: &str, content_type: &str, accept: &str) -> Request<Fu
 
     let bytes = match content_type {
         "grpc-web" => encode_body(),
-        _ => panic!("invalid content type {}", content_type),
+        _ => panic!("invalid content type {content_type}"),
     };
 
     Request::builder()
         .method(Method::POST)
-        .header(CONTENT_TYPE, format!("application/{}", content_type))
-        .header(ACCEPT, format!("application/{}", accept))
+        .header(CONTENT_TYPE, format!("application/{content_type}"))
+        .header(ACCEPT, format!("application/{accept}"))
         .uri(request_uri)
         .body(Full::new(bytes))
         .unwrap()

--- a/examples/src/grpc/tls/client.rs
+++ b/examples/src/grpc/tls/client.rs
@@ -19,12 +19,12 @@ async fn main() {
     let tls_config = ClientTlsConfig::new("example.com", connector);
 
     let addr: SocketAddr = "127.0.0.1:8080".parse().unwrap();
-    let client = volo_gen::proto_gen::hello::GreeterClientBuilder::new("hello")
+    let client = volo_gen::proto_gen::helloworld::GreeterClientBuilder::new("hello")
         .tls_config(tls_config)
         .address(addr)
         .build();
 
-    let req = volo_gen::proto_gen::hello::HelloRequest {
+    let req = volo_gen::proto_gen::helloworld::HelloRequest {
         name: FastStr::from_static_str("Volo"),
     };
     let resp = client.say_hello(req).await;

--- a/examples/src/grpc/tls/server.rs
+++ b/examples/src/grpc/tls/server.rs
@@ -7,13 +7,13 @@ use volo_grpc::server::{Server, ServiceBuilder};
 
 pub struct S;
 
-impl volo_gen::proto_gen::hello::Greeter for S {
+impl volo_gen::proto_gen::helloworld::Greeter for S {
     async fn say_hello(
         &self,
-        req: volo_grpc::Request<volo_gen::proto_gen::hello::HelloRequest>,
-    ) -> Result<volo_grpc::Response<volo_gen::proto_gen::hello::HelloReply>, volo_grpc::Status>
+        req: volo_grpc::Request<volo_gen::proto_gen::helloworld::HelloRequest>,
+    ) -> Result<volo_grpc::Response<volo_gen::proto_gen::helloworld::HelloReply>, volo_grpc::Status>
     {
-        let resp = volo_gen::proto_gen::hello::HelloReply {
+        let resp = volo_gen::proto_gen::helloworld::HelloReply {
             message: format!("Hello, {}!", req.get_ref().name).into(),
         };
         Ok(volo_grpc::Response::new(resp))
@@ -39,7 +39,9 @@ async fn main() {
 
     Server::new()
         .tls_config(tls_config)
-        .add_service(ServiceBuilder::new(volo_gen::proto_gen::hello::GreeterServer::new(S)).build())
+        .add_service(
+            ServiceBuilder::new(volo_gen::proto_gen::helloworld::GreeterServer::new(S)).build(),
+        )
         .run(addr)
         .await
         .unwrap();

--- a/examples/src/http/example-http-server.rs
+++ b/examples/src/http/example-http-server.rs
@@ -176,7 +176,7 @@ async fn box_body_test() -> Body {
 }
 
 async fn full_uri(uri: FullUri) -> String {
-    format!("{}\n", uri)
+    format!("{uri}\n")
 }
 
 async fn redirect_to_index() -> Redirect {

--- a/examples/src/thrift/multiplex/client.rs
+++ b/examples/src/thrift/multiplex/client.rs
@@ -19,7 +19,7 @@ async fn main() {
 
     let futs = |i| async move {
         let req = volo_gen::thrift_gen::hello::HelloRequest {
-            name: format!("volo{}", i).into(),
+            name: format!("volo{i}").into(),
         };
         let resp = CLIENT
             .clone()

--- a/scripts/clippy-and-test.sh
+++ b/scripts/clippy-and-test.sh
@@ -40,7 +40,8 @@ echo_command cargo clippy -p volo --no-default-features --features rustls-ring -
 echo_command cargo clippy -p volo-build -- --deny warnings
 echo_command cargo clippy -p volo-cli -- --deny warnings
 echo_command cargo clippy -p volo-macros -- --deny warnings
-echo_command cargo clippy -p examples -- -A clippy::literal_string_with_formatting_args --deny warnings
+echo_command cargo clippy -p examples -- --deny warnings
+echo_command cargo clippy -p examples --features tls -- --deny warnings
 
 # Test
 echo_command cargo test -p volo-thrift

--- a/volo-build/src/grpc_backend.rs
+++ b/volo-build/src/grpc_backend.rs
@@ -38,7 +38,7 @@ impl VoloGrpcBackend {
         let ty_str = if global_path {
             format!("{}", ty.global_path("volo_gen"))
         } else {
-            format!("{}", ty)
+            format!("{ty}")
         };
 
         if streaming {
@@ -58,7 +58,7 @@ impl VoloGrpcBackend {
         let ret_ty_str = if global_path {
             format!("{}", ret_ty.global_path("volo_gen"))
         } else {
-            format!("{}", ret_ty)
+            format!("{ret_ty}")
         };
 
         if streaming {
@@ -240,11 +240,11 @@ impl CodegenBackend for VoloGrpcBackend {
 
     fn codegen_service_impl(&self, def_id: DefId, stream: &mut String, s: &rir::Service) {
         let service_name = self.cx().rust_name(def_id);
-        let server_name = format!("{}Server", service_name);
-        let client_builder_name = format!("{}ClientBuilder", service_name);
-        let generic_client_name = format!("{}GenericClient", service_name);
-        let client_name = format!("{}Client", service_name);
-        let oneshot_client_name = format!("{}OneShotClient", service_name);
+        let server_name = format!("{service_name}Server");
+        let client_builder_name = format!("{service_name}ClientBuilder");
+        let generic_client_name = format!("{service_name}GenericClient");
+        let client_name = format!("{service_name}Client");
+        let oneshot_client_name = format!("{service_name}OneShotClient");
 
         let file_id = self.cx().node(def_id).unwrap().file_id;
         let file = self.cx().file(file_id).unwrap();
@@ -252,10 +252,10 @@ impl CodegenBackend for VoloGrpcBackend {
         let package = file.package.iter().join(".");
         let name = format!("{package}.{}", s.name);
 
-        let req_enum_name_send = format!("{}RequestSend", service_name);
-        let resp_enum_name_send = format!("{}ResponseSend", service_name);
-        let req_enum_name_recv = format!("{}RequestRecv", service_name);
-        let resp_enum_name_recv = format!("{}ResponseRecv", service_name);
+        let req_enum_name_send = format!("{service_name}RequestSend");
+        let resp_enum_name_send = format!("{service_name}ResponseSend");
+        let req_enum_name_recv = format!("{service_name}RequestRecv");
+        let resp_enum_name_recv = format!("{service_name}ResponseRecv");
 
         let path = self.cx().item_path(def_id);
         let path = path.as_ref();
@@ -385,7 +385,7 @@ impl CodegenBackend for VoloGrpcBackend {
             );
         });
 
-        let mk_client_name = format!("Mk{}", generic_client_name);
+        let mk_client_name = format!("Mk{generic_client_name}");
 
         let client_methods = client_methods.join("\n");
         let oneshot_client_methods = oneshot_client_methods.join("\n");
@@ -605,38 +605,38 @@ impl CodegenBackend for VoloGrpcBackend {
             write_item(
                 &mut mod_rs_stream,
                 base_dir,
-                format!("enum_{}.rs", req_enum_name_send),
+                format!("enum_{req_enum_name_send}.rs"),
                 req_enum_send_impl,
             );
             write_item(
                 &mut mod_rs_stream,
                 base_dir,
-                format!("enum_{}.rs", req_enum_name_recv),
+                format!("enum_{req_enum_name_recv}.rs"),
                 req_enum_recv_impl,
             );
             write_item(
                 &mut mod_rs_stream,
                 base_dir,
-                format!("enum_{}.rs", resp_enum_name_send),
+                format!("enum_{resp_enum_name_send}.rs"),
                 resp_enum_send_impl,
             );
             write_item(
                 &mut mod_rs_stream,
                 base_dir,
-                format!("enum_{}.rs", resp_enum_name_recv),
+                format!("enum_{resp_enum_name_recv}.rs"),
                 resp_enum_recv_impl,
             );
 
             write_item(
                 &mut mod_rs_stream,
                 base_dir,
-                format!("client_{}.rs", client_name),
+                format!("client_{client_name}.rs"),
                 client_impl,
             );
             write_item(
                 &mut mod_rs_stream,
                 base_dir,
-                format!("server_{}.rs", server_name),
+                format!("server_{server_name}.rs"),
                 server_impl,
             );
 

--- a/volo-build/src/legacy/util.rs
+++ b/volo-build/src/legacy/util.rs
@@ -40,8 +40,7 @@ pub fn read_config_from_file(f: &File) -> Result<Config, serde_yaml::Error> {
                 Ok(Config::new())
             } else {
                 Err(serde_yaml::Error::custom(format!(
-                    "failed to read config file, err: {}",
-                    e
+                    "failed to read config file, err: {e}"
                 )))
             }
         }
@@ -95,7 +94,7 @@ mod tests {
                 assert!(file.metadata().is_ok());
             }
             Err(err) => {
-                eprintln!("Error: {}", err);
+                eprintln!("Error: {err}");
                 panic!("Failed to create new file");
             }
         }
@@ -108,7 +107,7 @@ mod tests {
                 assert!(file.metadata().is_ok());
             }
             Err(err) => {
-                eprintln!("Error: {}", err);
+                eprintln!("Error: {err}");
                 panic!("Failed to append to existing file");
             }
         }

--- a/volo-build/src/thrift_backend.rs
+++ b/volo-build/src/thrift_backend.rs
@@ -705,13 +705,13 @@ impl pilota_build::CodegenBackend for VoloThriftBackend {
             write_item(
                 &mut mod_rs_stream,
                 base_dir,
-                format!("service_{}Server.rs", service_name),
+                format!("service_{service_name}Server.rs"),
                 server_string,
             );
             write_item(
                 &mut mod_rs_stream,
                 base_dir,
-                format!("service_{}Client.rs", service_name),
+                format!("service_{service_name}Client.rs"),
                 client_string,
             );
         } else {

--- a/volo-build/src/util.rs
+++ b/volo-build/src/util.rs
@@ -41,7 +41,7 @@ pub fn read_config_from_file(f: &mut File) -> Result<SingleConfig, serde_yaml::E
             } else {
                 let mut s = String::with_capacity(metadata.len() as usize);
                 f.read_to_string(&mut s).map_err(|e| {
-                    serde_yaml::Error::custom(format!("failed to read config file, err: {}", e))
+                    serde_yaml::Error::custom(format!("failed to read config file, err: {e}"))
                 })?;
                 match serde_yaml::from_str(s.as_str()) {
                     Ok(config) => Ok(config),
@@ -64,8 +64,7 @@ pub fn read_config_from_file(f: &mut File) -> Result<SingleConfig, serde_yaml::E
                 Ok(SingleConfig::new())
             } else {
                 Err(serde_yaml::Error::custom(format!(
-                    "failed to read config file, err: {}",
-                    e
+                    "failed to read config file, err: {e}"
                 )))
             }
         }
@@ -586,7 +585,7 @@ pub fn detect_protocol<P: AsRef<Path>>(path: P) -> IdlProtocol {
         Some("thrift") => IdlProtocol::Thrift,
         Some("proto") => IdlProtocol::Protobuf,
         _ => {
-            eprintln!("invalid file ext {:?}", path);
+            eprintln!("invalid file ext {path:?}");
             std::process::exit(1);
         }
     }
@@ -680,7 +679,7 @@ mod tests {
                 assert!(file.metadata().is_ok());
             }
             Err(err) => {
-                eprintln!("Error: {}", err);
+                eprintln!("Error: {err}");
                 panic!("Failed to create new file");
             }
         }
@@ -693,7 +692,7 @@ mod tests {
                 assert!(file.metadata().is_ok());
             }
             Err(err) => {
-                eprintln!("Error: {}", err);
+                eprintln!("Error: {err}");
                 panic!("Failed to append to existing file");
             }
         }

--- a/volo-build/src/workspace.rs
+++ b/volo-build/src/workspace.rs
@@ -49,14 +49,14 @@ where
         let config = match std::fs::read(work_dir.join("volo.workspace.yml")) {
             Ok(config) => config,
             Err(e) => {
-                eprintln!("failed to read volo.workspace.yml file, err: {}", e);
+                eprintln!("failed to read volo.workspace.yml file, err: {e}");
                 std::process::exit(1);
             }
         };
         let config = match serde_yaml::from_slice::<WorkspaceConfig>(&config) {
             Ok(config) => config,
             Err(e) => {
-                eprintln!("failed to parse volo.workspace.yml, err: {}", e);
+                eprintln!("failed to parse volo.workspace.yml, err: {e}");
                 std::process::exit(1);
             }
         };

--- a/volo-cli/src/migrate.rs
+++ b/volo-cli/src/migrate.rs
@@ -60,9 +60,8 @@ impl CliCommand for Migrate {
         .inspect_err(|_| {
             if let Err(e) = std::fs::rename(backup_path.as_path(), path.as_path()) {
                 eprintln!(
-                    "failed to restore backup file: {}, please manually rename it to volo.yml \
-                     before retry",
-                    e
+                    "failed to restore backup file: {e}, please manually rename it to volo.yml \
+                     before retry"
                 );
             }
         })?;

--- a/volo-grpc/src/codec/encode.rs
+++ b/volo-grpc/src/codec/encode.rs
@@ -42,12 +42,12 @@ where
                     if let Some(config)=compression_encoding{
                         compressed_buf.clear();
                         encoder.encode(item, &mut compressed_buf)
-                            .map_err(|err| Status::internal(format!("Error encoding: {}", err)))?;
+                            .map_err(|err| Status::internal(format!("Error encoding: {err}")))?;
                         compress(config,&mut compressed_buf,&mut buf)
-                            .map_err(|err| Status::internal(format!("Error compressing: {}", err)))?;
+                            .map_err(|err| Status::internal(format!("Error compressing: {err}")))?;
                     }else{
                         encoder.encode(item, &mut buf)
-                            .map_err(|err| Status::internal(format!("Error encoding: {}", err)))?;
+                            .map_err(|err| Status::internal(format!("Error encoding: {err}")))?;
                     }
                     let len = buf.len() - PREFIX_LEN;
                     assert!(len <= u32::MAX as usize);

--- a/volo-grpc/src/status.rs
+++ b/volo-grpc/src/status.rs
@@ -411,7 +411,7 @@ impl Status {
         }
         if let Some(h2_err) = err.source().and_then(|e| e.downcast_ref::<h2::Error>()) {
             let code = Self::code_from_h2(h2_err);
-            let status = Self::new(code, format!("h2 protocol error: {}", err));
+            let status = Self::new(code, format!("h2 protocol error: {err}"));
 
             return Some(status);
         }

--- a/volo-http/src/client/layer/header.rs
+++ b/volo-http/src/client/layer/header.rs
@@ -162,7 +162,7 @@ fn gen_host(
                 if is_default_port(scheme, sa.port()) {
                     HeaderValue::try_from(format!("{}", sa.ip())).ok()
                 } else {
-                    HeaderValue::try_from(format!("{}", sa)).ok()
+                    HeaderValue::try_from(format!("{sa}")).ok()
                 }
             }
             #[cfg(target_family = "unix")]

--- a/volo-thrift/src/context.rs
+++ b/volo-thrift/src/context.rs
@@ -514,6 +514,6 @@ mod tests {
             pilota::thrift::TMessageType::Call,
         )
         .rpc_info;
-        println!("{:?}", ri);
+        println!("{ri:?}");
     }
 }

--- a/volo-thrift/src/error.rs
+++ b/volo-thrift/src/error.rs
@@ -158,7 +158,7 @@ impl Display for BizError {
         let mut extra_str = String::new();
         if let Some(extra) = &self.extra {
             for (k, v) in extra {
-                extra_str.push_str(&format!("{}: {},", k, v));
+                extra_str.push_str(&format!("{k}: {v},"));
             }
         }
         write!(

--- a/volo-thrift/src/server/panic_handler.rs
+++ b/volo-thrift/src/server/panic_handler.rs
@@ -15,15 +15,12 @@ pub fn log_and_return_exception<Resp>(
     } else if let Some(s) = payload.downcast_ref::<&str>() {
         s.to_string()
     } else {
-        format!("{:?}", payload)
+        format!("{payload:?}")
     };
 
     // There may be some redundant information in the panic_info, but it's better to keep it, since
     // it seems that the payload and message are subject to change in the future.
-    let message = format!(
-        "panicked in biz logic: {}, panic_info: {}",
-        payload_msg, panic_info
-    );
+    let message = format!("panicked in biz logic: {payload_msg}, panic_info: {panic_info}");
 
     tracing::error!("[Volo-Thrift] {}, cx: {:?}", message, cx);
     Err(ServerError::Application(ApplicationException::new(

--- a/volo-thrift/src/transport/multiplex/client.rs
+++ b/volo-thrift/src/transport/multiplex/client.rs
@@ -131,7 +131,7 @@ where
     ) -> Result<Self::Response, Self::Error> {
         let rpc_info = &cx.rpc_info;
         let target = rpc_info.callee().address().ok_or_else(|| {
-            let msg = format!("address is required, rpcinfo: {:?}", rpc_info);
+            let msg = format!("address is required, rpcinfo: {rpc_info:?}");
             ClientError::Transport(io::Error::new(io::ErrorKind::InvalidData, msg).into())
         })?;
         let oneway = cx.message_type == TMessageType::OneWay;
@@ -144,7 +144,7 @@ where
                 return Err(ClientError::Transport(
                     pilota::thrift::TransportException::from(io::Error::new(
                         io::ErrorKind::UnexpectedEof,
-                        format!("an unexpected end of file from server, cx: {:?}", cx),
+                        format!("an unexpected end of file from server, cx: {cx:?}"),
                     )),
                 ));
             }

--- a/volo-thrift/src/transport/pingpong/client.rs
+++ b/volo-thrift/src/transport/pingpong/client.rs
@@ -115,7 +115,7 @@ where
         let target = rpc_info.callee().address().ok_or_else(|| {
             TransportException::from(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("address is required, rpc_info: {:?}", rpc_info),
+                format!("address is required, rpc_info: {rpc_info:?}"),
             ))
         })?;
         let oneway = cx.message_type == TMessageType::OneWay;

--- a/volo-thrift/src/transport/pingpong/thrift_transport.rs
+++ b/volo-thrift/src/transport/pingpong/thrift_transport.rs
@@ -90,7 +90,7 @@ where
     ) -> Result<Option<ThriftMessage<T>>, ClientError> {
         let thrift_msg = self.decoder.decode(cx).await.map_err(|e| {
             let mut e = e;
-            e.append_msg(&format!(", cx: {:?}", cx));
+            e.append_msg(&format!(", cx: {cx:?}"));
             tracing::error!("[VOLO] transport[{}] decode error: {}", self.id, e);
             e
         })?;
@@ -106,7 +106,7 @@ where
                 );
                 return Err(ClientError::Application(ApplicationException::new(
                     ApplicationExceptionKind::BAD_SEQUENCE_ID,
-                    format!("seq_id not match, cx: {:?}", cx),
+                    format!("seq_id not match, cx: {cx:?}"),
                 )));
             }
         };

--- a/volo-thrift/src/transport/pool/mod.rs
+++ b/volo-thrift/src/transport/pool/mod.rs
@@ -339,8 +339,7 @@ impl<K: Key, T: Poolable + Send + 'static> Pool<K, T> {
             Either::Left((Err(e), _)) => {
                 tracing::error!("[VOLO] wait a idle connection error: {:?}", e);
                 Err(TransportException::from(std::io::Error::other(format!(
-                    "wait a idle connection error: {:?}",
-                    e
+                    "wait a idle connection error: {e:?}"
                 )))
                 .into())
             }

--- a/volo/src/loadbalance/consistent_hash.rs
+++ b/volo/src/loadbalance/consistent_hash.rs
@@ -209,7 +209,7 @@ where
             let str = instance.address.to_string();
             let vnode_lens = virtual_factor * weight;
             // try to reuse the buffer
-            let mut buf = format!("{}#{}", str, vnode_lens).into_bytes();
+            let mut buf = format!("{str}#{vnode_lens}").into_bytes();
             let mut sharp_pos = 0;
             for (i, bytei) in buf.iter().enumerate() {
                 if *bytei == b'#' {
@@ -338,7 +338,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_consistent_hash_balancer() {
-        test_with_meta_info(|| consistent_hash_balancer_tests()).await;
+        test_with_meta_info(consistent_hash_balancer_tests).await;
     }
 
     async fn consistent_hash_balancer_tests() {
@@ -374,7 +374,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_consistent_hash_consistent() {
-        test_with_meta_info(|| consistent_hash_consistent_tests()).await;
+        test_with_meta_info(consistent_hash_consistent_tests).await;
     }
 
     async fn consistent_hash_consistent_tests() {
@@ -460,7 +460,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_consistent_hash_balance() {
-        test_with_meta_info(|| consistent_hash_balance_tests()).await;
+        test_with_meta_info(consistent_hash_balance_tests).await;
     }
 
     async fn consistent_hash_balance_tests() {
@@ -471,8 +471,8 @@ mod tests {
             let w = rng.random_range(10..=100);
             let sub_net = rng.random_range(0..=255);
             let port = rng.random_range(1000..=65535);
-            instances.push(new_instance(format!("172.17.0.{}:{}", sub_net, port), w));
-            instances.push(new_instance(format!("192.168.32.{}:{}", sub_net, port), w));
+            instances.push(new_instance(format!("172.17.0.{sub_net}:{port}"), w));
+            instances.push(new_instance(format!("192.168.32.{sub_net}:{port}"), w));
         }
         let result = simulate_random_picks(instances.clone(), 1000000).await;
         let sum_visits = result.values().sum::<usize>();
@@ -485,10 +485,10 @@ mod tests {
             let expect = instance.weight as f64 / sum_weight as f64 * sum_visits as f64;
             let eps = (exact - expect).abs() / expect;
             // compute the standard deviation
-            deviation = deviation + (eps * eps);
+            deviation += eps * eps;
             max_eps = max_eps.max(eps);
         }
-        println!("max_eps: {}", max_eps);
+        println!("max_eps: {max_eps}");
         println!(
             "standard deviation: {}",
             (deviation / instances.len() as f64).sqrt()
@@ -498,7 +498,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_consistent_hash_change() {
-        test_with_meta_info(|| consistent_hash_change_tests()).await;
+        test_with_meta_info(consistent_hash_change_tests).await;
     }
 
     async fn consistent_hash_change_tests() {
@@ -511,7 +511,7 @@ mod tests {
         let mut rng = rand::rng();
         for i in 0..30 {
             let w = rng.random_range(10..=100);
-            instances.push(new_instance(format!("127.0.0.1:{}", i), w));
+            instances.push(new_instance(format!("127.0.0.1:{i}"), w));
         }
         let discovery = StaticDiscover::new(instances.clone());
         let mut lb = ConsistentHashBalance::new(opt.clone());

--- a/volo/src/util/mod.rs
+++ b/volo/src/util/mod.rs
@@ -95,7 +95,7 @@ mod tests {
     fn test_display_trait() {
         let data = TestData;
         let borrowed_ref: Ref<'_, TestData> = (&data).into();
-        assert_eq!(format!("{}", borrowed_ref), format!("{}", data));
+        assert_eq!(format!("{borrowed_ref}"), format!("{}", data));
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

We noticed that there is a feature `tls` in `examples`, but we never tested `examples` with `tls`, and there were some compilation errors.

## Solution

Add tests for `examples` with `tls` and fix compilation errors.

In addition, we bump all dependencies in `Cargo.toml`.