### PR TITLE
chore(ci): add test for clippy all and test all

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,7 +85,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [nightly, stable]
+        rust: [stable]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -95,14 +95,14 @@ jobs:
       - name: Run tests
         run: |
           bash scripts/install-linux-dependencies.sh
-          bash scripts/clippy-and-test.sh
+          bash scripts/clippy-and-test.sh --no-test
 
   test-macos:
     runs-on: [self-hosted, macOS]
 
     strategy:
       matrix:
-        rust: [nightly, stable]
+        rust: [stable]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -111,7 +111,7 @@ jobs:
           toolchain: ${{matrix.rust}}
       - name: Run tests
         run: |
-          bash scripts/clippy-and-test.sh
+          bash scripts/clippy-and-test.sh --no-test
 
   test-windows:
     runs-on: [self-hosted, Windows]
@@ -127,7 +127,7 @@ jobs:
           toolchain: ${{matrix.rust}}
       - name: Run tests
         run: |
-          bash scripts/clippy-and-test.sh
+          bash scripts/clippy-and-test.sh --no-test
 
   test-cli:
     runs-on: [self-hosted, Linux, amd64]

--- a/benchmark/src/runner/counter.rs
+++ b/benchmark/src/runner/counter.rs
@@ -29,7 +29,7 @@ impl Counter {
 
     pub fn add_record(&self, idx: usize, err: bool, cost: usize) {
         unsafe {
-            (*self.costs.get())[idx] = cost;
+            (&mut (*self.costs.get()))[idx] = cost;
         }
         if err {
             self.failed.fetch_add(1, Ordering::Relaxed);

--- a/scripts/clippy-and-test.sh
+++ b/scripts/clippy-and-test.sh
@@ -18,38 +18,67 @@ echo_command() {
 	fi
 }
 
-# Clippy
-echo_command cargo clippy -p volo-thrift --no-default-features -- --deny warnings
-echo_command cargo clippy -p volo-thrift --no-default-features --features multiplex -- --deny warnings
-echo_command cargo clippy -p volo-thrift --no-default-features --features unsafe-codec -- --deny warnings
-echo_command cargo clippy -p volo-grpc --no-default-features -- --deny warnings
-echo_command cargo clippy -p volo-grpc --no-default-features --features rustls -- --deny warnings
-echo_command cargo clippy -p volo-grpc --no-default-features --features native-tls -- --deny warnings
-echo_command cargo clippy -p volo-grpc --no-default-features --features native-tls-vendored -- --deny warnings
-echo_command cargo clippy -p volo-grpc --no-default-features --features grpc-web -- --deny warnings
-echo_command cargo clippy -p volo-http --no-default-features -- --deny warnings
-echo_command cargo clippy -p volo-http --no-default-features --features client,http1,json -- --deny warnings
-echo_command cargo clippy -p volo-http --no-default-features --features client,http2,json -- --deny warnings
-echo_command cargo clippy -p volo-http --no-default-features --features server,http1,query,form,json,multipart,ws -- --deny warnings
-echo_command cargo clippy -p volo-http --no-default-features --features server,http2,query,form,json,multipart,ws -- --deny warnings
-echo_command cargo clippy -p volo-http --no-default-features --features full -- --deny warnings
-echo_command cargo clippy -p volo -- --deny warnings
-echo_command cargo clippy -p volo --no-default-features --features rustls-aws-lc-rs -- --deny warnings
-echo_command cargo clippy -p volo --no-default-features --features rustls-ring -- --deny warnings
-echo_command cargo clippy -p volo-build -- --deny warnings
-echo_command cargo clippy -p volo-cli -- --deny warnings
-echo_command cargo clippy -p volo-macros -- --deny warnings
-echo_command cargo clippy -p examples -- --deny warnings
-echo_command cargo clippy -p examples --features tls -- --deny warnings
-echo_command cargo clippy --all -- --deny warnings
+run_clippy() {
+	echo_command cargo clippy -p volo-thrift --no-default-features -- --deny warnings
+	echo_command cargo clippy -p volo-thrift --no-default-features --features multiplex -- --deny warnings
+	echo_command cargo clippy -p volo-thrift --no-default-features --features unsafe-codec -- --deny warnings
+	echo_command cargo clippy -p volo-grpc --no-default-features -- --deny warnings
+	echo_command cargo clippy -p volo-grpc --no-default-features --features rustls -- --deny warnings
+	echo_command cargo clippy -p volo-grpc --no-default-features --features native-tls -- --deny warnings
+	echo_command cargo clippy -p volo-grpc --no-default-features --features native-tls-vendored -- --deny warnings
+	echo_command cargo clippy -p volo-grpc --no-default-features --features grpc-web -- --deny warnings
+	echo_command cargo clippy -p volo-http --no-default-features -- --deny warnings
+	echo_command cargo clippy -p volo-http --no-default-features --features client,http1,json -- --deny warnings
+	echo_command cargo clippy -p volo-http --no-default-features --features client,http2,json -- --deny warnings
+	echo_command cargo clippy -p volo-http --no-default-features --features server,http1,query,form,json,multipart,ws -- --deny warnings
+	echo_command cargo clippy -p volo-http --no-default-features --features server,http2,query,form,json,multipart,ws -- --deny warnings
+	echo_command cargo clippy -p volo-http --no-default-features --features full -- --deny warnings
+	echo_command cargo clippy -p volo -- --deny warnings
+	echo_command cargo clippy -p volo --no-default-features --features rustls-aws-lc-rs -- --deny warnings
+	echo_command cargo clippy -p volo --no-default-features --features rustls-ring -- --deny warnings
+	echo_command cargo clippy -p volo-build -- --deny warnings
+	echo_command cargo clippy -p volo-cli -- --deny warnings
+	echo_command cargo clippy -p volo-macros -- --deny warnings
+	echo_command cargo clippy -p examples -- --deny warnings
+	echo_command cargo clippy -p examples --features tls -- --deny warnings
+	echo_command cargo clippy --all -- --deny warnings
+}
 
-# Test
-echo_command cargo test -p volo-thrift
-echo_command cargo test -p volo-grpc --features rustls
-echo_command cargo test -p volo-http --features client,server,http1,query,form,json,tls,cookie,multipart,ws
-echo_command cargo test -p volo-http --features client,server,http2,query,form,json,tls,cookie,multipart,ws
-echo_command cargo test -p volo-http --features full
-echo_command cargo test -p volo --features rustls
-echo_command cargo test -p volo-build
-echo_command cargo test -p volo-cli
-echo_command cargo test --all
+run_test() {
+	echo_command cargo test -p volo-thrift
+	echo_command cargo test -p volo-grpc --features rustls
+	echo_command cargo test -p volo-http --features client,server,http1,query,form,json,tls,cookie,multipart,ws
+	echo_command cargo test -p volo-http --features client,server,http2,query,form,json,tls,cookie,multipart,ws
+	echo_command cargo test -p volo-http --features full
+	echo_command cargo test -p volo --features rustls
+	echo_command cargo test -p volo-build
+	echo_command cargo test -p volo-cli
+	echo_command cargo test --all
+}
+
+main() {
+	local RUN_CLIPPY="yes"
+	local RUN_TEST="yes"
+
+	for arg in "$@"; do
+		case "${arg}" in
+		--no-clippy)
+			RUN_CLIPPY="no"
+			echo "info: clippy checks will be ignored"
+			;;
+		--no-test)
+			RUN_TEST="no"
+			echo "info: unit tests will be ignored"
+			;;
+		esac
+	done
+
+	if [ "${RUN_CLIPPY}" = "yes" ]; then
+		run_clippy
+	fi
+	if [ "${RUN_TEST}" = "yes" ]; then
+		run_test
+	fi
+}
+
+main "$@"

--- a/scripts/clippy-and-test.sh
+++ b/scripts/clippy-and-test.sh
@@ -12,13 +12,11 @@ echo_command() {
 		# output all
 		"$@"
 	else
+		trap 'echo -e "\e[1;31merror:\e[0m failed to run: $@"' ERR
 		# Disable outputs
 		"$@" > /dev/null 2>&1
 	fi
 }
-
-# Setup error handler
-trap 'echo "Failed to run $LINENO: $BASH_COMMAND (exit code: $?)" && exit 1' ERR
 
 # Clippy
 echo_command cargo clippy -p volo-thrift --no-default-features -- --deny warnings
@@ -43,6 +41,7 @@ echo_command cargo clippy -p volo-cli -- --deny warnings
 echo_command cargo clippy -p volo-macros -- --deny warnings
 echo_command cargo clippy -p examples -- --deny warnings
 echo_command cargo clippy -p examples --features tls -- --deny warnings
+echo_command cargo clippy --all -- --deny warnings
 
 # Test
 echo_command cargo test -p volo-thrift
@@ -53,3 +52,4 @@ echo_command cargo test -p volo-http --features full
 echo_command cargo test -p volo --features rustls
 echo_command cargo test -p volo-build
 echo_command cargo test -p volo-cli
+echo_command cargo test --all

--- a/scripts/selftest.sh
+++ b/scripts/selftest.sh
@@ -7,10 +7,11 @@ set -o pipefail
 echo_and_run() {
 	echo "$@"
 
-	if [ -n "${DEBUG:-}" ]; then
+	if [ "${GITHUB_ACTIONS:-}" = "true" ] || [ -n "${DEBUG:-}" ]; then
 		# If env `DEBUG` is non-empty, output all
 		"$@"
 	else
+		trap 'echo -e "\e[1;31merror:\e[0m failed to run: $@"' ERR
 		# Disable outputs
 		"$@" > /dev/null 2>&1
 	fi

--- a/scripts/volo-cli-test.sh
+++ b/scripts/volo-cli-test.sh
@@ -16,6 +16,7 @@ echo_command() {
 		# output all
 		"$@"
 	else
+		trap 'echo -e "\e[1;31merror:\e[0m failed to run: $@"' ERR
 		# Disable outputs
 		quiet "$@"
 	fi
@@ -36,7 +37,6 @@ init() {
 	export VOLO_DIR="$PWD"
 	echo_command cargo build -p volo-cli
 	export VOLO_CLI="$PWD/target/debug/volo"
-	trap 'echo "Failed to run $LINENO: $BASH_COMMAND (exit code: $?)" && exit 1' ERR
 }
 
 append_volo_dep_item() {


### PR DESCRIPTION
## Motivation

There is a clippy error in `benchmark`, which is not covered by the original ci script. And the `trap` command in the previous script does not work, which may cause users to not be aware of the exceptions that occur during self-testing.

## Solution

Add clippy and test for all crates (although no feature is specified), and fix usage of the `trap` command.

Additionally, to avoid taking up too much CI resources, we will keep unit tests only on Linux amd64, and will also remove CI on the nightly toolchains for Linux aarch64, macOS and Windows.