### PR TITLE
fix(volo-grpc): don't need sync for BoxStream and encode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4295,7 +4295,7 @@ dependencies = [
 
 [[package]]
 name = "volo-grpc"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/volo-grpc/Cargo.toml
+++ b/volo-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-grpc"
-version = "0.11.6"
+version = "0.11.7"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-grpc/src/codec/encode.rs
+++ b/volo-grpc/src/codec/encode.rs
@@ -17,7 +17,7 @@ pub fn encode<T, S>(
     compression_encoding: Option<CompressionEncoding>,
 ) -> BoxStream<'static, Result<Frame<Bytes>, Status>>
 where
-    S: Stream<Item = Result<T, Status>> + Send + Sync + 'static,
+    S: Stream<Item = Result<T, Status>> + Send + 'static,
     T: Message + 'static,
 {
     Box::pin(async_stream::stream! {

--- a/volo-grpc/src/lib.rs
+++ b/volo-grpc/src/lib.rs
@@ -22,10 +22,9 @@ pub mod tracing;
 pub mod transport;
 
 pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
-pub type BoxStream<'l, T> = std::pin::Pin<Box<dyn futures::Stream<Item = T> + Send + Sync + 'l>>;
-
 pub use client::Client;
 pub use codec::decode::RecvStream;
+pub use futures::stream::BoxStream;
 pub use message::{RecvEntryMessage, SendEntryMessage};
 pub use request::{IntoRequest, IntoStreamingRequest, Request};
 pub use response::Response;


### PR DESCRIPTION
## Motivation

`Sync` trait bound should not be required for BoxStream here.

## Solution

Remove it.
