### PR TITLE
chore(volo-http): use less errors, print more details

### DIFF
--- a/volo-cli/src/idl/add.rs
+++ b/volo-cli/src/idl/add.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 use clap::{Parser, value_parser};
 use volo_build::{
@@ -84,7 +87,7 @@ impl CliCommand for Add {
             // iter the entries to find the entry
             for (entry_name, entry) in config.entries.iter_mut() {
                 if entry_name != &cx.entry_name {
-                    if entry.filename == PathBuf::from(&self.filename) {
+                    if entry.filename == Path::new(&self.filename) {
                         eprintln!(
                             "The specified filename '{}' already exists in entry '{}'!",
                             self.filename, entry_name
@@ -107,7 +110,7 @@ impl CliCommand for Add {
                     std::process::exit(1);
                 }
 
-                if entry.filename != PathBuf::from(&self.filename) {
+                if entry.filename != Path::new(&self.filename) {
                     eprintln!(
                         "The specified filename '{}' doesn't match the current filename '{}' in \
                          the entry '{}'!",

--- a/volo-http/src/client/loadbalance.rs
+++ b/volo-http/src/client/loadbalance.rs
@@ -130,22 +130,22 @@ where
             service,
         };
 
-        if let Some(mut channel) = service.discover.watch(None) {
-            tokio::spawn(async move {
-                loop {
-                    match channel.recv().await {
-                        Ok(recv) => lb.rebalance(recv),
-                        Err(err) => match err {
-                            RecvError::Closed => break,
-                            _ => tracing::warn!(
-                                "[Volo-HTTP] discovering subscription error: {:?}",
-                                err
-                            ),
-                        },
-                    }
+        let Some(mut channel) = service.discover.watch(None) else {
+            return service;
+        };
+
+        tokio::spawn(async move {
+            loop {
+                match channel.recv().await {
+                    Ok(recv) => lb.rebalance(recv),
+                    Err(err) => match err {
+                        RecvError::Closed => break,
+                        _ => tracing::warn!("[Volo-HTTP] discovering subscription error: {err}"),
+                    },
                 }
-            });
-        }
+            }
+        });
+
         service
     }
 }

--- a/volo-http/src/client/target.rs
+++ b/volo-http/src/client/target.rs
@@ -347,14 +347,12 @@ impl Apply<ClientContext> for Target {
                 match rt.host {
                     RemoteHost::Ip(ip) => {
                         let sa = SocketAddr::new(ip, rt.port);
-                        tracing::trace!("[Volo-HTTP] Target::apply: set target to {sa}");
                         let callee = cx.rpc_info_mut().callee_mut();
                         callee.set_service_name(FastStr::from_string(format!("{}", sa.ip())));
                         callee.set_address(Address::Ip(sa));
                     }
                     RemoteHost::Name(host) => {
                         let port = rt.port;
-                        tracing::trace!("[Volo-HTTP] Target::apply: set target to {host}:{port}");
                         let callee = cx.rpc_info_mut().callee_mut();
                         callee.set_service_name(ipv6_strip_brackets(host));
                         // Since Service Discover (DNS) can only access the `callee`, we must

--- a/volo-http/src/client/transport/plain.rs
+++ b/volo-http/src/client/transport/plain.rs
@@ -39,7 +39,7 @@ where
         match self.mk_conn.make_connection(req.address.clone()).await {
             Ok(conn) => Ok(conn),
             Err(err) => {
-                tracing::error!("[Volo-HTTP] failed to make connection, error: {err}");
+                tracing::warn!("[Volo-HTTP] failed to make connection, error: {err}");
                 Err(request_error(err).with_address(req.address))
             }
         }

--- a/volo-http/src/client/transport/protocol.rs
+++ b/volo-http/src/client/transport/protocol.rs
@@ -227,7 +227,7 @@ where
     let conn = match connector.make_connection(peer).await {
         Ok(conn) => conn,
         Err(err) => {
-            tracing::error!("failed to make connection: {err}");
+            tracing::warn!("[Volo-HTTP] failed to make connection: {err}");
             return Err(err);
         }
     };

--- a/volo-http/src/client/transport/tls.rs
+++ b/volo-http/src/client/transport/tls.rs
@@ -48,7 +48,7 @@ where
         match self.tls_connector.connect(&target_name, tcp_stream).await {
             Ok(conn) => Ok(conn),
             Err(err) => {
-                tracing::error!("[Volo-HTTP] failed to make tls connection, error: {err}");
+                tracing::warn!("[Volo-HTTP] failed to make tls connection, error: {err}");
                 Err(request_error(err))
             }
         }

--- a/volo-http/src/error/client.rs
+++ b/volo-http/src/error/client.rs
@@ -23,7 +23,7 @@ macro_rules! tri {
         match $result {
             Ok(val) => val,
             Err(err) => {
-                ::tracing::error!($($arg)*);
+                ::tracing::info!($($arg)*);
                 return Err(err);
             }
         }

--- a/volo-http/src/server/extract.rs
+++ b/volo-http/src/server/extract.rs
@@ -427,15 +427,13 @@ where
             .to_bytes();
 
         if let Some(cap) = get_header_value(&parts.headers, header::CONTENT_LENGTH) {
-            if let Ok(cap) = cap.parse::<usize>() {
-                if bytes.len() != cap {
-                    tracing::warn!(
-                        "[Volo-HTTP] The length of body ({}) does not match the Content-Length \
-                         ({})",
-                        bytes.len(),
-                        cap,
-                    );
-                }
+            if let Ok(cap) = cap.parse::<usize>()
+                && bytes.len() != cap
+            {
+                tracing::warn!(
+                    "[Volo-HTTP] The length of body ({}) does not match the Content-Length ({cap})",
+                    bytes.len(),
+                );
             }
         }
 


### PR DESCRIPTION
## Motivation

Volo-HTTP has too many logs, some of which are at too high a level, and some of which do not contain useful information.

## Solution

Fix them