### PR TITLE
docs(volo-build): update README config example

### DIFF
--- a/volo-build/README.md
+++ b/volo-build/README.md
@@ -19,29 +19,46 @@ First, add `volo-build` to your `Cargo.toml`:
 volo-build = "*" # make sure you use a compatible version with `volo`
 ```
 
-Second, creates a `build.rs` file:
+Second, create a `build.rs` file:
 
 ```rust,ignore
 fn main() {
-    volo_build::Builder::default().write().unwrap();
+    volo_build::ConfigBuilder::default().write().unwrap();
 }
 ```
 
-Third, creates a `volo.yml` file in the same directory of `build.rs` with the following layout:
+Third, create a `volo.yml` file in the same directory as `build.rs` with the following layout:
 
 ```yaml
 ---
-idls:
-  - source: local
-    path: path/to/your/idl.thrift
-  - source: local
-    path: path/to/your/protobuf/idl.proto
-    includes:
-    - path/to/your/protobuf/
-  - source: git
-    repo: git@github.com:cloudwego/volo.git
-    ref: main
-    path: path/in/repo/idl.thrift
+entries:
+  thrift:
+    filename: thrift_gen.rs
+    protocol: thrift
+    repos:
+      volo:
+        url: https://github.com/cloudwego/volo.git
+        ref: main
+        lock: 58a9eebc4941eb2090c8a07ea142bf073f3527c9
+    services:
+      - idl:
+          source: local
+          path: path/to/your/idl.thrift
+      - idl:
+          source: git
+          repo: volo
+          path: path/in/repo/idl.thrift
+  protobuf:
+    filename: protobuf_gen.rs
+    protocol: protobuf
+    services:
+      - idl:
+          source: local
+          path: path/to/your/protobuf/idl.proto
+          includes:
+            - path/to/your/protobuf
 ```
+
+See the [configuration file format guide](https://www.cloudwego.io/docs/volo/guide/config/) for all available options.
 
 That's it!


### PR DESCRIPTION
## Motivation

`volo-build/README.md` still uses the removed `Builder::default()` API and a pre-refactor top-level `idls` configuration. Following the direct-use instructions therefore fails to compile and the shown YAML does not match the current configuration model.

Fixes: #668

## Solution

- Use `ConfigBuilder::default()` in the `build.rs` example.
- Replace the obsolete YAML with current named `entries` for Thrift and Protobuf, including the required repository lock field.
- Link to the complete configuration format guide and fix the surrounding grammar.

## Validation

- Reproduced the old snippet's `E0599` compiler error in a minimal path-dependent consumer.
- Verified the corrected `ConfigBuilder` consumer with `cargo check --offline`.
- Deserialized the README's exact YAML block as `volo_build::model::SingleConfig` and asserted both entries.
- `cargo test -p volo-build --locked` (16 passed).
- `cargo rustdoc -p volo-build --all-features --locked -- --deny warnings`.
- `cargo fmt --all -- --check`.
- `git diff --check`.