### PR TITLE
fix(volo-build): use the global path for exception item when generate…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4227,7 +4227,7 @@ dependencies = [
 
 [[package]]
 name = "volo-build"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4257,7 +4257,7 @@ dependencies = [
 
 [[package]]
 name = "volo-cli"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/volo-build/Cargo.toml
+++ b/volo-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-build"
-version = "0.11.5"
+version = "0.11.6"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-cli/Cargo.toml
+++ b/volo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-cli"
-version = "0.11.3"
+version = "0.11.4"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true


### PR DESCRIPTION
… the thrift server template

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/volo/blob/main/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
The volo-cli init cmd helps to generate the server template, but the method with exception will encounter the reference path problem, which is not adapted to the global path for finding the gen code. 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Use global path for thrift exception type, that is `volo_gen::{item_path}`.
