### PR TITLE
chore(volo-http): fix clippy warning `mismatched_lifetime_syntaxes`

### DIFF
--- a/volo-http/src/server/route/utils.rs
+++ b/volo-http/src/server/route/utils.rs
@@ -69,7 +69,7 @@ impl Matcher {
         self.router.at(path).map_err(MatcherError::RouterMatchError)
     }
 
-    pub fn drain(&mut self) -> Drain<String, RouteId> {
+    pub fn drain(&mut self) -> Drain<'_, String, RouteId> {
         self.matches.drain()
     }
 }


### PR DESCRIPTION
## Motivation

```
error: lifetime flowing from input to output with different syntax can be confusing
  --> volo-http/src/server/route/utils.rs:72:18
   |
72 |     pub fn drain(&mut self) -> Drain<String, RouteId> {
   |                  ^^^^^^^^^     ---------------------- the lifetime gets resolved as `'_`
   |                  |
   |                  this lifetime flows to the output
   |
   = note: `-D mismatched-lifetime-syntaxes` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(mismatched_lifetime_syntaxes)]`
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
   |
72 |     pub fn drain(&mut self) -> Drain<'_, String, RouteId> {
   |                                      +++

error: could not compile `volo-http` (lib) due to 1 previous error
```
