### PR TITLE
feat(thrift): add fallback address option for shmipc

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,7 @@ jobs:
           toolchain: ${{matrix.rust}}
       - name: Run tests
         run: |
-          bash scripts/install-linux-dependencies.sh
+          sudo bash scripts/install-linux-dependencies.sh
           bash scripts/clippy-and-test.sh
 
   test-linux-aarch64:
@@ -94,7 +94,7 @@ jobs:
           toolchain: ${{matrix.rust}}
       - name: Run tests
         run: |
-          bash scripts/install-linux-dependencies.sh
+          sudo bash scripts/install-linux-dependencies.sh
           bash scripts/clippy-and-test.sh --no-test
 
   test-macos:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       - run: exit 0
 
   lint:
-    runs-on: [self-hosted, Linux, amd64]
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -44,7 +44,7 @@ jobs:
           cargo fmt -- --check
 
   docs-check:
-    runs-on: [self-hosted, Linux, amd64]
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -81,7 +81,7 @@ jobs:
           bash scripts/clippy-and-test.sh
 
   test-linux-aarch64:
-    runs-on: [self-hosted, Linux, aarch64]
+    runs-on: ubuntu-24.04-arm
 
     strategy:
       matrix:
@@ -98,7 +98,7 @@ jobs:
           bash scripts/clippy-and-test.sh --no-test
 
   test-macos:
-    runs-on: [self-hosted, macOS]
+    runs-on: macos-latest
 
     strategy:
       matrix:
@@ -114,7 +114,7 @@ jobs:
           bash scripts/clippy-and-test.sh --no-test --no-shmipc
 
   test-windows:
-    runs-on: [self-hosted, Windows]
+    runs-on: windows-latest
 
     strategy:
       matrix:
@@ -130,7 +130,7 @@ jobs:
           bash scripts/clippy-and-test.sh --no-test --no-shmipc
 
   test-cli:
-    runs-on: [self-hosted, Linux, amd64]
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -146,7 +146,7 @@ jobs:
           bash scripts/volo-cli-test.sh
 
   coverage:
-    runs-on: [self-hosted, Linux, amd64]
+    runs-on: ubuntu-latest
     timeout-minutes: 40
     permissions:
       contents: read

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -6,7 +6,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: [self-hosted, Linux, amd64]
+    runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4161,7 +4161,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "volo"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "arc-swap",
  "async-broadcast",
@@ -4364,7 +4364,7 @@ version = "0.12.0"
 
 [[package]]
 name = "volo-thrift"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "ahash",
  "anyhow",

--- a/volo-thrift/Cargo.toml
+++ b/volo-thrift/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-thrift"
-version = "0.12.2"
+version = "0.12.3"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-thrift/src/client/mod.rs
+++ b/volo-thrift/src/client/mod.rs
@@ -499,26 +499,31 @@ impl<IL, OL, C, Req, Resp, MkT, MkC, LB> ClientBuilder<IL, OL, C, Req, Resp, MkT
 
     #[cfg(feature = "shmipc")]
     /// Set the address for the client with shmipc fallback.
-    pub fn address_with_fallback<A1: Into<Address>, A2: Into<Address>>(
+    ///
+    /// Must be called after `.address(shmipc_addr)`.
+    pub fn shmipc_fallback_address<A: Into<Address>>(
         self,
-        shmipc_addr: A1,
-        fallback_addr: A2,
+        fallback_addr: A,
     ) -> ClientBuilder<IL, OL, C, Req, Resp, ShmipcMakeTransportWithFallback, MkC, LB> {
+        let shmipc_addr = self
+            .address
+            .expect("Must call .address() before .with_fallback_address()");
+
         ClientBuilder {
-            address: Some(shmipc_addr.into()),
+            config: self.config,
+            pool: self.pool,
+            caller_name: self.caller_name,
+            callee_name: self.callee_name,
+            address: Some(shmipc_addr),
+            inner_layer: self.inner_layer,
+            outer_layer: self.outer_layer,
+            mk_client: self.mk_client,
+            _marker: PhantomData,
             make_transport: ShmipcMakeTransportWithFallback::new(
                 DefaultMakeTransport::default(),
                 DefaultMakeTransport::default(),
                 fallback_addr.into(),
             ),
-            config: self.config,
-            pool: self.pool,
-            caller_name: self.caller_name,
-            callee_name: self.callee_name,
-            inner_layer: self.inner_layer,
-            outer_layer: self.outer_layer,
-            mk_client: self.mk_client,
-            _marker: PhantomData,
             make_codec: self.make_codec,
             mk_lb: self.mk_lb,
             disable_timeout_layer: self.disable_timeout_layer,

--- a/volo/Cargo.toml
+++ b/volo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo"
-version = "0.12.2"
+version = "0.12.3"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo/src/net/mod.rs
+++ b/volo/src/net/mod.rs
@@ -4,6 +4,8 @@ pub mod ext;
 pub mod incoming;
 #[cfg(feature = "shmipc")]
 pub mod shmipc;
+#[cfg(feature = "shmipc")]
+pub mod shmipc_fallback;
 #[cfg(feature = "__tls")]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "rustls", feature = "native-tls"))))]
 pub mod tls;

--- a/volo/src/net/shmipc_fallback.rs
+++ b/volo/src/net/shmipc_fallback.rs
@@ -1,0 +1,123 @@
+use std::io;
+
+use futures::{FutureExt, future::Either};
+
+use super::{
+    Address, DefaultIncoming, MakeIncoming,
+    conn::{Conn, OwnedReadHalf, OwnedWriteHalf},
+    dial::{DefaultMakeTransport, MakeTransport},
+    incoming::Incoming,
+};
+
+pub struct ShmipcAddressWithFallback<MI> {
+    pub shmipc_addr: Address,
+    pub default_mi: MI,
+}
+
+impl<MI, I> MakeIncoming for ShmipcAddressWithFallback<MI>
+where
+    MI: MakeIncoming<Incoming = I> + Send,
+    I: Incoming + Send,
+{
+    type Incoming = ShmipcIncoming<I>;
+
+    async fn make_incoming(self) -> io::Result<Self::Incoming> {
+        Ok(ShmipcIncoming {
+            shmipc_listener: self.shmipc_addr.make_incoming().await?,
+            default_incoming: self.default_mi.make_incoming().await?,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct ShmipcIncoming<I> {
+    shmipc_listener: DefaultIncoming,
+    default_incoming: I,
+}
+
+impl<I> Incoming for ShmipcIncoming<I>
+where
+    I: Incoming,
+{
+    async fn accept(&mut self) -> io::Result<Option<Conn>> {
+        self.try_next().await
+    }
+}
+
+impl<I> ShmipcIncoming<I>
+where
+    I: Incoming,
+{
+    async fn try_next(&mut self) -> io::Result<Option<Conn>> {
+        let shmipc_conn = self.shmipc_listener.accept().fuse();
+        let default_conn = self.default_incoming.accept().fuse();
+        futures::pin_mut!(shmipc_conn, default_conn);
+        match futures::future::select(shmipc_conn, default_conn).await {
+            Either::Left((conn, _)) => {
+                tracing::trace!("recv a conn from shmipc");
+                conn
+            }
+            Either::Right((conn, _)) => {
+                tracing::trace!("recv a conn from default");
+                conn
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ShmipcMakeTransportWithFallback {
+    pub shmipc_mkt: DefaultMakeTransport,
+    pub default_mkt: DefaultMakeTransport,
+    pub fallback_addr: Address,
+}
+
+impl ShmipcMakeTransportWithFallback {
+    pub fn new(
+        shmipc: DefaultMakeTransport,
+        default_mkt: DefaultMakeTransport,
+        fallback_addr: Address,
+    ) -> Self {
+        Self {
+            shmipc_mkt: shmipc,
+            default_mkt,
+            fallback_addr,
+        }
+    }
+}
+
+impl MakeTransport for ShmipcMakeTransportWithFallback {
+    type ReadHalf = OwnedReadHalf;
+    type WriteHalf = OwnedWriteHalf;
+
+    async fn make_transport(
+        &self,
+        mut addr: Address,
+    ) -> io::Result<(Self::ReadHalf, Self::WriteHalf)> {
+        if addr.is_shmipc() {
+            match self.shmipc_mkt.make_transport(addr).await {
+                Ok(ret) => return Ok(ret),
+                Err(e) => {
+                    tracing::info!(
+                        "failed to connect to shmipc target: {e}, fallback to default target"
+                    );
+                    addr = self.fallback_addr.clone();
+                }
+            }
+        }
+
+        self.default_mkt.make_transport(addr).await
+    }
+
+    fn set_connect_timeout(&mut self, timeout: Option<std::time::Duration>) {
+        self.default_mkt.set_connect_timeout(timeout);
+    }
+
+    fn set_read_timeout(&mut self, timeout: Option<std::time::Duration>) {
+        self.default_mkt.set_read_timeout(timeout);
+    }
+
+    fn set_write_timeout(&mut self, timeout: Option<std::time::Duration>) {
+        self.default_mkt.set_write_timeout(timeout);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/volo/blob/main/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
Currently, volo-thrift supports shmipc transport for high-performance local communication but it may not be available or fail to connect. This PR introduces functionality which allows users to set a fallback address.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Added ShmipcMakeTransportWithFallback which wraps a DefaultMakeTransport