### PR TITLE
feat(thrift): add support for shmipc fallback address

### DIFF
--- a/volo/src/net/mod.rs
+++ b/volo/src/net/mod.rs
@@ -4,6 +4,8 @@ pub mod ext;
 pub mod incoming;
 #[cfg(feature = "shmipc")]
 pub mod shmipc;
+#[cfg(feature = "shmipc")]
+pub mod shmipc_fallback;
 #[cfg(feature = "__tls")]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "rustls", feature = "native-tls"))))]
 pub mod tls;

--- a/volo/src/net/shmipc_fallback.rs
+++ b/volo/src/net/shmipc_fallback.rs
@@ -1,0 +1,123 @@
+use std::io;
+
+use futures::{FutureExt, future::Either};
+
+use super::{
+    Address, DefaultIncoming, MakeIncoming,
+    conn::{Conn, OwnedReadHalf, OwnedWriteHalf},
+    dial::{DefaultMakeTransport, MakeTransport},
+    incoming::Incoming,
+};
+
+pub struct ShmipcAddressWithFallback<MI> {
+    pub shmipc_addr: Address,
+    pub default_mi: MI,
+}
+
+impl<MI, I> MakeIncoming for ShmipcAddressWithFallback<MI>
+where
+    MI: MakeIncoming<Incoming = I> + Send,
+    I: Incoming + Send,
+{
+    type Incoming = ShmipcIncoming<I>;
+
+    async fn make_incoming(self) -> io::Result<Self::Incoming> {
+        Ok(ShmipcIncoming {
+            shmipc_listener: self.shmipc_addr.make_incoming().await?,
+            default_incoming: self.default_mi.make_incoming().await?,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct ShmipcIncoming<I> {
+    shmipc_listener: DefaultIncoming,
+    default_incoming: I,
+}
+
+impl<I> Incoming for ShmipcIncoming<I>
+where
+    I: Incoming,
+{
+    async fn accept(&mut self) -> io::Result<Option<Conn>> {
+        self.try_next().await
+    }
+}
+
+impl<I> ShmipcIncoming<I>
+where
+    I: Incoming,
+{
+    async fn try_next(&mut self) -> io::Result<Option<Conn>> {
+        let shmipc_conn = self.shmipc_listener.accept().fuse();
+        let default_conn = self.default_incoming.accept().fuse();
+        futures::pin_mut!(shmipc_conn, default_conn);
+        match futures::future::select(shmipc_conn, default_conn).await {
+            Either::Left((conn, _)) => {
+                tracing::trace!("recv a conn from shmipc");
+                conn
+            }
+            Either::Right((conn, _)) => {
+                tracing::trace!("recv a conn from default");
+                conn
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ShmipcMakeTransportWithFallback {
+    pub shmipc_mkt: DefaultMakeTransport,
+    pub default_mkt: DefaultMakeTransport,
+    pub fallback_addr: Address,
+}
+
+impl ShmipcMakeTransportWithFallback {
+    pub fn new(
+        shmipc: DefaultMakeTransport,
+        default_mkt: DefaultMakeTransport,
+        fallback_addr: Address,
+    ) -> Self {
+        Self {
+            shmipc_mkt: shmipc,
+            default_mkt,
+            fallback_addr,
+        }
+    }
+}
+
+impl MakeTransport for ShmipcMakeTransportWithFallback {
+    type ReadHalf = OwnedReadHalf;
+    type WriteHalf = OwnedWriteHalf;
+
+    async fn make_transport(
+        &self,
+        mut addr: Address,
+    ) -> io::Result<(Self::ReadHalf, Self::WriteHalf)> {
+        if addr.is_shmipc() {
+            match self.shmipc_mkt.make_transport(addr).await {
+                Ok(ret) => return Ok(ret),
+                Err(e) => {
+                    tracing::info!(
+                        "failed to connect to shmipc target: {e}, fallback to default target"
+                    );
+                    addr = self.fallback_addr.clone();
+                }
+            }
+        }
+
+        self.default_mkt.make_transport(addr).await
+    }
+
+    fn set_connect_timeout(&mut self, timeout: Option<std::time::Duration>) {
+        self.default_mkt.set_connect_timeout(timeout);
+    }
+
+    fn set_read_timeout(&mut self, timeout: Option<std::time::Duration>) {
+        self.default_mkt.set_read_timeout(timeout);
+    }
+
+    fn set_write_timeout(&mut self, timeout: Option<std::time::Duration>) {
+        self.default_mkt.set_write_timeout(timeout);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/volo/blob/main/CONTRIBUTING.md
-->

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/volo/blob/main/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
Currently, volo-thrift supports shmipc transport for high-performance local communication but it may not be available or fail to connect. This PR introduces functionality which allows users to set a fallback address.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Added ShmipcMakeTransportWithFallback which wraps a DefaultMakeTransport