### PR TITLE
feat(volo-grpc): box server service with BoxCloneService

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4273,7 +4273,7 @@ dependencies = [
 
 [[package]]
 name = "volo-grpc"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/volo-grpc/Cargo.toml
+++ b/volo-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-grpc"
-version = "0.11.3"
+version = "0.11.4"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/volo/blob/main/CONTRIBUTING.md
-->

## Motivation
Outer layer for server had trait bounds that were too restrictive, leading to errors when trying to initialize a custom SpanProvider in lust-grpc which required a specific trait bound which could not be satisfied.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Used BoxCloneService to box the Service in volo-grpc 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
