### PR TITLE
opt(lb): optimize the performance of weighted_random load balancer

### DIFF
--- a/volo/src/discovery/mod.rs
+++ b/volo/src/discovery/mod.rs
@@ -165,7 +165,7 @@ impl Discover for StaticDiscover {
     }
 }
 
-/// [`WeightedStaticDiscover`] is a simple implementation of [`Discover`] that returns a static list 
+/// [`WeightedStaticDiscover`] is a simple implementation of [`Discover`] that returns a static list
 /// of instances with weight.
 #[derive(Clone)]
 pub struct WeightedStaticDiscover {

--- a/volo/src/discovery/mod.rs
+++ b/volo/src/discovery/mod.rs
@@ -165,8 +165,8 @@ impl Discover for StaticDiscover {
     }
 }
 
-/// [`WeightedStaticDiscover`] is a simple implementation of [`Discover`] that returns a static list of
-/// instances with weight.
+/// [`WeightedStaticDiscover`] is a simple implementation of [`Discover`] that returns a static list 
+/// of instances with weight.
 #[derive(Clone)]
 pub struct WeightedStaticDiscover {
     instances: Vec<Arc<Instance>>,

--- a/volo/src/discovery/mod.rs
+++ b/volo/src/discovery/mod.rs
@@ -165,6 +165,51 @@ impl Discover for StaticDiscover {
     }
 }
 
+/// [`WeightedStaticDiscover`] is a simple implementation of [`Discover`] that returns a static list of
+/// instances with weight.
+#[derive(Clone)]
+pub struct WeightedStaticDiscover {
+    instances: Vec<Arc<Instance>>,
+}
+
+impl WeightedStaticDiscover {
+    /// Creates a new [`StaticDiscover`].
+    pub fn new(instances: Vec<Arc<Instance>>) -> Self {
+        Self { instances }
+    }
+}
+
+impl From<Vec<(SocketAddr, u32)>> for WeightedStaticDiscover {
+    fn from(addrs: Vec<(SocketAddr, u32)>) -> Self {
+        let instances = addrs
+            .into_iter()
+            .map(|addr| {
+                Arc::new(Instance {
+                    address: Address::Ip(addr.0),
+                    weight: addr.1,
+                    tags: Default::default(),
+                })
+            })
+            .collect();
+        Self { instances }
+    }
+}
+
+impl Discover for WeightedStaticDiscover {
+    type Key = ();
+    type Error = Infallible;
+
+    async fn discover<'s>(&'s self, _: &'s Endpoint) -> Result<Vec<Arc<Instance>>, Self::Error> {
+        Ok(self.instances.clone())
+    }
+
+    fn key(&self, _: &Endpoint) -> Self::Key {}
+
+    fn watch(&self, _keys: Option<&[Self::Key]>) -> Option<Receiver<Change<Self::Key>>> {
+        None
+    }
+}
+
 /// [`DummyDiscover`] always returns an empty list.
 ///
 /// Users that don't specify the address directly need to use their own [`Discover`].
@@ -196,7 +241,7 @@ impl From<Infallible> for LoadBalanceError {
 mod tests {
     use std::sync::Arc;
 
-    use super::{Discover, Instance, StaticDiscover};
+    use super::{Discover, Instance, StaticDiscover, WeightedStaticDiscover};
     use crate::{context::Endpoint, net::Address};
 
     #[test]
@@ -216,6 +261,35 @@ mod tests {
             Arc::new(Instance {
                 address: Address::Ip("127.0.0.2:9000".parse().unwrap()),
                 weight: 1,
+                tags: Default::default(),
+            }),
+        ];
+        assert_eq!(resp, expected);
+    }
+
+    #[test]
+    fn test_weighted_static_discover() {
+        let empty = Endpoint::new("".into());
+        let discover = WeightedStaticDiscover::from(vec![
+            ("127.0.0.1:8000".parse().unwrap(), 2),
+            ("127.0.0.2:9000".parse().unwrap(), 3),
+            ("127.0.0.3:9000".parse().unwrap(), 4),
+        ]);
+        let resp = futures::executor::block_on(async { discover.discover(&empty).await }).unwrap();
+        let expected = vec![
+            Arc::new(Instance {
+                address: Address::Ip("127.0.0.1:8000".parse().unwrap()),
+                weight: 2,
+                tags: Default::default(),
+            }),
+            Arc::new(Instance {
+                address: Address::Ip("127.0.0.2:9000".parse().unwrap()),
+                weight: 3,
+                tags: Default::default(),
+            }),
+            Arc::new(Instance {
+                address: Address::Ip("127.0.0.3:9000".parse().unwrap()),
+                weight: 4,
                 tags: Default::default(),
             }),
         ];

--- a/volo/src/loadbalance/random.rs
+++ b/volo/src/loadbalance/random.rs
@@ -19,7 +19,7 @@ fn pick_one(
     if sum_of_weight == 0 {
         return None;
     }
-    if instances.len() == 0 {
+    if instances.is_empty() {
         return None;
     }
     let weight = rand::rng().random_range(0..sum_of_weight);

--- a/volo/src/loadbalance/random.rs
+++ b/volo/src/loadbalance/random.rs
@@ -162,11 +162,15 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{LoadBalance, WeightedRandomBalance};
-    use crate::discovery::WeightedStaticDiscover;
-    use crate::{context::Endpoint, discovery::StaticDiscover};
-    use rand::{rng, RngCore};
     use std::collections::HashMap;
+
+    use rand::{rng, RngCore};
+
+    use super::{LoadBalance, WeightedRandomBalance};
+    use crate::{
+        context::Endpoint,
+        discovery::{StaticDiscover, WeightedStaticDiscover},
+    };
 
     #[tokio::test]
     async fn test_weighted_random() {

--- a/volo/src/loadbalance/random.rs
+++ b/volo/src/loadbalance/random.rs
@@ -19,6 +19,9 @@ fn pick_one(
     if sum_of_weight == 0 {
         return None;
     }
+    if instances.len() == 0 {
+        return None;
+    }
     let weight = rand::rng().random_range(0..sum_of_weight);
     let index = prefix_sum_of_weights
         .binary_search(&weight)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/volo/blob/main/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Volo provides a weighted random load balancer with CDF (cumulative distribution function) or as known as prefix sum method. But after reviewing the code, I found some optimize point to make volo having better performance:

1. `pick_one` method is consuming random weight by iterating each instance from first to last, which needs O(n) time. But the prefix sum is an ordered slice, so we could using binary search to find upper bound of random weight which only need O(log n) time.
2. `Iterator` of `InstancePicker`, each time the upstream call failed, we need to copy a new slice and then perform weighted random sampling without replacement. But since each instance is without replacement, it will act as unweighted random sampling, but always need O(n) to calculate the prefix sum of weight. Since we are weighted random picked in the first round, we could just using RoundRobin with random picked start position which only need O(1) time and zero memory allocation.

