### PR TITLE
fix(volo-http): put stripping IPv6 brackets in front.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4307,7 +4307,7 @@ dependencies = [
 
 [[package]]
 name = "volo-http"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "ahash",
  "async-broadcast",

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-http"
-version = "0.4.2"
+version = "0.4.3"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-http/src/client/dns.rs
+++ b/volo-http/src/client/dns.rs
@@ -4,7 +4,7 @@
 
 use std::{
     net::{IpAddr, SocketAddr},
-    ops::{Deref, Index},
+    ops::Deref,
     sync::Arc,
 };
 
@@ -61,14 +61,6 @@ impl DnsResolver {
 
     /// Resolve a host to an IP address.
     pub async fn resolve(&self, host: &str) -> Option<IpAddr> {
-        let host = {
-            let bytes = host.as_bytes();
-            match (bytes.first(), bytes.last()) {
-                (Some(b'['), Some(b']')) => host.index(1..host.len() - 1),
-                _ => host,
-            }
-        };
-
         // Note that the Resolver will try to parse the host as an IP address first, so we don't
         // need to parse it manually.
         self.resolver.lookup_ip(host).await.ok()?.into_iter().next()
@@ -184,12 +176,6 @@ mod dns_tests {
             resolver.resolve("::1").await,
             Some(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))),
         );
-        assert_eq!(
-            resolver.resolve("[::1]").await,
-            Some(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))),
-        );
-        assert_eq!(resolver.resolve("[::1").await, None);
-        assert_eq!(resolver.resolve("::1]").await, None);
-        assert_eq!(resolver.resolve("[::1]:8080").await, None);
+        assert_eq!(resolver.resolve("[::1]").await, None);
     }
 }


### PR DESCRIPTION
## Motivation

In a previous commit, we fixed an issue where the DNS resolver didn't strip brackets from IPv6 addresses
(it accepted `::1` instead of `[::1]`), but we only handled this during DNS resolution and ignored the logic for SNI delivery, while IPv6 addresses using TLS suffered from the same issue during the TLS handshake.

## Solution

This commit move the stripping logics from DNS resolving to service name setting so that it works on everywhere.

Fixes: #597 