### PR TITLE
feat: support generate Arc<Req> for service

### DIFF
--- a/volo-build/src/thrift_backend.rs
+++ b/volo-build/src/thrift_backend.rs
@@ -756,10 +756,20 @@ impl pilota_build::CodegenBackend for VoloThriftBackend {
             .map(|a| {
                 let ty = self.inner.codegen_item_ty(a.ty.kind.clone());
                 let ident = self.cx().rust_name(a.def_id); // use the rust name as string format which will escape the keyword
+                let ty = if let Some(RustWrapperArc(true)) = self
+                    .cx()
+                    .tags(a.tags_id)
+                    .as_ref()
+                    .and_then(|tags| tags.get::<RustWrapperArc>())
+                {
+                    format!("::std::sync::Arc<{ty}>")
+                } else {
+                    ty.to_string()
+                };
                 let ty = if a.kind == rir::FieldKind::Optional {
                     format!("::std::option::Option<{ty}>")
                 } else {
-                    format!("{ty}")
+                    ty.to_string()
                 };
                 format!("{ident}: {ty}")
             })


### PR DESCRIPTION
## Motivation

Using Arc in request and response can reduce the size of stack future, and thus reduce memmove costs.

## Solution

Support wrap request in Arc.