### PR TITLE
feat(volo-thrift): support shmipc for pingpong transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4161,7 +4161,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "volo"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "arc-swap",
  "async-broadcast",
@@ -4261,7 +4261,7 @@ dependencies = [
 
 [[package]]
 name = "volo-grpc"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4307,7 +4307,7 @@ dependencies = [
 
 [[package]]
 name = "volo-http"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "ahash",
  "async-broadcast",
@@ -4364,7 +4364,7 @@ version = "0.12.0"
 
 [[package]]
 name = "volo-thrift"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "ahash",
  "anyhow",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -112,20 +112,27 @@ path = "src/grpc/grpc-web/client.rs"
 [[bin]]
 name = "example-http-server"
 path = "src/http/example-http-server.rs"
-
 [[bin]]
 name = "example-http-client"
 path = "src/http/example-http-client.rs"
-
 [[bin]]
 name = "http-tls-server"
 path = "src/http/http-tls-server.rs"
 required-features = ["__tls"]
-
 [[bin]]
 name = "http-tls-client"
 path = "src/http/http-tls-client.rs"
 required-features = ["__tls"]
+
+# shmipc
+[[bin]]
+name = "shmipc-thrift-server"
+path = "src/thrift/shmipc/server.rs"
+required-features = ["shmipc"]
+[[bin]]
+name = "shmipc-thrift-client"
+path = "src/thrift/shmipc/client.rs"
+required-features = ["shmipc"]
 
 [dependencies]
 anyhow.workspace = true
@@ -166,6 +173,7 @@ volo-gen = { path = "./volo-gen" }
 
 [features]
 tls = ["rustls"]
+shmipc = ["volo/shmipc", "volo-thrift/shmipc"]
 
 __tls = []
 rustls = ["__tls", "volo/rustls", "volo-grpc/rustls", "volo-http/rustls"]

--- a/examples/src/thrift/shmipc/client.rs
+++ b/examples/src/thrift/shmipc/client.rs
@@ -1,0 +1,56 @@
+use std::sync::LazyLock;
+
+use volo_thrift::client::CallOpt;
+
+static CLIENT: LazyLock<volo_gen::thrift_gen::hello::HelloServiceClient> = LazyLock::new(|| {
+    let uds_path = std::os::unix::net::SocketAddr::from_pathname("/tmp/hello_test.sock").unwrap();
+    volo_gen::thrift_gen::hello::HelloServiceClientBuilder::new("hello")
+        .address(volo::net::ShmipcAddr(uds_path))
+        .build()
+});
+
+#[volo::main]
+async fn main() {
+    let subscriber = tracing_subscriber::FmtSubscriber::builder()
+        .with_max_level(tracing::Level::WARN)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+
+    let config = volo::net::shmipc::config::Config {
+        share_memory_path_prefix: "/dev/shm/client.ipc.shm".to_string(),
+        mem_map_type: volo::net::shmipc::config::MemMapType::MemMapTypeMemFd,
+        ..Default::default()
+    };
+    volo::net::shmipc::config::DEFAULT_SHMIPC_CONFIG.store(config.into());
+
+    let desc = volo_gen::thrift_gen::hello::HelloRequest::get_descriptor()
+        .unwrap()
+        .type_descriptor();
+    println!("{desc:?}");
+
+    loop {
+        let fm = pilota_thrift_fieldmask::FieldMaskBuilder::new(&desc, &["$.hello"])
+            .with_options(pilota_thrift_fieldmask::Options::new().with_black_list_mode(true))
+            .build()
+            .unwrap();
+        println!("{fm:?}");
+        let mut req = volo_gen::thrift_gen::hello::HelloRequest {
+            name: "volo".into(),
+            hello: Some("world".into()),
+            _field_mask: None,
+        };
+        req.set_field_mask(fm);
+
+        println!("req with field mask: {req:?}");
+        let resp = CLIENT
+            .clone()
+            .with_callopt(CallOpt::default())
+            .hello(req)
+            .await;
+        match resp {
+            Ok(info) => println!("{info:?}"),
+            Err(e) => eprintln!("{e:?}"),
+        }
+        // tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+}

--- a/examples/src/thrift/shmipc/server.rs
+++ b/examples/src/thrift/shmipc/server.rs
@@ -1,0 +1,31 @@
+pub struct S;
+
+impl volo_gen::thrift_gen::hello::HelloService for S {
+    async fn hello(
+        &self,
+        req: volo_gen::thrift_gen::hello::HelloRequest,
+    ) -> Result<volo_gen::thrift_gen::hello::HelloResponse, volo_thrift::ServerError> {
+        println!("req: {req:?}");
+        let resp = volo_gen::thrift_gen::hello::HelloResponse {
+            message: format!("Hello, {}!", req.name).into(),
+            _field_mask: None,
+        };
+        Ok(resp)
+    }
+}
+
+#[volo::main]
+async fn main() {
+    let subscriber = tracing_subscriber::FmtSubscriber::builder()
+        .with_max_level(tracing::Level::WARN)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+
+    let addr = std::os::unix::net::SocketAddr::from_pathname("/tmp/hello_test.sock").unwrap();
+    let addr = volo::net::Address::from(volo::net::ShmipcAddr(addr));
+
+    volo_gen::thrift_gen::hello::HelloServiceServer::new(S)
+        .run(addr)
+        .await
+        .unwrap();
+}

--- a/volo-grpc/Cargo.toml
+++ b/volo-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-grpc"
-version = "0.12.1"
+version = "0.12.2"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
@@ -24,7 +24,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 pilota.workspace = true
-volo = { version = "0.12", path = "../volo" }
+volo = { version = "0.12.2", path = "../volo" }
 motore = { workspace = true, features = ["tower"] }
 metainfo.workspace = true
 async-broadcast.workspace = true

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-http"
-version = "0.5.2"
+version = "0.5.3"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
@@ -19,7 +19,7 @@ keywords = ["async", "rpc", "http"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-volo = { version = "0.12", path = "../volo" }
+volo = { version = "0.12.2", path = "../volo" }
 
 ahash.workspace = true
 bytes.workspace = true

--- a/volo-thrift/Cargo.toml
+++ b/volo-thrift/Cargo.toml
@@ -58,3 +58,5 @@ multiplex = []
 unsafe-codec = []
 # This will use unwrap_unchecked instead of unwrap in some places.
 unsafe_unchecked = ["volo/unsafe_unchecked"]
+
+shmipc = ["volo/shmipc"]

--- a/volo-thrift/Cargo.toml
+++ b/volo-thrift/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-thrift"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
@@ -19,7 +19,7 @@ keywords = ["async", "rpc", "thrift"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-volo = { version = "0.12", path = "../volo" }
+volo = { version = "0.12.2", path = "../volo" }
 pilota.workspace = true
 motore.workspace = true
 metainfo.workspace = true

--- a/volo-thrift/src/codec/mod.rs
+++ b/volo-thrift/src/codec/mod.rs
@@ -23,6 +23,11 @@ pub trait Decoder: Send + Sync + 'static {
     fn is_closed(&self) -> impl Future<Output = bool> + Send {
         async { false }
     }
+
+    #[cfg(feature = "shmipc")]
+    fn shmipc_helper(&self) -> ::volo::net::shmipc::ShmipcHelper {
+        ::volo::net::shmipc::ShmipcHelper::none()
+    }
 }
 
 /// [`Encoder`] writes a [`ThriftMessage`] to an [`AsyncWrite`] and flushes the data.
@@ -37,6 +42,11 @@ pub trait Encoder: Send + Sync + 'static {
 
     fn is_closed(&self) -> impl Future<Output = bool> + Send {
         async { false }
+    }
+
+    #[cfg(feature = "shmipc")]
+    fn shmipc_helper(&self) -> ::volo::net::shmipc::ShmipcHelper {
+        ::volo::net::shmipc::ShmipcHelper::none()
     }
 }
 

--- a/volo-thrift/src/transport/multiplex/client.rs
+++ b/volo-thrift/src/transport/multiplex/client.rs
@@ -61,6 +61,13 @@ where
     type Error = io::Error;
 
     async fn call(&self, target: Address) -> Result<Self::Response, Self::Error> {
+        #[cfg(feature = "shmipc")]
+        if target.is_shmipc() {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "shmipc does not support multiplex",
+            ));
+        }
         let make_transport = self.make_transport.clone();
         let (rh, wh) = make_transport.make_transport(target.clone()).await?;
         Ok(ThriftTransport::new(

--- a/volo/Cargo.toml
+++ b/volo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo"
-version = "0.12.1"
+version = "0.12.2"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo/src/net/mod.rs
+++ b/volo/src/net/mod.rs
@@ -134,7 +134,10 @@ impl Hash for Address {
                 }
             }
             #[cfg(feature = "shmipc")]
-            Self::Shmipc(addr) => Hash::hash(addr, state),
+            Self::Shmipc(addr) => {
+                state.write_u8(4);
+                Hash::hash(addr, state);
+            }
         }
     }
 }


### PR DESCRIPTION
## Motivation

Introduce ShmIPC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces optional ShmIPC support in `volo-thrift` ping-pong transport and wires it through codec, client, and server paths.
> 
> - Adds `shmipc` feature and `shmipc_helper` plumbing to `Encoder`/`Decoder` and default codec for managing reuse/close semantics
> - Updates ping-pong client/server/transport to reuse/close via ShmIPC; guards against multiplex over ShmIPC and returns an error if attempted
> - Extends server accept loop to reject multiplex when peer is ShmIPC; adds close guards on ShmIPC connections
> - Adds `examples` binaries: `shmipc-thrift-server` and `shmipc-thrift-client` gated by `shmipc`
> - Bumps versions: `volo` to `0.12.2`, `volo-grpc` to `0.12.2`, `volo-http` to `0.5.3`, `volo-thrift` to `0.12.1`; aligns dependencies
> - Minor: switch some logs to `tracing::trace/warn/debug`; fix `Address` hash discriminator for `Shmipc`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17cb5630082f834c67536ddd1cc8630b151c182c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->