### PR TITLE
feat(volo-grpc): expose http2_max_pending_accept_reset_streams on Server

### DIFF
--- a/volo-grpc/src/server/mod.rs
+++ b/volo-grpc/src/server/mod.rs
@@ -179,6 +179,16 @@ impl<IL, OL, SP> Server<IL, OL, SP> {
         self
     }
 
+    /// Sets the max number of remotely-reset streams pending acceptance
+    /// across the lifetime of the connection.
+    ///
+    /// If the remote peer exceeds this limit, the connection will be
+    /// closed. If not set, will default from underlying transport.
+    pub fn http2_max_pending_accept_reset_streams(mut self, max: impl Into<Option<usize>>) -> Self {
+        self.http2_config.max_pending_accept_reset_streams = max.into();
+        self
+    }
+
     /// Allow this server to accept http1 requests.
     ///
     /// Accepting http1 requests is only useful when developing `grpc-web`
@@ -418,7 +428,10 @@ impl<IL, OL, SP> Server<IL, OL, SP> {
                         .keep_alive_timeout(self.http2_config.http2_keepalive_timeout)
                         .max_frame_size(self.http2_config.max_frame_size)
                         .max_send_buf_size(self.http2_config.max_send_buf_size)
-                        .max_header_list_size(self.http2_config.max_header_list_size);
+                        .max_header_list_size(self.http2_config.max_header_list_size)
+                        .max_pending_accept_reset_streams(
+                            self.http2_config.max_pending_accept_reset_streams,
+                        );
 
                     let mut watch = rx.clone();
                     spawn(async move {
@@ -510,6 +523,7 @@ pub struct Http2Config {
     pub(crate) max_frame_size: Option<u32>,
     pub(crate) max_send_buf_size: usize,
     pub(crate) max_header_list_size: u32,
+    pub(crate) max_pending_accept_reset_streams: Option<usize>,
     pub(crate) accept_http1: bool,
 }
 
@@ -525,7 +539,28 @@ impl Default for Http2Config {
             max_frame_size: None,
             max_send_buf_size: DEFAULT_MAX_SEND_BUF_SIZE,
             max_header_list_size: DEFAULT_SETTINGS_MAX_HEADER_LIST_SIZE,
+            max_pending_accept_reset_streams: None,
             accept_http1: false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn http2_max_pending_accept_reset_streams_defaults_to_none() {
+        let server = Server::new();
+        assert_eq!(server.http2_config.max_pending_accept_reset_streams, None);
+    }
+
+    #[test]
+    fn http2_max_pending_accept_reset_streams_sets_value() {
+        let server = Server::new().http2_max_pending_accept_reset_streams(64);
+        assert_eq!(
+            server.http2_config.max_pending_accept_reset_streams,
+            Some(64)
+        );
     }
 }


### PR DESCRIPTION
### References

Closes #657

### Why

The underlying hyper/h2 server already supports capping the number of remotely-reset streams pending acceptance before the connection is closed (`max_pending_accept_reset_streams`, defaulting to 20 in h2), but `volo-grpc`'s `Server` didn't expose this knob. Under load with frequent stream resets, this surfaces as repeated warnings:

```
recv_reset; remotely-reset pending-accept streams reached limit (20)
```

with no way for the application to raise the limit.

### What changed

Added `Server::http2_max_pending_accept_reset_streams`, following the exact same `Http2Config` passthrough pattern already used by the sibling setters (`http2_max_concurrent_streams`, `http2_max_header_list_size`, `http2_max_frame_size`, etc.):

- New `Http2Config::max_pending_accept_reset_streams: Option<usize>` field, defaulting to `None` (unchanged behavior — hyper's own default of 20 still applies).
- New builder method `Server::http2_max_pending_accept_reset_streams(max: impl Into<Option<usize>>)`.
- Wired into the `hyper_util` HTTP/2 builder alongside the other `http2_*` config calls.

This is purely additive — no existing behavior changes, no new dependencies (the method already exists on `hyper_util::server::conn::auto::Http2Builder`).

### Surface area

- [x] New feature (non-breaking change which adds functionality)

### Validation

```
cargo build -p volo-grpc --all-features
cargo clippy -p volo-grpc --all-features
cargo fmt -p volo-grpc -- --check
cargo test -p volo-grpc http2_max_pending_accept_reset_streams
```

All pass. Added two unit tests (`http2_max_pending_accept_reset_streams_defaults_to_none`, `http2_max_pending_accept_reset_streams_sets_value`) covering the default and the builder wiring — the crate had no prior unit tests for the sibling `http2_*` config setters to follow, so this establishes the pattern for this one field.

### AI assistance

- **Tool(s) used:** Claude Code
- **How you used it:** AI verified the exact hyper/h2 API surface (`hyper_util::server::conn::auto::Http2Builder::max_pending_accept_reset_streams`) matches the reporter's proposed API, implemented the field/builder/wiring following the existing `Http2Config` pattern, and wrote the two unit tests.
- **Human verification:** Read and understood every line of this change; confirmed via the vendored hyper/hyper-util source that the method exists with the expected signature before writing any code; ran `cargo build`/`clippy`/`fmt --check`/`test` myself and confirmed all pass; confirmed the change only touches `volo-grpc/src/server/mod.rs` with no unrelated edits; take responsibility for this change.
- [x] I've read and understand every line of this change and take responsibility for it.
