### PR TITLE
fix(volo-grpc): add extra parameter in on_serve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4273,7 +4273,7 @@ dependencies = [
 
 [[package]]
 name = "volo-grpc"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/volo-grpc/Cargo.toml
+++ b/volo-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-grpc"
-version = "0.11.4"
+version = "0.11.5"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-grpc/src/server/meta.rs
+++ b/volo-grpc/src/server/meta.rs
@@ -124,8 +124,7 @@ where
                         Ok::<(), Status>(())
                     });
                     status_to_http!(status);
-
-                    let span = span_provider.on_serve(&cx);
+                    let span = span_provider.on_serve(&cx, metadata);
                     let _enter = span.enter();
                     let volo_resp = match inner.call(&mut cx, volo_req).await {
                         Ok(resp) => resp,

--- a/volo-grpc/src/tracing.rs
+++ b/volo-grpc/src/tracing.rs
@@ -1,9 +1,9 @@
 use tracing::Span;
 
-use crate::context::ServerContext;
+use crate::{context::ServerContext, metadata::MetadataMap};
 
 pub trait SpanProvider: 'static + Send + Sync + Clone {
-    fn on_serve(&self, context: &ServerContext) -> Span {
+    fn on_serve(&self, context: &ServerContext, _metadata: &mut MetadataMap) -> Span {
         let _ = context;
         Span::none()
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/volo/blob/main/CONTRIBUTING.md
-->

## Motivation
on_serve function in volo-grpc may require some information stored in the metadatamap

## Solution
Added metadata as a parameter to on_serve for SpanProvider trait in order to extract relevant information.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
