### PR TITLE
feat(volo-http): add `layer` for `RequestBuilder`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4256,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "volo-http"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ahash",
  "async-broadcast",

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-http"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Motivation

Make `RequestBuilder` more scalable.

## Solution

Add `layer` into `RequestBuilder`.

In addition, `WithOpt` can also be implemented through `layer` method.