### PR TITLE
chore(volo): combine rustls and native-tls

### DIFF
--- a/volo-grpc/src/server/mod.rs
+++ b/volo-grpc/src/server/mod.rs
@@ -20,7 +20,7 @@ use motore::{
 pub use service::ServiceBuilder;
 use tower::util::BoxCloneService;
 #[cfg(feature = "__tls")]
-use volo::net::tls::{Acceptor, ServerTlsConfig};
+use volo::net::tls::ServerTlsConfig;
 use volo::{
     net::{conn::Conn, incoming::Incoming},
     spawn,

--- a/volo-http/src/client/transport/tls.rs
+++ b/volo-http/src/client/transport/tls.rs
@@ -1,8 +1,8 @@
 use http::uri::Scheme;
 use motore::service::UnaryService;
 use volo::net::{
-    conn::{Conn, ConnStream},
-    tls::{Connector, TlsConnector},
+    conn::{Conn, ConnInfo, ConnStream},
+    tls::TlsConnector,
 };
 
 use super::{connector::PeerInfo, plain::PlainMakeConnection};
@@ -46,7 +46,12 @@ where
             _ => unreachable!(),
         };
         match self.tls_connector.connect(&target_name, tcp_stream).await {
-            Ok(conn) => Ok(conn),
+            Ok(stream) => Ok(Conn {
+                stream,
+                info: ConnInfo {
+                    peer_addr: Some(req.address),
+                },
+            }),
             Err(err) => {
                 tracing::warn!("[Volo-HTTP] failed to make tls connection, error: {err}");
                 Err(request_error(err))

--- a/volo-http/src/server/mod.rs
+++ b/volo-http/src/server/mod.rs
@@ -29,7 +29,7 @@ use scopeguard::defer;
 use tokio::sync::Notify;
 use tracing::Instrument;
 #[cfg(feature = "__tls")]
-use volo::net::{conn::ConnStream, tls::Acceptor, tls::ServerTlsConfig};
+use volo::net::{conn::ConnStream, tls::ServerTlsConfig};
 use volo::{
     context::Context,
     net::{Address, MakeIncoming, conn::Conn, incoming::Incoming},

--- a/volo/src/net/dial.rs
+++ b/volo/src/net/dial.rs
@@ -78,7 +78,6 @@ impl DefaultMakeTransport {
 
 impl MakeTransport for DefaultMakeTransport {
     type ReadHalf = OwnedReadHalf;
-
     type WriteHalf = OwnedWriteHalf;
 
     async fn make_transport(&self, addr: Address) -> io::Result<(Self::ReadHalf, Self::WriteHalf)> {

--- a/volo/src/net/ready.rs
+++ b/volo/src/net/ready.rs
@@ -20,10 +20,10 @@ impl AsyncReady for OwnedReadHalf {
             OwnedReadHalf::Tcp(half) => half.ready(interest).await,
             #[cfg(target_family = "unix")]
             OwnedReadHalf::Unix(half) => half.ready(interest).await,
-            #[cfg(feature = "rustls")]
-            OwnedReadHalf::Rustls(_) => todo!(),
-            #[cfg(feature = "native-tls")]
-            OwnedReadHalf::NativeTls(_) => todo!(),
+            #[cfg(feature = "__tls")]
+            OwnedReadHalf::Tls(_) => {
+                unimplemented!("AsyncReady is not supported for TLS connection")
+            }
         }
     }
 }
@@ -34,10 +34,10 @@ impl AsyncReady for OwnedWriteHalf {
             OwnedWriteHalf::Tcp(half) => half.ready(interest).await,
             #[cfg(target_family = "unix")]
             OwnedWriteHalf::Unix(half) => half.ready(interest).await,
-            #[cfg(feature = "rustls")]
-            OwnedWriteHalf::Rustls(_) => todo!(),
-            #[cfg(feature = "native-tls")]
-            OwnedWriteHalf::NativeTls(_) => todo!(),
+            #[cfg(feature = "__tls")]
+            OwnedWriteHalf::Tls(_) => {
+                unimplemented!("AsyncReady is not supported for TLS connection")
+            }
         }
     }
 }


### PR DESCRIPTION
## Motivation

In previous implementation, `volo::net::Conn` has 4 variants: `Tcp`, `Unix`, `Rustls` and `NativeTls`, but we think it's not elegant to put `Rustls` and `NativeTls` here. And what's more, in most cases, we only need to be aware of TLS and do not need to be aware of which library is used behind it.

## Solution

Wraps `Rustls` and `NativeTls` into `Tls` prefixed types and makes `Conn` cleaner.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies rustls/native-tls under generic TLS types and updates conn/transport/server paths to use `Tls*`, while bumping `volo`, `volo-grpc`, and `volo-http` versions.
> 
> - **Networking/TLS**:
>   - Introduce unified TLS abstractions: `TlsStream`, `TlsConnector`, `TlsAcceptor`, `OwnedReadHalf`, `OwnedWriteHalf` in `volo/src/net/tls/*`.
>   - Replace `ConnStream::{Rustls,NativeTls}` with `ConnStream::Tls`; update `negotiated_alpn`, `peer_addr`, and split logic accordingly in `volo/src/net/conn.rs`.
>   - Update connector/acceptor APIs to return `ConnStream` via unified `Tls*` types; add builders and ALPN support; mark `AsyncReady` unsupported for TLS in `volo/src/net/ready.rs`.
>   - Disallow Unix domain sockets for TLS transports; route TCP connects through unified TLS in `TlsMakeTransport`.
> - **HTTP** (`volo-http`):
>   - Client: `TlsMakeConnection` now wraps TLS handshake and returns `Conn` with `ConnInfo` using unified `TlsConnector`.
>   - Server: perform TLS accept with `ServerTlsConfig` and `ConnStream::Tcp` only; import cleanup.
>   - Cargo: pin `volo = "0.11.2"` and bump crate to `0.4.4`.
> - **gRPC** (`volo-grpc`):
>   - Server: use `ServerTlsConfig` for TLS; minor import adjustments.
>   - Cargo: bump to `0.11.8` and depend on `volo = "0.11.2"`.
> - **Core** (`volo`):
>   - Expose unified TLS types and builders; adjust dialing/transport to use new TLS path; minor API return type changes (`io::Result`).
>   - Version bump to `0.11.2` and lockfile updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1597eff22e99bd17442061f5ce1f897965be5da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->