### PR TITLE
fix(volo-build): adapt to the change of pilota pb backend trait for pb custom options codegen and process the pilota.rust_wrapper_arc for init cmd of volo-cli to codegen server template

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.46"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -425,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.46"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -438,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.45"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1781,9 +1781,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "loom"
@@ -2361,9 +2361,8 @@ dependencies = [
 
 [[package]]
 name = "pilota"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e235d8bd36b9c1846bd9f944faee3060d53519abe555b5b64155e87886b3fe2"
+version = "0.12.3"
+source = "git+https://github.com/cloudwego/pilota.git?branch=fix%2Fcustom_options#0c4b7a9f5181f03ffb9eedbb03ba5d526abdd30b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2384,9 +2383,8 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.12.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b11e0e6013cd06488ef0e48a6d334b3ba4ffa9fc09692e897a68898f8cb5cc"
+version = "0.12.15"
+source = "git+https://github.com/cloudwego/pilota.git?branch=fix%2Fcustom_options#0c4b7a9f5181f03ffb9eedbb03ba5d526abdd30b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2422,9 +2420,8 @@ dependencies = [
 
 [[package]]
 name = "pilota-thrift-fieldmask"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6308306be67d4bff638618873a70918bbf1383c1bff13acc530795ded89cdacc"
+version = "0.1.2"
+source = "git+https://github.com/cloudwego/pilota.git?branch=fix%2Fcustom_options#0c4b7a9f5181f03ffb9eedbb03ba5d526abdd30b"
 dependencies = [
  "ahash",
  "faststr",
@@ -2432,14 +2429,14 @@ dependencies = [
  "pilota",
  "pilota-thrift-parser",
  "pilota-thrift-reflect",
+ "serde",
  "thiserror 2.0.16",
 ]
 
 [[package]]
 name = "pilota-thrift-parser"
 version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5ff6b8520c31228693bf3fb2157d6f0ebe7a0198404f492e95f25861249a6b7"
+source = "git+https://github.com/cloudwego/pilota.git?branch=fix%2Fcustom_options#0c4b7a9f5181f03ffb9eedbb03ba5d526abdd30b"
 dependencies = [
  "bytes",
  "faststr",
@@ -2449,8 +2446,7 @@ dependencies = [
 [[package]]
 name = "pilota-thrift-reflect"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd7265747b3aad84071203baee7bfb0cf2057bf8b7b08088560f8817cc900d8"
+source = "git+https://github.com/cloudwego/pilota.git?branch=fix%2Fcustom_options#0c4b7a9f5181f03ffb9eedbb03ba5d526abdd30b"
 dependencies = [
  "ahash",
  "bytes",
@@ -2458,7 +2454,7 @@ dependencies = [
  "faststr",
  "pilota",
  "pilota-thrift-parser",
- "thiserror 1.0.69",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -3649,9 +3645,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.42"
+version = "0.3.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca967379f9d8eb8058d86ed467d81d03e81acd45757e4ca341c24affbe8e8e3"
+checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
 dependencies = [
  "deranged",
  "num-conv",
@@ -3663,15 +3659,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9108bb380861b07264b950ded55a44a14a4adc68b9f5efd85aafc3aa4d40a68"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7182799245a7264ce590b349d90338f1c1affad93d2639aed5f8f69c090b334c"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4226,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "volo-build"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.35"
+version = "1.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590f9024a68a8c40351881787f1934dc11afd69090f5edb6831464694d836ea3"
+checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -399,7 +399,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -695,7 +695,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -869,9 +869,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
+checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
 
 [[package]]
 name = "fixedbitset"
@@ -1089,7 +1089,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.3+wasi-0.2.4",
+ "wasi 0.14.4+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -1658,9 +1658,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2362,7 +2362,8 @@ dependencies = [
 [[package]]
 name = "pilota"
 version = "0.12.3"
-source = "git+https://github.com/cloudwego/pilota.git?branch=fix%2Fcustom_options#0c4b7a9f5181f03ffb9eedbb03ba5d526abdd30b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a89d1987392f07bf54b6851a9693a44288a950ba08f46939e1fda0577d0b88d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2384,7 +2385,8 @@ dependencies = [
 [[package]]
 name = "pilota-build"
 version = "0.12.15"
-source = "git+https://github.com/cloudwego/pilota.git?branch=fix%2Fcustom_options#0c4b7a9f5181f03ffb9eedbb03ba5d526abdd30b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8df9fefd426a915841d575394cc32710c17133acca5a0179d90006fb9c32e9f"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2421,7 +2423,8 @@ dependencies = [
 [[package]]
 name = "pilota-thrift-fieldmask"
 version = "0.1.2"
-source = "git+https://github.com/cloudwego/pilota.git?branch=fix%2Fcustom_options#0c4b7a9f5181f03ffb9eedbb03ba5d526abdd30b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e33211f367fe0d29ef7df90782fb0f2c459a0d8e560230280de199954aa1c41"
 dependencies = [
  "ahash",
  "faststr",
@@ -2436,7 +2439,8 @@ dependencies = [
 [[package]]
 name = "pilota-thrift-parser"
 version = "0.12.1"
-source = "git+https://github.com/cloudwego/pilota.git?branch=fix%2Fcustom_options#0c4b7a9f5181f03ffb9eedbb03ba5d526abdd30b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5ff6b8520c31228693bf3fb2157d6f0ebe7a0198404f492e95f25861249a6b7"
 dependencies = [
  "bytes",
  "faststr",
@@ -2446,7 +2450,8 @@ dependencies = [
 [[package]]
 name = "pilota-thrift-reflect"
 version = "0.1.0"
-source = "git+https://github.com/cloudwego/pilota.git?branch=fix%2Fcustom_options#0c4b7a9f5181f03ffb9eedbb03ba5d526abdd30b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfd7265747b3aad84071203baee7bfb0cf2057bf8b7b08088560f8817cc900d8"
 dependencies = [
  "ahash",
  "bytes",
@@ -2454,7 +2459,7 @@ dependencies = [
  "faststr",
  "pilota",
  "pilota-thrift-parser",
- "thiserror 2.0.16",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2827,9 +2832,9 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.5.0"
+version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
  "bitflags",
 ]
@@ -3237,9 +3242,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4093,9 +4098,9 @@ dependencies = [
 
 [[package]]
 name = "ureq"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00432f493971db5d8e47a65aeb3b02f8226b9b11f1450ff86bb772776ebadd70"
+checksum = "9504c6ba73daec8a6541440ab9fb64f97320251582292265420e5587559c9095"
 dependencies = [
  "base64",
  "cookie_store 0.22.0",
@@ -4114,9 +4119,9 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe120bb823a0061680e66e9075942fcdba06d46551548c2c259766b9558bc9a"
+checksum = "60b4531c118335662134346048ddb0e54cc86bd7e81866757873055f0e38f5d2"
 dependencies = [
  "base64",
  "http",
@@ -4252,7 +4257,7 @@ dependencies = [
 
 [[package]]
 name = "volo-cli"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -4445,30 +4450,31 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.3+wasi-0.2.4"
+version = "0.14.4+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
+checksum = "88a5f4a424faf49c3c2c344f166f0662341d470ea185e939657aaff130f0ec4a"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
 dependencies = [
  "bumpalo",
  "log",
@@ -4480,9 +4486,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "0ca85039a9b469b38336411d6d6ced91f3fc87109a2a27b0c197663f5144dffe"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4493,9 +4499,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4503,9 +4509,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4516,18 +4522,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4588,11 +4594,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -4610,7 +4616,7 @@ dependencies = [
  "windows-collections",
  "windows-core",
  "windows-future",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-numerics",
 ]
 
@@ -4631,7 +4637,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -4643,7 +4649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-threading",
 ]
 
@@ -4676,13 +4682,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4691,7 +4703,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -4702,7 +4714,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4711,7 +4723,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4751,6 +4763,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link 0.2.0",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4787,7 +4808,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -4804,7 +4825,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4966,9 +4987,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
+checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
 
 [[package]]
 name = "writeable"
@@ -5002,18 +5023,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5100,9 +5121,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.15+zstd.1.5.7"
+version = "2.0.16+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,10 +153,10 @@ incremental = false
 overflow-checks = false
 
 [patch.crates-io]
-pilota = { git = "https://github.com/cloudwego/pilota.git", branch = "fix/custom_options" }
-pilota-build = { git = "https://github.com/cloudwego/pilota.git", branch = "fix/custom_options" }
-pilota-thrift-parser = { git = "https://github.com/cloudwego/pilota.git", branch = "fix/custom_options" }
-pilota-thrift-reflect = { git = "https://github.com/cloudwego/pilota.git", branch = "fix/custom_options" }
-pilota-thrift-fieldmask = { git = "https://github.com/cloudwego/pilota.git", branch = "fix/custom_options" }
+# pilota = { git = "https://github.com/cloudwego/pilota.git", branch = "main" }
+# pilota-build = { git = "https://github.com/cloudwego/pilota.git", branch = "main" }
+# pilota-thrift-parser = { git = "https://github.com/cloudwego/pilota.git", branch = "main" }
+# pilota-thrift-reflect = { git = "https://github.com/cloudwego/pilota.git", branch = "main" }
+# pilota-thrift-fieldmask = { git = "https://github.com/cloudwego/pilota.git", branch = "main" }
 # motore = { git = "https://github.com/cloudwego/motore.git", branch = "main" }
 # metainfo = { git = "https://github.com/cloudwego/metainfo.git", branch = "main"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,10 +153,10 @@ incremental = false
 overflow-checks = false
 
 [patch.crates-io]
-# pilota = { git = "https://github.com/cloudwego/pilota.git", branch = "main" }
-# pilota-build = { git = "https://github.com/cloudwego/pilota.git", branch = "main" }
-# pilota-thrift-parser = { git = "https://github.com/cloudwego/pilota.git", branch = "main" }
-# pilota-thrift-reflect = { git = "https://github.com/cloudwego/pilota.git", branch = "main" }
-# pilota-thrift-fieldmask = { git = "https://github.com/cloudwego/pilota.git", branch = "main" }
+pilota = { git = "https://github.com/cloudwego/pilota.git", branch = "fix/custom_options" }
+pilota-build = { git = "https://github.com/cloudwego/pilota.git", branch = "fix/custom_options" }
+pilota-thrift-parser = { git = "https://github.com/cloudwego/pilota.git", branch = "fix/custom_options" }
+pilota-thrift-reflect = { git = "https://github.com/cloudwego/pilota.git", branch = "fix/custom_options" }
+pilota-thrift-fieldmask = { git = "https://github.com/cloudwego/pilota.git", branch = "fix/custom_options" }
 # motore = { git = "https://github.com/cloudwego/motore.git", branch = "main" }
 # metainfo = { git = "https://github.com/cloudwego/metainfo.git", branch = "main"}

--- a/volo-build/Cargo.toml
+++ b/volo-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-build"
-version = "0.11.4"
+version = "0.11.5"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-build/src/grpc_backend.rs
+++ b/volo-build/src/grpc_backend.rs
@@ -809,7 +809,17 @@ impl CodegenBackend for VoloGrpcBackend {
             .codegen_file_descriptor_at_mod(stream, f, mod_path, has_direct)
     }
 
-    fn codegen_exts(&self, stream: &mut String, extensions: &[rir::Extension]) {
-        self.inner.codegen_exts(stream, extensions)
+    fn codegen_exts(
+        &self,
+        stream: &mut String,
+        suffix: &str,
+        cur_pkg: &[Symbol],
+        extensions: &[rir::Extension],
+    ) {
+        self.inner.codegen_exts(stream, suffix, cur_pkg, extensions)
+    }
+
+    fn codegen_impl_enum_message(&self, name: &str) -> String {
+        self.inner.codegen_impl_enum_message(name)
     }
 }

--- a/volo-build/src/thrift_backend.rs
+++ b/volo-build/src/thrift_backend.rs
@@ -819,6 +819,16 @@ impl pilota_build::CodegenBackend for VoloThriftBackend {
                     .inner
                     .codegen_item_ty(a.ty.kind.clone())
                     .global_path("volo_gen");
+                let ty = if let Some(RustWrapperArc(true)) = self
+                    .cx()
+                    .tags(a.tags_id)
+                    .as_ref()
+                    .and_then(|tags| tags.get::<RustWrapperArc>())
+                {
+                    format!("::std::sync::Arc<{ty}>")
+                } else {
+                    ty.to_string()
+                };
                 let ident = self.cx().rust_name(a.def_id).0.field_ident(); // use the _{rust-style fieldname} without keyword escaping
                 format!("_{ident}: {ty}")
             })

--- a/volo-cli/Cargo.toml
+++ b/volo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-cli"
-version = "0.11.2"
+version = "0.11.3"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/volo/blob/main/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
1. volo-cli init command will encounter the error when use pilota.rust_wrapper_arc for method args or ret.
2. pilota-build has adjusted some backend trait methods for pb custom options.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

1. process the annotation for server lib init codegen
2. adapt to the new trait defined in pilota
