### PR TITLE
fix(volo-http): fix `clippy::result_large_err`

### DIFF
--- a/volo-http/src/client/layer/header.rs
+++ b/volo-http/src/client/layer/header.rs
@@ -50,7 +50,6 @@ impl Header {
     ///
     /// [`ClientError`]: crate::error::client::ClientError
     /// [`ErrorKind::Builder`]: crate::error::client::ErrorKind::Builder
-    #[allow(clippy::result_large_err)]
     pub fn try_new<K, V>(key: K, val: V) -> Result<Self>
     where
         K: TryInto<HeaderName>,

--- a/volo-http/src/client/mod.rs
+++ b/volo-http/src/client/mod.rs
@@ -666,7 +666,6 @@ impl<IL, OL, C, LB> ClientBuilder<IL, OL, C, LB> {
     /// - Transport through network or unix domain socket.
     ///
     /// [`DnsResolver`]: crate::client::dns::DnsResolver
-    #[allow(clippy::result_large_err)]
     pub fn build(mut self) -> Result<C::Target>
     where
         IL: Layer<ClientMetaService>,
@@ -701,7 +700,6 @@ impl<IL, OL, C, LB> ClientBuilder<IL, OL, C, LB> {
     /// default layers,
     ///
     /// See [`ClientBuilder::build`] for more details.
-    #[allow(clippy::result_large_err)]
     pub fn build_without_extra_layers(self) -> Result<C::Target>
     where
         IL: Layer<ClientTransport>,
@@ -745,7 +743,6 @@ impl<IL, OL, C, LB> ClientBuilder<IL, OL, C, LB> {
     }
 }
 
-#[allow(clippy::result_large_err)]
 fn insert_header<K, V>(headers: &mut HeaderMap, key: K, value: V) -> Result<()>
 where
     K: TryInto<HeaderName>,

--- a/volo-http/src/client/target.rs
+++ b/volo-http/src/client/target.rs
@@ -54,7 +54,6 @@ pub enum RemoteTargetAddress {
     Name(FastStr),
 }
 
-#[allow(clippy::result_large_err)]
 fn check_scheme(scheme: &Scheme) -> Result<()> {
     if scheme == &Scheme::HTTPS {
         #[cfg(not(feature = "__tls"))]
@@ -123,7 +122,6 @@ impl Target {
     }
 
     /// Create a [`Target`] through a scheme, host name and a port
-    #[allow(clippy::result_large_err)]
     pub fn new_host<S>(scheme: Option<Scheme>, host: S, port: Option<u16>) -> Result<Self>
     where
         S: Into<Cow<'static, str>>,
@@ -140,7 +138,6 @@ impl Target {
     }
 
     /// Create a [`Target`] through a scheme, ip address and a port
-    #[allow(clippy::result_large_err)]
     pub fn new_addr(scheme: Option<Scheme>, ip: IpAddr, port: Option<u16>) -> Result<Self> {
         let scheme = scheme.unwrap_or(Scheme::HTTP);
         check_scheme(&scheme)?;
@@ -163,7 +160,6 @@ impl Target {
     }
 
     /// Create a [`Target`] from [`Uri`]
-    #[allow(clippy::result_large_err)]
     pub fn from_uri(uri: &Uri) -> Result<Self> {
         let scheme = uri.scheme().cloned().unwrap_or(Scheme::HTTP);
         check_scheme(&scheme)?;
@@ -192,7 +188,6 @@ impl Target {
     ///
     /// Note that if the previous is default port of the previous scheme, the port will be also
     /// updated to default port of the new scheme.
-    #[allow(clippy::result_large_err)]
     pub fn set_scheme(&mut self, scheme: Scheme) -> Result<()> {
         let rt = match self.remote_mut() {
             Some(rt) => rt,
@@ -210,7 +205,6 @@ impl Target {
     }
 
     /// Set a new port to the [`Target`]
-    #[allow(clippy::result_large_err)]
     pub fn set_port(&mut self, port: u16) -> Result<()> {
         let rt = match self.remote_mut() {
             Some(rt) => rt,

--- a/volo-http/src/client/test_helpers.rs
+++ b/volo-http/src/client/test_helpers.rs
@@ -109,7 +109,6 @@ impl Service<ClientContext, Request> for MockTransport {
 
 impl<IL, OL, C, LB> ClientBuilder<IL, OL, C, LB> {
     /// Build a mock HTTP client with a [`MockTransport`] service.
-    #[allow(clippy::result_large_err)]
     pub fn mock(self, transport: MockTransport) -> Result<C::Target>
     where
         IL: Layer<ClientMockService>,


### PR DESCRIPTION
## Motivation

The type `Uri` takes up 88 bytes, which causes the entire `ClientError` to take up 144 bytes and clippy will throw `clippy::result_large_err`.

## Solution

Considering that the field will not be used in the hot path, in order to avoid the problem of `ClientError` being too large, we added `Box` to `Uri`.

With this change, the size of `ClientError` is reduced from 144 to 64.