### PR TITLE
fix(volo-thrift): eliminate multiplex pool race causing ghost connections

### DIFF
--- a/volo-thrift/src/transport/multiplex/thrift_transport.rs
+++ b/volo-thrift/src/transport/multiplex/thrift_transport.rs
@@ -382,7 +382,6 @@ impl<TTEncoder: Send, Resp: Send> Poolable for ThriftTransport<TTEncoder, Resp> 
         if !self.write_error.load(std::sync::atomic::Ordering::Relaxed)
             && !self.read_error.load(std::sync::atomic::Ordering::Relaxed)
             && !self.read_closed.load(std::sync::atomic::Ordering::Relaxed)
-            && !self.dirty.load(std::sync::atomic::Ordering::Relaxed)
         {
             Some(self.clone())
         } else {

--- a/volo-thrift/src/transport/multiplex/thrift_transport.rs
+++ b/volo-thrift/src/transport/multiplex/thrift_transport.rs
@@ -377,4 +377,16 @@ impl<TTEncoder: Send, Resp: Send> Poolable for ThriftTransport<TTEncoder, Resp> 
     fn can_share(&self) -> bool {
         true
     }
+
+    fn try_checkout(&self) -> Option<Self> {
+        if !self.write_error.load(std::sync::atomic::Ordering::Relaxed)
+            && !self.read_error.load(std::sync::atomic::Ordering::Relaxed)
+            && !self.read_closed.load(std::sync::atomic::Ordering::Relaxed)
+            && !self.dirty.load(std::sync::atomic::Ordering::Relaxed)
+        {
+            Some(self.clone())
+        } else {
+            None
+        }
+    }
 }

--- a/volo-thrift/src/transport/pool/mod.rs
+++ b/volo-thrift/src/transport/pool/mod.rs
@@ -57,6 +57,16 @@ pub trait Poolable: Sized {
     fn can_share(&self) -> bool {
         false
     }
+
+    /// Synchronous, non-consuming checkout for shared connections.
+    ///
+    /// Returns `Some(clone)` if the connection is reusable; `None` otherwise.
+    /// This allows shared (multiplex) connections to be checked out while
+    /// holding the pool lock, eliminating the race window where the idle pool
+    /// appears empty to concurrent callers.
+    fn try_checkout(&self) -> Option<Self> {
+        None
+    }
 }
 
 /// When checking out a pooled connection, it might be that the connection
@@ -239,6 +249,26 @@ impl<K: Key, T: Poolable + Send + 'static> Pool<K, T> {
 
                     if let Some(list) = inner.idle.get_mut(&key) {
                         tracing::trace!("[VOLO] take? {:?}: expiration = {:?}", key, expiration.0);
+
+                        // Fast path: shared (multiplex) connections can be checked out
+                        // synchronously while holding the lock. This avoids the race where
+                        // the idle pool appears empty after pop, causing spurious new
+                        // connections.
+                        while list.front().is_some_and(|e| e.inner.can_share()) {
+                            if expiration.expires(list[0].idle_at) {
+                                list.pop_front();
+                                continue;
+                            }
+                            if let Some(conn) = list[0].inner.try_checkout() {
+                                list[0].idle_at = Instant::now();
+                                return Ok(self.reuse(&key, conn));
+                            }
+                            // try_checkout returned None: either not implemented or
+                            // connection is broken. Fall through to the slow path
+                            // which will do the full async reusable() check.
+                            break;
+                        }
+
                         while let Some(entry) = list.pop_front() {
                             // TODO: Actually, since the `idle` list is pushed to the end always,
                             // that would imply that if *this* entry is expired, then anything


### PR DESCRIPTION
## Summary

- Fix race condition in `Pool::get()` where multiplex shared connections were popped from the idle pool, lock released for `reusable()` check, then cloned and reinserted — during the unlock window concurrent callers saw the pool as empty and created spurious TCP connections ("ghosts") that led to TIME_WAIT buildup under high concurrency (20k+ QPS)
- Add `Poolable::try_checkout()` for synchronous, non-consuming checkout of shared connections while holding the pool lock, so the idle pool never appears empty to concurrent callers
- Multiplex `ThriftTransport` implements `try_checkout` by checking `write_error`, `read_error`, `read_closed`, and `dirty` flags (4 atomic loads + cheap `Arc` clone)
- When `try_checkout()` returns `None` (not implemented or connection broken), falls through to the existing slow path, preserving backward compatibility for external `Poolable` implementations

## Test plan

- [x] `cargo build -p volo-thrift` (default features)
- [x] `cargo build -p volo-thrift --features multiplex`
- [x] `cargo test -p volo-thrift` (all 15 tests pass)
- [x] `cargo clippy -p volo-thrift --features multiplex` (no warnings)
- [ ] Manual verification under high-concurrency multiplex workload to confirm TIME_WAIT count reduction

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core connection pooling concurrency logic; subtle locking/checkout behavior changes could impact reuse or liveness under load despite a backward-compatible default.
> 
> **Overview**
> Fixes a race in `Pool::get()` for shared/multiplex connections by adding a lock-held fast path that checks out a reusable shared connection without popping it first, preventing concurrent callers from seeing an empty idle pool and opening extra “ghost” connections.
> 
> Introduces `Poolable::try_checkout()` (default `None`) for synchronous non-consuming checkout, and implements it for multiplex `ThriftTransport` by cloning only when its error/closed/dirty flags indicate the transport is safe to reuse; otherwise the pool falls back to the existing async `reusable()` slow path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cef4d761ac5503f1abd9b588899e57c2aea88841. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->