### PR TITLE
chore: remove `doc_auto_cfg` in volo, volo-http and volo-grpc

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,11 +57,11 @@ jobs:
           toolchain: ${{matrix.rust}}
       - name: Docs check
         run: |
-          cargo rustdoc -p volo --all-features -- --deny warnings
-          cargo rustdoc -p volo-build --all-features -- --deny warnings
-          cargo rustdoc -p volo-grpc --all-features -- --deny warnings
-          cargo rustdoc -p volo-http --all-features -- --deny warnings
-          cargo rustdoc -p volo-thrift --all-features -- --deny warnings
+          cargo +nightly rustdoc -p volo --all-features --config 'build.rustdocflags=["--cfg", "docsrs"]' -- --deny warnings
+          cargo +nightly rustdoc -p volo-build --all-features --config 'build.rustdocflags=["--cfg", "docsrs"]' -- --deny warnings
+          cargo +nightly rustdoc -p volo-grpc --all-features --config 'build.rustdocflags=["--cfg", "docsrs"]' -- --deny warnings
+          cargo +nightly rustdoc -p volo-http --all-features --config 'build.rustdocflags=["--cfg", "docsrs"]' -- --deny warnings
+          cargo +nightly rustdoc -p volo-thrift --all-features --config 'build.rustdocflags=["--cfg", "docsrs"]' -- --deny warnings
 
   test-linux:
     runs-on: [self-hosted, Linux, amd64]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4112,7 +4112,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "volo"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "async-broadcast",
  "dashmap",
@@ -4210,7 +4210,7 @@ dependencies = [
 
 [[package]]
 name = "volo-grpc"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4256,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "volo-http"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "ahash",
  "async-broadcast",

--- a/scripts/selftest.sh
+++ b/scripts/selftest.sh
@@ -22,11 +22,11 @@ fmt_check() {
 }
 
 docs_check() {
-	echo_and_run cargo rustdoc -p volo --all-features -- --deny warnings
-	echo_and_run cargo rustdoc -p volo-build --all-features -- --deny warnings
-	echo_and_run cargo rustdoc -p volo-grpc --all-features -- --deny warnings
-	echo_and_run cargo rustdoc -p volo-http --all-features -- --deny warnings
-	echo_and_run cargo rustdoc -p volo-thrift --all-features -- --deny warnings
+	echo_and_run cargo +nightly rustdoc -p volo --all-features --config 'build.rustdocflags=["--cfg", "docsrs"]' -- --deny warnings
+	echo_and_run cargo +nightly rustdoc -p volo-build --all-features --config 'build.rustdocflags=["--cfg", "docsrs"]' -- --deny warnings
+	echo_and_run cargo +nightly rustdoc -p volo-grpc --all-features --config 'build.rustdocflags=["--cfg", "docsrs"]' -- --deny warnings
+	echo_and_run cargo +nightly rustdoc -p volo-http --all-features --config 'build.rustdocflags=["--cfg", "docsrs"]' -- --deny warnings
+	echo_and_run cargo +nightly rustdoc -p volo-thrift --all-features --config 'build.rustdocflags=["--cfg", "docsrs"]' -- --deny warnings
 }
 
 clippy_and_test() {

--- a/volo-grpc/Cargo.toml
+++ b/volo-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-grpc"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-grpc/src/lib.rs
+++ b/volo-grpc/src/lib.rs
@@ -3,7 +3,6 @@
 )]
 #![cfg_attr(not(doctest), doc = include_str!("../README.md"))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![allow(clippy::result_large_err)]
 
 pub mod body;

--- a/volo-http/Cargo.toml
+++ b/volo-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-http"
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-http/src/lib.rs
+++ b/volo-http/src/lib.rs
@@ -2,7 +2,7 @@
     html_logo_url = "https://github.com/cloudwego/volo/raw/main/.github/assets/logo.png?sanitize=true"
 )]
 #![cfg_attr(not(doctest), doc = include_str!("../README.md"))]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(missing_docs)]
 
 pub mod body;

--- a/volo/Cargo.toml
+++ b/volo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo/src/lib.rs
+++ b/volo/src/lib.rs
@@ -2,7 +2,7 @@
     html_logo_url = "https://github.com/cloudwego/volo/raw/main/.github/assets/logo.png?sanitize=true"
 )]
 #![cfg_attr(not(doctest), doc = include_str!("../README.md"))]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub use motore::{Service, layer, layer::Layer, service};
 pub use tokio::main;


### PR DESCRIPTION
## Motivation

Cargo removed `doc_auto_cfg` in version 1.92.0; adding this item would cause document generation to fail.

ref:
- <https://docs.rs/crate/volo-http/latest/builds/2805732>
- <https://github.com/rust-lang/rust/pull/138907>

## Solution

- Remove them
- Run `rustdoc` with `--cfg docsrs` in test cases
- Release a new version to trigger it again
