### PR TITLE
fix(volo-cli): use r#gen rather than gen as the mod name following edition 2024

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4220,7 +4220,7 @@ dependencies = [
 
 [[package]]
 name = "volo-cli"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/volo-cli/Cargo.toml
+++ b/volo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-cli"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-cli/src/templates/grpc/cargo_toml
+++ b/volo-cli/src/templates/grpc/cargo_toml
@@ -28,10 +28,10 @@ rpath = false
 
 [workspace]
 members = ["volo-gen"]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
-edition = "2021"
+edition = "2024"
 
 [workspace.dependencies]
 # we recommend to use the latest framework version for new features and bug fixes

--- a/volo-cli/src/templates/grpc/volo-gen/src/lib_rs
+++ b/volo-cli/src/templates/grpc/volo-gen/src/lib_rs
@@ -1,7 +1,7 @@
 
 
-mod gen {{
+mod r#gen {{
     include!(concat!(env!("OUT_DIR"), "/volo_gen.rs"));
 }}
 
-pub use gen::volo_gen::*;
+pub use r#gen::volo_gen::*;

--- a/volo-cli/src/templates/http/cargo_toml
+++ b/volo-cli/src/templates/http/cargo_toml
@@ -1,7 +1,7 @@
 [package]
 name = "{name}"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/volo-cli/src/templates/thrift/cargo_toml
+++ b/volo-cli/src/templates/thrift/cargo_toml
@@ -28,10 +28,10 @@ rpath = false
 
 [workspace]
 members = ["volo-gen"]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
-edition = "2021"
+edition = "2024"
 
 [workspace.dependencies]
 # we recommend to use the latest framework version for new features and bug fixes

--- a/volo-cli/src/templates/thrift/volo-gen/src/lib_rs
+++ b/volo-cli/src/templates/thrift/volo-gen/src/lib_rs
@@ -1,5 +1,5 @@
-mod gen {{
+mod r#gen {{
     include!(concat!(env!("OUT_DIR"), "/volo_gen.rs"));
 }}
 
-pub use gen::volo_gen::*;
+pub use r#gen::volo_gen::*;


### PR DESCRIPTION
Change-Id: I4caf93c31aa842d5ae346757c583099788ccd8f7

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/volo/blob/main/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
