### PR TITLE
chore(volo-grpc): add default generic types for Server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4273,7 +4273,7 @@ dependencies = [
 
 [[package]]
 name = "volo-grpc"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/volo-grpc/Cargo.toml
+++ b/volo-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-grpc"
-version = "0.11.2"
+version = "0.11.3"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-grpc/src/server/meta.rs
+++ b/volo-grpc/src/server/meta.rs
@@ -11,7 +11,7 @@ use crate::{
     metadata::{
         DESTINATION_SERVICE, HEADER_TRANS_REMOTE_ADDR, KeyAndValueRef, MetadataKey, SOURCE_SERVICE,
     },
-    tracing::SpanProvider,
+    tracing::{DefaultProvider, SpanProvider},
 };
 
 macro_rules! status_to_http {
@@ -24,7 +24,7 @@ macro_rules! status_to_http {
 }
 
 #[derive(Clone, Debug)]
-pub struct MetaService<S, SP> {
+pub struct MetaService<S, SP = DefaultProvider> {
     inner: S,
     span_provider: SP,
 }

--- a/volo-grpc/src/server/mod.rs
+++ b/volo-grpc/src/server/mod.rs
@@ -45,7 +45,7 @@ pub trait NamedService {
 
 /// A server for a gRPC service.
 #[derive(Clone)]
-pub struct Server<IL, OL, SP> {
+pub struct Server<IL = Identity, OL = tower::layer::util::Identity, SP = DefaultProvider> {
     inner_layer: IL,
     outer_layer: OL,
     http2_config: Http2Config,
@@ -70,7 +70,7 @@ impl Server<Identity, tower::layer::util::Identity, DefaultProvider> {
             outer_layer: tower::layer::util::Identity::new(),
             http2_config: Http2Config::default(),
             router: Router::new(),
-            span_provider: DefaultProvider {},
+            span_provider: DefaultProvider,
 
             #[cfg(feature = "__tls")]
             tls_config: None,


### PR DESCRIPTION
## Motivation

Adding a new generic type is a break change of Volo-gRPC

## Solution

Add default generic types to `Server` and `MetaService`