### PR TITLE
fix(volo-http): fix error on ipv6 literal address resolving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4300,7 +4300,7 @@ dependencies = [
 
 [[package]]
 name = "volo-http"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ahash",
  "async-broadcast",

--- a/examples/src/http/example-http-client.rs
+++ b/examples/src/http/example-http-client.rs
@@ -21,21 +21,6 @@ async fn main() -> Result<(), BoxError> {
         .finish();
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
-    // simple `get` function with dns resolve
-    println!(
-        "{}",
-        get("http://httpbin.org/get").await?.into_string().await?
-    );
-
-    // HTTPS `get`
-    #[cfg(feature = "__tls")]
-    {
-        println!(
-            "{}",
-            get("https://httpbin.org/get").await?.into_string().await?
-        );
-    }
-
     // create client by builder
     let client = {
         let mut builder = ClientBuilder::new().layer_outer_front(TargetLayer::new_address(
@@ -47,29 +32,6 @@ async fn main() -> Result<(), BoxError> {
             .header("Test", "Test");
         builder.build()?
     };
-
-    // set host and override the default one
-    println!(
-        "{}",
-        client
-            .request_builder()
-            .host("httpbin.org")
-            .uri("/get")
-            .send()
-            .await?
-            .into_string()
-            .await?
-    );
-
-    println!(
-        "{}",
-        client
-            .get("http://127.0.0.1:8080/")
-            .send()
-            .await?
-            .into_string()
-            .await?
-    );
 
     // use default target address
     println!(
@@ -108,6 +70,15 @@ async fn main() -> Result<(), BoxError> {
             .into_string()
             .await?
     );
+    println!(
+        "{}",
+        client
+            .get("http://[::1]:8080/")
+            .send()
+            .await?
+            .into_string()
+            .await?
+    );
 
     // invalid request because there is no target address
     println!(
@@ -118,6 +89,21 @@ async fn main() -> Result<(), BoxError> {
             .await
             .expect_err("this request should fail"),
     );
+
+    // simple `get` function with dns resolve
+    println!(
+        "{}",
+        get("http://httpbin.org/get").await?.into_string().await?
+    );
+
+    // HTTPS `get`
+    #[cfg(feature = "__tls")]
+    {
+        println!(
+            "{}",
+            get("https://httpbin.org/get").await?.into_string().await?
+        );
+    }
 
     Ok(())
 }

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-http"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-http/src/client/dns.rs
+++ b/volo-http/src/client/dns.rs
@@ -4,7 +4,7 @@
 
 use std::{
     net::{IpAddr, SocketAddr},
-    ops::Deref,
+    ops::{Deref, Index},
     sync::Arc,
 };
 
@@ -61,6 +61,14 @@ impl DnsResolver {
 
     /// Resolve a host to an IP address.
     pub async fn resolve(&self, host: &str) -> Option<IpAddr> {
+        let host = {
+            let bytes = host.as_bytes();
+            match (bytes.first(), bytes.last()) {
+                (Some(b'['), Some(b']')) => host.index(1..host.len() - 1),
+                _ => host,
+            }
+        };
+
         // Note that the Resolver will try to parse the host as an IP address first, so we don't
         // need to parse it manually.
         self.resolver.lookup_ip(host).await.ok()?.into_iter().next()
@@ -144,7 +152,9 @@ impl Discover for DnsResolver {
             return Ok(vec![Arc::new(instance)]);
         };
         tracing::error!("[Volo-HTTP] DnsResolver: no address resolved");
-        Err(LoadBalanceError::Discover(Box::new(bad_host_name())))
+        Err(LoadBalanceError::Discover(Box::new(bad_host_name(
+            endpoint.service_name(),
+        ))))
     }
 
     fn key(&self, endpoint: &Endpoint) -> Self::Key {
@@ -153,5 +163,33 @@ impl Discover for DnsResolver {
 
     fn watch(&self, _: Option<&[Self::Key]>) -> Option<Receiver<Change<Self::Key>>> {
         None
+    }
+}
+
+#[cfg(test)]
+mod dns_tests {
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    use crate::client::dns::DnsResolver;
+
+    #[tokio::test]
+    async fn static_resolve() {
+        let resolver = DnsResolver::default();
+
+        assert_eq!(
+            resolver.resolve("127.0.0.1").await,
+            Some(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))),
+        );
+        assert_eq!(
+            resolver.resolve("::1").await,
+            Some(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))),
+        );
+        assert_eq!(
+            resolver.resolve("[::1]").await,
+            Some(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))),
+        );
+        assert_eq!(resolver.resolve("[::1").await, None);
+        assert_eq!(resolver.resolve("::1]").await, None);
+        assert_eq!(resolver.resolve("[::1]:8080").await, None);
     }
 }

--- a/volo-http/src/client/transport/connector.rs
+++ b/volo-http/src/client/transport/connector.rs
@@ -96,7 +96,7 @@ impl UnaryService<PeerInfo> for HttpMakeConnection {
         match self {
             Self::Plain(plain) => {
                 if req.scheme != Scheme::HTTP {
-                    return Err(bad_scheme());
+                    return Err(bad_scheme(req.scheme));
                 }
                 plain.call(req).await
             }


### PR DESCRIPTION
## Motivation

In previous implementation, HTTP client cannot resolve IPv6 literal address in URI like `http://[::1]:8080/`, and it will throw `BadHostName` without any context.

## Solution

This PR fixes this issue and adds context for errors like `BadScheme` and `BadHostName`, which will now print the error message along with its content, it should make troubleshooting easier.
