### PR TITLE
fix(volo-http, volo-grpc): fix wrong usage of span

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4273,7 +4273,7 @@ dependencies = [
 
 [[package]]
 name = "volo-grpc"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/volo-grpc/Cargo.toml
+++ b/volo-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-grpc"
-version = "0.11.5"
+version = "0.11.6"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-grpc/src/server/meta.rs
+++ b/volo-grpc/src/server/meta.rs
@@ -2,6 +2,7 @@ use std::{cell::RefCell, net::SocketAddr, str::FromStr, sync::Arc, task::Poll};
 
 use futures::{FutureExt, future::BoxFuture};
 use metainfo::{Backward, Forward};
+use tracing::Instrument;
 use volo::{FastStr, Service, context::Context};
 
 use crate::{
@@ -125,8 +126,7 @@ where
                     });
                     status_to_http!(status);
                     let span = span_provider.on_serve(&cx, metadata);
-                    let _enter = span.enter();
-                    let volo_resp = match inner.call(&mut cx, volo_req).await {
+                    let volo_resp = match inner.call(&mut cx, volo_req).instrument(span).await {
                         Ok(resp) => resp,
                         Err(err) => {
                             span_provider.leave_serve(&cx);


### PR DESCRIPTION
## Motivation

For async function, span should be used with `instrument` instead of `enter`

## Solution

Fix them