### PR TITLE
feat(volo-build): add option to preserve idl field names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,7 +758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1573,7 +1573,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2271,9 +2271,8 @@ dependencies = [
 
 [[package]]
 name = "pilota"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b2b4411cfe7a943e5109deeaefe170f16b395e584917fb25c8d95d2b85695a"
+version = "0.13.1"
+source = "git+https://github.com/Joshuahoky/pilota.git?branch=feat%2Fserde_rename_plugin#51173ac1d5fccfc0d530afc1b45a65dfe3a064cd"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2294,9 +2293,8 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9009e333edaac3698d6da157cb3eafa38777ec77d7954ce7f93026be048323a1"
+version = "0.13.10"
+source = "git+https://github.com/Joshuahoky/pilota.git?branch=feat%2Fserde_rename_plugin#51173ac1d5fccfc0d530afc1b45a65dfe3a064cd"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2351,9 +2349,8 @@ dependencies = [
 
 [[package]]
 name = "pilota-thrift-parser"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a446cfb1c72ce1717620d5a0a49430aae965ca1a873922280d39c161b97e8370"
+version = "0.13.6"
+source = "git+https://github.com/Joshuahoky/pilota.git?branch=feat%2Fserde_rename_plugin#51173ac1d5fccfc0d530afc1b45a65dfe3a064cd"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -2366,8 +2363,7 @@ dependencies = [
 [[package]]
 name = "pilota-thrift-reflect"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23783143b2508a130f578f289ed0a0ddf5e4ed3a5b400408e0f866604e2240ae"
+source = "git+https://github.com/Joshuahoky/pilota.git?branch=feat%2Fserde_rename_plugin#51173ac1d5fccfc0d530afc1b45a65dfe3a064cd"
 dependencies = [
  "ahash",
  "bytes",
@@ -2377,6 +2373,7 @@ dependencies = [
  "pilota",
  "pilota-thrift-parser",
  "thiserror 2.0.17",
+ "tracing",
 ]
 
 [[package]]
@@ -2650,7 +2647,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2989,7 +2986,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3002,7 +2999,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3167,7 +3164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3430,6 +3427,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
+ "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -3527,7 +3525,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5190,3 +5188,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "pilota-thrift-fieldmask"
+version = "0.2.1"
+source = "git+https://github.com/Joshuahoky/pilota.git?branch=feat%2Fserde_rename_plugin#51173ac1d5fccfc0d530afc1b45a65dfe3a064cd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4193,7 +4193,7 @@ dependencies = [
 
 [[package]]
 name = "volo-build"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4222,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "volo-cli"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,7 +758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1573,7 +1573,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2647,7 +2647,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2986,7 +2986,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2999,7 +2999,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3164,7 +3164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3427,7 +3427,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -3525,7 +3524,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2272,7 +2272,7 @@ dependencies = [
 [[package]]
 name = "pilota"
 version = "0.13.1"
-source = "git+https://github.com/Joshuahoky/pilota.git?branch=feat%2Fserde_rename_plugin#51173ac1d5fccfc0d530afc1b45a65dfe3a064cd"
+source = "git+https://github.com/Joshuahoky/pilota.git?branch=feat%2Fserde_rename_plugin#6592fff59b9142f217ff666d389b642b60cae0cf"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2294,7 +2294,7 @@ dependencies = [
 [[package]]
 name = "pilota-build"
 version = "0.13.10"
-source = "git+https://github.com/Joshuahoky/pilota.git?branch=feat%2Fserde_rename_plugin#51173ac1d5fccfc0d530afc1b45a65dfe3a064cd"
+source = "git+https://github.com/Joshuahoky/pilota.git?branch=feat%2Fserde_rename_plugin#6592fff59b9142f217ff666d389b642b60cae0cf"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2350,7 +2350,7 @@ dependencies = [
 [[package]]
 name = "pilota-thrift-parser"
 version = "0.13.6"
-source = "git+https://github.com/Joshuahoky/pilota.git?branch=feat%2Fserde_rename_plugin#51173ac1d5fccfc0d530afc1b45a65dfe3a064cd"
+source = "git+https://github.com/Joshuahoky/pilota.git?branch=feat%2Fserde_rename_plugin#6592fff59b9142f217ff666d389b642b60cae0cf"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -2363,7 +2363,7 @@ dependencies = [
 [[package]]
 name = "pilota-thrift-reflect"
 version = "0.2.0"
-source = "git+https://github.com/Joshuahoky/pilota.git?branch=feat%2Fserde_rename_plugin#51173ac1d5fccfc0d530afc1b45a65dfe3a064cd"
+source = "git+https://github.com/Joshuahoky/pilota.git?branch=feat%2Fserde_rename_plugin#6592fff59b9142f217ff666d389b642b60cae0cf"
 dependencies = [
  "ahash",
  "bytes",
@@ -5191,4 +5191,4 @@ dependencies = [
 [[patch.unused]]
 name = "pilota-thrift-fieldmask"
 version = "0.2.1"
-source = "git+https://github.com/Joshuahoky/pilota.git?branch=feat%2Fserde_rename_plugin#51173ac1d5fccfc0d530afc1b45a65dfe3a064cd"
+source = "git+https://github.com/Joshuahoky/pilota.git?branch=feat%2Fserde_rename_plugin#6592fff59b9142f217ff666d389b642b60cae0cf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,7 +758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1573,7 +1573,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2272,7 +2272,7 @@ dependencies = [
 [[package]]
 name = "pilota"
 version = "0.13.1"
-source = "git+https://github.com/Joshuahoky/pilota.git?branch=feat%2Fserde_rename_plugin#6592fff59b9142f217ff666d389b642b60cae0cf"
+source = "git+https://github.com/Joshuahoky/pilota.git?branch=feat%2Fserde_rename_plugin#16c37dc235e7deee308acad59f4c3b849dde25f3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2294,7 +2294,7 @@ dependencies = [
 [[package]]
 name = "pilota-build"
 version = "0.13.10"
-source = "git+https://github.com/Joshuahoky/pilota.git?branch=feat%2Fserde_rename_plugin#6592fff59b9142f217ff666d389b642b60cae0cf"
+source = "git+https://github.com/Joshuahoky/pilota.git?branch=feat%2Fserde_rename_plugin#16c37dc235e7deee308acad59f4c3b849dde25f3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2350,7 +2350,7 @@ dependencies = [
 [[package]]
 name = "pilota-thrift-parser"
 version = "0.13.6"
-source = "git+https://github.com/Joshuahoky/pilota.git?branch=feat%2Fserde_rename_plugin#6592fff59b9142f217ff666d389b642b60cae0cf"
+source = "git+https://github.com/Joshuahoky/pilota.git?branch=feat%2Fserde_rename_plugin#16c37dc235e7deee308acad59f4c3b849dde25f3"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -2363,7 +2363,7 @@ dependencies = [
 [[package]]
 name = "pilota-thrift-reflect"
 version = "0.2.0"
-source = "git+https://github.com/Joshuahoky/pilota.git?branch=feat%2Fserde_rename_plugin#6592fff59b9142f217ff666d389b642b60cae0cf"
+source = "git+https://github.com/Joshuahoky/pilota.git?branch=feat%2Fserde_rename_plugin#16c37dc235e7deee308acad59f4c3b849dde25f3"
 dependencies = [
  "ahash",
  "bytes",
@@ -2647,7 +2647,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2986,7 +2986,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2999,7 +2999,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3164,7 +3164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3427,6 +3427,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
+ "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -3524,7 +3525,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5191,4 +5192,4 @@ dependencies = [
 [[patch.unused]]
 name = "pilota-thrift-fieldmask"
 version = "0.2.1"
-source = "git+https://github.com/Joshuahoky/pilota.git?branch=feat%2Fserde_rename_plugin#6592fff59b9142f217ff666d389b642b60cae0cf"
+source = "git+https://github.com/Joshuahoky/pilota.git?branch=feat%2Fserde_rename_plugin#16c37dc235e7deee308acad59f4c3b849dde25f3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,3 +162,10 @@ overflow-checks = false
 # pilota-thrift-fieldmask = { git = "https://github.com/cloudwego/pilota.git", branch = "main" }
 # motore = { git = "https://github.com/cloudwego/motore.git", branch = "main" }
 # metainfo = { git = "https://github.com/cloudwego/metainfo.git", branch = "main"}
+
+[patch.crates-io]
+pilota = { git = "https://github.com/Joshuahoky/pilota.git", branch = "feat/serde_rename_plugin" }
+pilota-build = { git = "https://github.com/Joshuahoky/pilota.git", branch = "feat/serde_rename_plugin" }
+pilota-thrift-parser = { git = "https://github.com/Joshuahoky/pilota.git", branch = "feat/serde_rename_plugin" }
+pilota-thrift-reflect = { git = "https://github.com/Joshuahoky/pilota.git", branch = "feat/serde_rename_plugin" }
+pilota-thrift-fieldmask = { git = "https://github.com/Joshuahoky/pilota.git", branch = "feat/serde_rename_plugin" }

--- a/scripts/volo-cli-test.sh
+++ b/scripts/volo-cli-test.sh
@@ -45,16 +45,20 @@ detect_pilota_branch() {
 
 	if grep -q '^\[patch\.crates-io\]' "$cargo_toml"; then
 		local pilota_line=$(sed -n '/^\[patch\.crates-io\]/,/^\[/p' "$cargo_toml" | grep '^pilota[[:space:]]*=' | grep 'branch[[:space:]]*=' | head -n 1)
-		
+
 		if [ -n "$pilota_line" ]; then
 			export PILOTA_BRANCH=$(echo "$pilota_line" | sed -n 's/.*branch[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p')
-			echo "Detected pilota patch: branch = $PILOTA_BRANCH"
-			return
+			export PILOTA_GIT=$(echo "$pilota_line" | sed -n 's/.*git[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p')
+			if [ -n "$PILOTA_GIT" ]; then
+				echo "Detected pilota patch: git = $PILOTA_GIT, branch = $PILOTA_BRANCH"
+				return
+			fi
 		fi
 	fi
-	
+
+	export PILOTA_GIT="https://github.com/cloudwego/pilota.git"
 	export PILOTA_BRANCH="main"
-	echo "No pilota patch detected, using default: branch = main"
+	echo "No pilota patch detected, using default: git = $PILOTA_GIT, branch = main"
 }
 
 append_volo_dep_item() {
@@ -62,7 +66,7 @@ append_volo_dep_item() {
 }
 
 append_pilota_dep_item() {
-	echo "$1 = { git = \"https://github.com/cloudwego/pilota.git\", branch = \"$PILOTA_BRANCH\" }" >> Cargo.toml
+	echo "$1 = { git = \"$PILOTA_GIT\", branch = \"$PILOTA_BRANCH\" }" >> Cargo.toml
 }
 
 patch_cargo_toml() {

--- a/volo-build/CLAUDE.md
+++ b/volo-build/CLAUDE.md
@@ -22,7 +22,7 @@ volo-build/src/
 
 Main code generation builder supporting both Thrift and Protobuf protocols. Created via `Builder::thrift()` or `Builder::protobuf()`.
 
-Key methods: `add_service(path)`, `out_dir(path)`, `filename(name)`, `plugin(p)`, `ignore_unused(bool)`, `touch(items)`, `keep_unknown_fields(paths)`, `split_generated_files(bool)`, `special_namings(namings)`, `dedup(list)`, `common_crate_name(name)`, `with_descriptor(bool)`, `with_field_mask(bool)`, `with_comments(bool)`, `include_dirs(dirs)`, `write()`, `init_service()`.
+Key methods: `add_service(path)`, `out_dir(path)`, `filename(name)`, `plugin(p)`, `ignore_unused(bool)`, `touch(items)`, `keep_unknown_fields(paths)`, `split_generated_files(bool)`, `special_namings(namings)`, `dedup(list)`, `common_crate_name(name)`, `with_descriptor(bool)`, `with_field_mask(bool)`, `with_comments(bool)`, `with_preserve_idl_field_names(bool)`, `include_dirs(dirs)`, `write()`, `init_service()`.
 
 ## ConfigBuilder (`config_builder.rs`)
 
@@ -56,6 +56,7 @@ entries:
     dedups: []
     special_namings: []
     split_generated_files: false
+    preserve_idl_field_names: false
 ```
 
 ## Thrift Backend (`thrift_backend.rs`)

--- a/volo-build/Cargo.toml
+++ b/volo-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-build"
-version = "0.12.3"
+version = "0.12.4"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-build/src/config_builder.rs
+++ b/volo-build/src/config_builder.rs
@@ -432,7 +432,7 @@ mod tests {
     fn preserve_idl_field_names_skips_a_hand_registered_serde_rename_plugin() {
         let dir = tempdir().unwrap();
         let generated = gen_with_preserve_idl_field_names_and(dir.path(), true, |builder| {
-            builder.plugin(pilota_build::plugin::SerdeRenamePlugin)
+            builder.plugin(pilota_build::plugin::SerdePreserveIdlNamesPlugin)
         });
 
         assert_eq!(

--- a/volo-build/src/config_builder.rs
+++ b/volo-build/src/config_builder.rs
@@ -17,6 +17,7 @@ pub struct ConfigBuilder {
     filename: PathBuf,
     plugins: Vec<BoxClonePlugin>,
     out_dir: Option<PathBuf>,
+    serde_plugins: crate::SerdePlugins,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -42,6 +43,17 @@ impl InnerBuilder {
         match self {
             InnerBuilder::Protobuf(inner) => InnerBuilder::Protobuf(inner.plugin(p)),
             InnerBuilder::Thrift(inner) => InnerBuilder::Thrift(inner.plugin(p)),
+        }
+    }
+
+    fn with_serde_plugins(self, serde_plugins: crate::SerdePlugins) -> Self {
+        match self {
+            InnerBuilder::Protobuf(inner) => {
+                InnerBuilder::Protobuf(inner.with_serde_plugins(serde_plugins))
+            }
+            InnerBuilder::Thrift(inner) => {
+                InnerBuilder::Thrift(inner.with_serde_plugins(serde_plugins))
+            }
         }
     }
 
@@ -203,6 +215,17 @@ impl InnerBuilder {
             InnerBuilder::Thrift(inner) => InnerBuilder::Thrift(inner.with_comments(with_comments)),
         }
     }
+
+    pub fn with_preserve_idl_field_names(self, enable: bool) -> Self {
+        match self {
+            InnerBuilder::Protobuf(inner) => {
+                InnerBuilder::Protobuf(inner.with_preserve_idl_field_names(enable))
+            }
+            InnerBuilder::Thrift(inner) => {
+                InnerBuilder::Thrift(inner.with_preserve_idl_field_names(enable))
+            }
+        }
+    }
 }
 
 impl ConfigBuilder {
@@ -211,10 +234,12 @@ impl ConfigBuilder {
             filename,
             plugins: Vec::new(),
             out_dir: None,
+            serde_plugins: Default::default(),
         }
     }
 
     pub fn plugin<P: pilota_build::ClonePlugin + 'static>(mut self, p: P) -> Self {
+        self.serde_plugins.record::<P>();
         self.plugins.push(BoxClonePlugin::new(p));
 
         self
@@ -255,7 +280,8 @@ impl ConfigBuilder {
                     model::IdlProtocol::Protobuf => InnerBuilder::protobuf(),
                 }
                 .filename(entry.filename.clone())
-                .out_dir(&out_dir);
+                .out_dir(&out_dir)
+                .with_serde_plugins(self.serde_plugins);
 
                 for p in self.plugins.iter() {
                     builder = builder.plugin(p.clone());
@@ -285,6 +311,7 @@ impl ConfigBuilder {
                     .with_descriptor(entry.common_option.with_descriptor)
                     .with_field_mask(entry.common_option.with_field_mask)
                     .with_comments(entry.common_option.with_comments)
+                    .with_preserve_idl_field_names(entry.common_option.preserve_idl_field_names)
                     .write()?;
 
                 Ok(())
@@ -319,6 +346,116 @@ mod tests {
             ),
         )
         .unwrap();
+    }
+
+    /// Generates from an entry that sets `preserve_idl_field_names` to `enabled`,
+    /// returning the generated source.
+    fn gen_with_preserve_idl_field_names(dir: &Path, enabled: bool) -> String {
+        gen_with_preserve_idl_field_names_and(dir, enabled, |builder| builder)
+    }
+
+    /// [`gen_with_preserve_idl_field_names`], with `customize` applied to the
+    /// builder first.
+    fn gen_with_preserve_idl_field_names_and(
+        dir: &Path,
+        enabled: bool,
+        customize: impl FnOnce(ConfigBuilder) -> ConfigBuilder,
+    ) -> String {
+        let idl = dir.join("rename.thrift");
+        let config_path = dir.join("volo.yml");
+        let out_dir = dir.join("out");
+
+        fs::write(
+            &idl,
+            "namespace rs rename_test\n\nstruct Item {\n    1: required string ItemName,\n}\n",
+        )
+        .unwrap();
+
+        fs::write(
+            &config_path,
+            format!(
+                "entries:\n  sample:\n    filename: generated.rs\n    protocol: thrift\n    \
+                 touch_all: true\n    preserve_idl_field_names: {enabled}\n    services:\n      - \
+                 idl:\n          source: local\n          path: {}\n",
+                idl.display()
+            ),
+        )
+        .unwrap();
+
+        customize(ConfigBuilder::new(config_path))
+            .out_dir(&out_dir)
+            .write()
+            .unwrap();
+
+        fs::read_to_string(out_dir.join("generated.rs")).unwrap()
+    }
+
+    #[test]
+    fn preserve_idl_field_names_renames_fields_to_the_idl_spelling() {
+        let dir = tempdir().unwrap();
+        let generated = gen_with_preserve_idl_field_names(dir.path(), true);
+
+        assert!(generated.contains("item_name"), "{generated}");
+        assert!(
+            generated.contains(r#"#[serde(rename = "ItemName")]"#),
+            "{generated}"
+        );
+        // The option implies the derives the rename attributes attach to.
+        assert!(
+            generated.contains("::pilota::serde::Serialize"),
+            "{generated}"
+        );
+    }
+
+    /// A build.rs that already registered `SerdePlugin` must keep working when
+    /// `preserve_idl_field_names` is turned on: a second registration would emit
+    /// a second `derive(Serialize, Deserialize)` and fail to compile.
+    #[test]
+    fn preserve_idl_field_names_skips_a_hand_registered_serde_plugin() {
+        let dir = tempdir().unwrap();
+        let generated = gen_with_preserve_idl_field_names_and(dir.path(), true, |builder| {
+            builder.plugin(pilota_build::plugin::SerdePlugin)
+        });
+
+        assert_eq!(
+            generated.matches("::pilota::serde::Serialize").count(),
+            1,
+            "{generated}"
+        );
+        assert!(
+            generated.contains(r#"#[serde(rename = "ItemName")]"#),
+            "{generated}"
+        );
+    }
+
+    #[test]
+    fn preserve_idl_field_names_skips_a_hand_registered_serde_rename_plugin() {
+        let dir = tempdir().unwrap();
+        let generated = gen_with_preserve_idl_field_names_and(dir.path(), true, |builder| {
+            builder.plugin(pilota_build::plugin::SerdeRenamePlugin)
+        });
+
+        assert_eq!(
+            generated
+                .matches(r#"#[serde(rename = "ItemName")]"#)
+                .count(),
+            1,
+            "{generated}"
+        );
+        assert_eq!(
+            generated.matches("::pilota::serde::Serialize").count(),
+            1,
+            "{generated}"
+        );
+    }
+
+    #[test]
+    fn preserve_idl_field_names_is_off_by_default() {
+        let dir = tempdir().unwrap();
+        let generated = gen_with_preserve_idl_field_names(dir.path(), false);
+
+        assert!(generated.contains("item_name"), "{generated}");
+        assert!(!generated.contains("serde"), "{generated}");
     }
 
     #[test]

--- a/volo-build/src/lib.rs
+++ b/volo-build/src/lib.rs
@@ -37,7 +37,7 @@ impl SerdePlugins {
     pub(crate) fn record<P: 'static>(&mut self) {
         if TypeId::of::<P>() == TypeId::of::<pilota_build::plugin::SerdePlugin>() {
             self.serde = true;
-        } else if TypeId::of::<P>() == TypeId::of::<pilota_build::plugin::SerdeRenamePlugin>() {
+        } else if TypeId::of::<P>() == TypeId::of::<pilota_build::plugin::SerdePreserveIdlNamesPlugin>() {
             self.serde_rename = true;
         }
     }
@@ -232,7 +232,7 @@ where
             if !self.serde_plugins.serde_rename {
                 self.pilota_builder = self
                     .pilota_builder
-                    .plugin(pilota_build::plugin::SerdeRenamePlugin);
+                    .plugin(pilota_build::plugin::SerdePreserveIdlNamesPlugin);
             }
         }
 

--- a/volo-build/src/lib.rs
+++ b/volo-build/src/lib.rs
@@ -37,7 +37,9 @@ impl SerdePlugins {
     pub(crate) fn record<P: 'static>(&mut self) {
         if TypeId::of::<P>() == TypeId::of::<pilota_build::plugin::SerdePlugin>() {
             self.serde = true;
-        } else if TypeId::of::<P>() == TypeId::of::<pilota_build::plugin::SerdePreserveIdlNamesPlugin>() {
+        } else if TypeId::of::<P>()
+            == TypeId::of::<pilota_build::plugin::SerdePreserveIdlNamesPlugin>()
+        {
             self.serde_rename = true;
         }
     }

--- a/volo-build/src/lib.rs
+++ b/volo-build/src/lib.rs
@@ -4,6 +4,7 @@
 #![cfg_attr(not(doctest), doc = include_str!("../README.md"))]
 #![allow(clippy::mutable_key_type)]
 use std::{
+    any::TypeId,
     path::{Path, PathBuf},
     str::FromStr,
 };
@@ -25,12 +26,36 @@ pub use pilota_build::{
     BoxClonePlugin, ClonePlugin, Context, DefId, MakeBackend, Plugin, parser, plugin, rir,
 };
 
+/// Tracks the serde plugins a caller registered by hand.
+#[derive(Default, Clone, Copy)]
+pub(crate) struct SerdePlugins {
+    serde: bool,
+    serde_rename: bool,
+}
+
+impl SerdePlugins {
+    pub(crate) fn record<P: 'static>(&mut self) {
+        if TypeId::of::<P>() == TypeId::of::<pilota_build::plugin::SerdePlugin>() {
+            self.serde = true;
+        } else if TypeId::of::<P>() == TypeId::of::<pilota_build::plugin::SerdeRenamePlugin>() {
+            self.serde_rename = true;
+        }
+    }
+
+    pub(crate) fn merge(&mut self, other: Self) {
+        self.serde |= other.serde;
+        self.serde_rename |= other.serde_rename;
+    }
+}
+
 pub struct Builder<MkB, P> {
     pilota_builder: pilota_build::Builder<MkB, P>,
     idls: Vec<PathBuf>,
     out_dir: Option<PathBuf>,
     filename: PathBuf,
     config_file_path: PathBuf,
+    preserve_idl_field_names: bool,
+    serde_plugins: SerdePlugins,
 }
 
 impl Builder<thrift_backend::MkThriftBackend, parser::ThriftParser> {
@@ -42,6 +67,8 @@ impl Builder<thrift_backend::MkThriftBackend, parser::ThriftParser> {
             filename: "volo_gen.rs".into(),
             idls: Default::default(),
             config_file_path: "volo.yml".into(),
+            preserve_idl_field_names: false,
+            serde_plugins: Default::default(),
         }
     }
 }
@@ -54,6 +81,8 @@ impl Builder<grpc_backend::MkGrpcBackend, parser::ProtobufParser> {
             filename: "volo_gen.rs".into(),
             idls: Default::default(),
             config_file_path: "volo.yml".into(),
+            preserve_idl_field_names: false,
+            serde_plugins: Default::default(),
         }
     }
 }
@@ -69,8 +98,14 @@ impl<MkB, Parser> Builder<MkB, Parser> {
     }
 
     pub fn plugin<P: Plugin + 'static>(mut self, p: P) -> Self {
+        self.serde_plugins.record::<P>();
         self.pilota_builder = self.pilota_builder.plugin(p);
 
+        self
+    }
+
+    pub(crate) fn with_serde_plugins(mut self, serde_plugins: SerdePlugins) -> Self {
+        self.serde_plugins.merge(serde_plugins);
         self
     }
 
@@ -163,6 +198,17 @@ impl<MkB, Parser> Builder<MkB, Parser> {
         self.pilota_builder = self.pilota_builder.with_comments(with_comments);
         self
     }
+
+    /// Keeps the IDL spelling of field names in serde output, instead of the
+    /// snake_case idents generated for Rust.
+    ///
+    /// Off by default. Enabling it also registers
+    /// [`pilota_build::plugin::SerdePlugin`], since the `rename` attributes need
+    /// serde derives to attach to.
+    pub fn with_preserve_idl_field_names(mut self, enable: bool) -> Self {
+        self.preserve_idl_field_names = enable;
+        self
+    }
 }
 
 impl<MkB, P> Builder<MkB, P>
@@ -176,7 +222,20 @@ where
         self
     }
 
-    pub fn write(self) -> anyhow::Result<()> {
+    pub fn write(mut self) -> anyhow::Result<()> {
+        if self.preserve_idl_field_names {
+            if !self.serde_plugins.serde {
+                self.pilota_builder = self
+                    .pilota_builder
+                    .plugin(pilota_build::plugin::SerdePlugin);
+            }
+            if !self.serde_plugins.serde_rename {
+                self.pilota_builder = self
+                    .pilota_builder
+                    .plugin(pilota_build::plugin::SerdeRenamePlugin);
+            }
+        }
+
         let out_dir = self.get_out_dir()?;
 
         if !out_dir.exists() {
@@ -220,3 +279,46 @@ macro_rules! join_multi_strs {
 
 pub(crate) use join_multi_strs;
 use volo::FastStr;
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::Builder;
+
+    #[test]
+    fn preserve_idl_field_names_skips_a_hand_registered_serde_plugin() {
+        let dir = tempdir().unwrap();
+        let idl = dir.path().join("rename.thrift");
+        let out_dir = dir.path().join("out");
+        std::fs::write(
+            &idl,
+            "namespace rs rename_test\n\nstruct Item {\n    1: required string ItemName,\n}\n",
+        )
+        .unwrap();
+
+        Builder::thrift()
+            .add_service(&idl)
+            .out_dir(&out_dir)
+            .plugin(pilota_build::plugin::SerdePlugin)
+            .with_preserve_idl_field_names(true)
+            // The IDL has no service, so keep `Item` from being pruned as unused.
+            .ignore_unused(false)
+            .write()
+            .unwrap();
+
+        let generated = std::fs::read_to_string(out_dir.join("volo_gen.rs")).unwrap();
+        assert_eq!(
+            generated.matches("::pilota::serde::Serialize").count(),
+            1,
+            "{generated}"
+        );
+        assert_eq!(
+            generated
+                .matches(r#"#[serde(rename = "ItemName")]"#)
+                .count(),
+            1,
+            "{generated}"
+        );
+    }
+}

--- a/volo-build/src/model.rs
+++ b/volo-build/src/model.rs
@@ -30,6 +30,8 @@ pub struct CommonOption {
     pub with_field_mask: bool,
     #[serde(default, skip_serializing_if = "is_false")]
     pub with_comments: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub preserve_idl_field_names: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/volo-build/src/workspace.rs
+++ b/volo-build/src/workspace.rs
@@ -143,7 +143,7 @@ where
             if !this.serde_plugins.serde_rename {
                 this.pilota_builder = this
                     .pilota_builder
-                    .plugin(pilota_build::plugin::SerdeRenamePlugin);
+                    .plugin(pilota_build::plugin::SerdePreserveIdlNamesPlugin);
             }
         }
 

--- a/volo-build/src/workspace.rs
+++ b/volo-build/src/workspace.rs
@@ -10,6 +10,8 @@ use crate::{
 
 pub struct Builder<MkB, P> {
     pilota_builder: pilota_build::Builder<MkB, P>,
+    preserve_idl_field_names: bool,
+    serde_plugins: crate::SerdePlugins,
 }
 
 impl Builder<crate::thrift_backend::MkThriftBackend, crate::parser::ThriftParser> {
@@ -17,6 +19,8 @@ impl Builder<crate::thrift_backend::MkThriftBackend, crate::parser::ThriftParser
         Self {
             pilota_builder: pilota_build::Builder::thrift()
                 .with_backend(crate::thrift_backend::MkThriftBackend),
+            preserve_idl_field_names: false,
+            serde_plugins: Default::default(),
         }
     }
 }
@@ -26,6 +30,8 @@ impl Builder<crate::grpc_backend::MkGrpcBackend, crate::parser::ProtobufParser> 
         Self {
             pilota_builder: pilota_build::Builder::pb()
                 .with_backend(crate::grpc_backend::MkGrpcBackend),
+            preserve_idl_field_names: false,
+            serde_plugins: Default::default(),
         }
     }
 }
@@ -117,7 +123,8 @@ where
                 self = self.keep_unknown_fields([path]);
             }
         }
-        self.ignore_unused(!config.common_option.touch_all)
+        let mut this = self
+            .ignore_unused(!config.common_option.touch_all)
             .dedup(config.common_option.dedups)
             .special_namings(config.common_option.special_namings)
             .common_crate_name(config.common_crate_name)
@@ -125,11 +132,27 @@ where
             .with_descriptor(config.common_option.with_descriptor)
             .with_field_mask(config.common_option.with_field_mask)
             .with_comments(config.common_option.with_comments)
-            .pilota_builder
+            .with_preserve_idl_field_names(config.common_option.preserve_idl_field_names);
+
+        if this.preserve_idl_field_names {
+            if !this.serde_plugins.serde {
+                this.pilota_builder = this
+                    .pilota_builder
+                    .plugin(pilota_build::plugin::SerdePlugin);
+            }
+            if !this.serde_plugins.serde_rename {
+                this.pilota_builder = this
+                    .pilota_builder
+                    .plugin(pilota_build::plugin::SerdeRenamePlugin);
+            }
+        }
+
+        this.pilota_builder
             .compile_with_config(idl_services, pilota_build::Output::Workspace(work_dir));
     }
 
-    pub fn plugin(mut self, plugin: impl Plugin + 'static) -> Self {
+    pub fn plugin<Plu: Plugin + 'static>(mut self, plugin: Plu) -> Self {
+        self.serde_plugins.record::<Plu>();
         self.pilota_builder = self.pilota_builder.plugin(plugin);
         self
     }
@@ -199,6 +222,16 @@ where
 
     pub fn with_comments(mut self, with_comments: bool) -> Self {
         self.pilota_builder = self.pilota_builder.with_comments(with_comments);
+        self
+    }
+
+    /// Keeps the IDL spelling of field names in serde output, instead of the
+    /// snake_case idents generated for Rust.
+    ///
+    /// Off by default. Like the other [`crate::model::CommonOption`] flags, `gen`
+    /// applies the value from `volo.workspace.yml` over anything set here.
+    pub fn with_preserve_idl_field_names(mut self, enable: bool) -> Self {
+        self.preserve_idl_field_names = enable;
         self
     }
 }

--- a/volo-cli/Cargo.toml
+++ b/volo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volo-cli"
-version = "0.12.1"
+version = "0.12.2"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/volo-cli/src/migrate.rs
+++ b/volo-cli/src/migrate.rs
@@ -53,6 +53,7 @@ impl CliCommand for Migrate {
                             with_descriptor: false,
                             with_field_mask: false,
                             with_comments: false,
+                            preserve_idl_field_names: false,
                         },
                     };
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/volo/blob/main/CONTRIBUTING.md
-->

## Motivation
See https://github.com/cloudwego/pilota/pull/366
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Adds an opt-in `preserve_idl_field_names` option that keeps the original IDL spelling. The option is off by default. 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
